### PR TITLE
Service Anexo

### DIFF
--- a/custom_components/securitas/services.yaml
+++ b/custom_components/securitas/services.yaml
@@ -1,11 +1,9 @@
-check_alarm_panel:
-  name: Check alarm panel
+refresh_alarm_status:
+  name: Refresh the status of the alarm.
   description: Make a request to check the status of the alarm.
   fields:
     instalation_id:
       name: Instalation Id
       description: The instalation id of the alarm.
       required: true
-      example: Look for that information in the component.
-      selector:
-        text:
+      example: Instalation id.

--- a/custom_components/securitas/services.yaml
+++ b/custom_components/securitas/services.yaml
@@ -1,0 +1,11 @@
+check_alarm_panel:
+  name: Check alarm panel
+  description: Make a request to check the status of the alarm.
+  fields:
+    instalation_id:
+      name: Instalation Id
+      description: The instalation id of the alarm.
+      required: true
+      example: Look for that information in the component.
+      selector:
+        text:


### PR DESCRIPTION
Me gustaría que añadan la opción de anexo

Mi contrato tiene un sensor Anexo y al armar la alarma con el sensor en anexo armado, se queda bloqueado en armando aún que la alarma esté ya armada.

Entiendo que al armar la alarma más anexo, recibe que la alarma se a activado más anexo y está esperando recibir alarma activada. Al recibir otra cosa no sabe que ha pasado y se queda en bucle de armando alarma, así se puede quedar días, asta que no reinicias no se queda en desarmado. Por que no entiende el estado de la alarma al estar armado el anexo. Si desactivo el anexo funciona todo sin problemas 

Gracias 