### PR TITLE
support for PERI alarms (again)

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -340,7 +340,7 @@ class SecuritasHub:
         self.lang: str = self.country.lower() if self.country != "UK" else "en"
         self.hass: HomeAssistant = hass
         self.services: dict[int, list[Service]] = {1: []}
-        command_type: CommandType = (
+        self.command_type: CommandType = (
             CommandType.PERI if domain_config[CONF_PERI_ALARM] else CommandType.STD
         )
         self.session: ApiManager = ApiManager(
@@ -352,7 +352,7 @@ class SecuritasHub:
             domain_config[CONF_DEVICE_ID],
             domain_config[CONF_UNIQUE_ID],
             domain_config[CONF_DEVICE_INDIGITALL],
-            command_type,
+            self.command_type,
             domain_config[CONF_DELAY_CHECK_OPERATION],
         )
         self.installations: list[Installation] = []

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -24,6 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 
 from .securitas_direct_new_api import (
+    ApiDomains,
     ApiManager,
     CheckAlarmStatus,
     CommandType,
@@ -337,7 +338,7 @@ class SecuritasHub:
         self.sentinel_services: list[Service] = []
         self.check_alarm: bool = domain_config[CONF_CHECK_ALARM_PANEL]
         self.country: str = domain_config[CONF_COUNTRY].upper()
-        self.lang: str = self.country.lower() if self.country != "UK" else "en"
+        self.lang: str = ApiDomains().get_language(self.country)
         self.hass: HomeAssistant = hass
         self.services: dict[int, list[Service]] = {1: []}
         self.command_type: CommandType = (
@@ -347,7 +348,6 @@ class SecuritasHub:
             domain_config[CONF_USERNAME],
             domain_config[CONF_PASSWORD],
             self.country,
-            self.lang,
             http_client,
             domain_config[CONF_DEVICE_ID],
             domain_config[CONF_UNIQUE_ID],

--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -182,7 +182,7 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
 
         arm_status = await self.client.session.arm_alarm(
             self.installation, self.state_map[mode]
-        )  # , self._get_proto_status()
+        )
 
         self.update_status_alarm(
             CheckAlarmStatus(
@@ -269,9 +269,7 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
         """Send disarm command."""
         if self.check_code(code):
             self.__force_state(STATE_ALARM_DISARMING)
-            disarm_status = await self.client.session.disarm_alarm(
-                self.installation
-            )  # , self._get_proto_status()
+            disarm_status = await self.client.session.disarm_alarm(self.installation)
 
             self.update_status_alarm(
                 CheckAlarmStatus(

--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -28,7 +28,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 
 from . import (
-    CONF_DELAY_CHECK_OPERATION,
     CONF_ENABLE_CODE,
     CONF_INSTALLATION_KEY,
     DEFAULT_SCAN_INTERVAL,
@@ -37,14 +36,35 @@ from . import (
     SecuritasHub,
 )
 from .securitas_direct_new_api import (
-    AlarmStates,
     CheckAlarmStatus,
+    CommandType,
     Installation,
+    SecDirAlarmState,
     SecuritasDirectError,
 )
 
+STD_STATE_MAP = {
+    STATE_ALARM_DISARMED: SecDirAlarmState.TOTAL_DISARMED,
+    STATE_ALARM_ARMED_AWAY: SecDirAlarmState.TOTAL_ARMED,
+    STATE_ALARM_ARMED_NIGHT: SecDirAlarmState.NIGHT_ARMED,
+    STATE_ALARM_ARMED_HOME: SecDirAlarmState.INTERIOR_PARTIAL,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS: SecDirAlarmState.EXTERIOR_ARMED,
+}
+PERI_STATE_MAP = {
+    STATE_ALARM_DISARMED: SecDirAlarmState.TOTAL_DISARMED,
+    STATE_ALARM_ARMED_AWAY: SecDirAlarmState.TOTAL_ARMED,
+    STATE_ALARM_ARMED_NIGHT: SecDirAlarmState.INTERIOR_PARTIAL_AND_PERI,
+    STATE_ALARM_ARMED_HOME: SecDirAlarmState.INTERIOR_PARTIAL,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS: SecDirAlarmState.EXTERIOR_ARMED,
+}
+
+STATE_MAP = {
+    CommandType.STD: STD_STATE_MAP,
+    CommandType.PERI: PERI_STATE_MAP,
+}
+
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = timedelta(seconds=1200)  # FIXME: is this used?
+# SCAN_INTERVAL = timedelta(seconds=1200)  # FIXME: is this used?
 
 
 async def async_setup_entry(
@@ -86,7 +106,7 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
         """Initialize the Securitas alarm panel."""
         self._state: str = STATE_ALARM_DISARMED
         self._last_status: str = STATE_ALARM_DISARMED
-        self._digits: int = digits
+        self._digits: int = digits  # FIXME: never used
         self._changed_by = None
         self._device = installation.address
         self._entity_id = f"securitas_direct.{installation.number}"
@@ -96,6 +116,7 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
         self.installation = installation
         self._attr_extra_state_attributes = {}
         self.client: SecuritasHub = client
+        self.state_map = STATE_MAP[self.client.command_type]
         self.hass: HomeAssistant = hass
         self._update_interval = timedelta(
             seconds=client.config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
@@ -117,9 +138,6 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
         self._last_status = self._state
         self._state = state
         self.async_schedule_update_ha_state()
-
-    def get_delay_configuration(self) -> int:
-        return self.client.config_entry.data.get(CONF_DELAY_CHECK_OPERATION, 1)
 
     async def get_arm_state(self) -> CheckAlarmStatus:
         """Get alarm state."""
@@ -159,12 +177,12 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
             )
         )
 
-    async def set_arm_state(self, state, attempts=3) -> None:
+    async def set_arm_state(self, mode, attempts=3) -> None:
         """Send set arm state command."""
 
         arm_status = await self.client.session.arm_alarm(
-            self.installation, state, self._get_proto_status()
-        )
+            self.installation, self.state_map[mode]
+        )  # , self._get_proto_status()
 
         self.update_status_alarm(
             CheckAlarmStatus(
@@ -201,21 +219,6 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
     def changed_by(self):
         """Return the last change triggered by."""
         return self._changed_by
-
-    def _get_proto_status(self) -> str:
-        """Get the string that represent the alarm status."""
-        if self._last_status == STATE_ALARM_DISARMED:
-            return "D"
-        elif self._last_status == STATE_ALARM_ARMED_AWAY:
-            return "T"
-        elif self._last_status == STATE_ALARM_ARMED_NIGHT:
-            return "Q"
-        elif self._last_status == STATE_ALARM_ARMED_HOME:
-            return "P"
-        elif self._last_status == STATE_ALARM_ARMED_CUSTOM_BYPASS:
-            return "E"
-        else:
-            return "D"
 
     def update_status_alarm(self, status: CheckAlarmStatus = None):
         """Update alarm status, from last alarm setting register or EST."""
@@ -267,8 +270,8 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
         if self.check_code(code):
             self.__force_state(STATE_ALARM_DISARMING)
             disarm_status = await self.client.session.disarm_alarm(
-                self.installation, self._get_proto_status()
-            )
+                self.installation
+            )  # , self._get_proto_status()
 
             self.update_status_alarm(
                 CheckAlarmStatus(
@@ -285,25 +288,25 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
         """Send arm home command."""
         if self.check_code(code):
             self.__force_state(STATE_ALARM_ARMING)
-            await self.set_arm_state(AlarmStates.INTERIOR_PARTIAL)  # "ARMDAY1"
+            await self.set_arm_state(STATE_ALARM_ARMED_HOME)
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
         if self.check_code(code):
             self.__force_state(STATE_ALARM_ARMING)
-            await self.set_arm_state(AlarmStates.TOTAL_ARMED)  # ARM1
+            await self.set_arm_state(STATE_ALARM_ARMED_AWAY)
 
     async def async_alarm_arm_night(self, code=None):
         """Send arm home command."""
         if self.check_code(code):
             self.__force_state(STATE_ALARM_ARMING)
-            await self.set_arm_state(AlarmStates.NIGHT_ARMED)  # "ARMNIGHT1"
+            await self.set_arm_state(STATE_ALARM_ARMED_NIGHT)
 
     async def async_alarm_arm_custom_bypass(self, code=None):
         """Send arm perimeter command."""
         if self.check_code(code):
             self.__force_state(STATE_ALARM_ARMING)
-            await self.set_arm_state(AlarmStates.EXTERIOR_ARMED)  # "PERI1"
+            await self.set_arm_state(STATE_ALARM_ARMED_CUSTOM_BYPASS)
 
     @property
     def supported_features(self) -> int:

--- a/custom_components/securitas/securitas_direct_new_api/__init__.py
+++ b/custom_components/securitas/securitas_direct_new_api/__init__.py
@@ -3,7 +3,7 @@
 import logging
 
 from .apimanager import ApiManager, generate_device_id, generate_uuid
-from .const import AlarmStates, CommandType
+from .const import SecDirAlarmState, CommandType
 from .dataTypes import CheckAlarmStatus, Installation, OtpPhone, Service, SStatus
 from .exceptions import Login2FAError, LoginError, SecuritasDirectError
 

--- a/custom_components/securitas/securitas_direct_new_api/__init__.py
+++ b/custom_components/securitas/securitas_direct_new_api/__init__.py
@@ -2,9 +2,16 @@
 
 import logging
 
-from .apimanager import ApiManager, generate_device_id, generate_uuid
-from .const import SecDirAlarmState, CommandType
-from .dataTypes import CheckAlarmStatus, Installation, OtpPhone, Service, SStatus
-from .exceptions import Login2FAError, LoginError, SecuritasDirectError
+from .apimanager import ApiManager, generate_device_id, generate_uuid  # noqa: F401
+from .const import CommandType, SecDirAlarmState  # noqa: F401
+from .dataTypes import (  # noqa: F401
+    CheckAlarmStatus,
+    Installation,
+    OtpPhone,
+    Service,
+    SStatus,
+)
+from .domains import ApiDomains  # noqa: F401
+from .exceptions import Login2FAError, LoginError, SecuritasDirectError  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 from aiohttp import ClientResponse, ClientSession
 import jwt
 
-from .const import COMMAND_MAP, AlarmStates, CommandType
+from .const import COMMAND_MAP, CommandType, SecDirAlarmState
 from .dataTypes import (
     AirQuality,
     ArmStatus,
@@ -63,12 +63,16 @@ class ApiManager:
         self.language = language.lower()
         self.api_url = ApiDomains().get_url(language=language)
         self.command_map = COMMAND_MAP[command_type]
+        self.delay_check_operation: int = delay_check_operation
+
+        self.protom_response: str
         self.authentication_token: str = None
         self.authentication_token_exp: datetime = datetime.min
-        self.authentication_milliseconds: int = 0
+        self.login_timestamp: int = 0
         self.authentication_otp_challenge_value: tuple[str, int] = None
         self.http_client = http_client
         self.refresh_token_value: str = None
+
         # device specific configuration for the API
         self.device_id: str = device_id
         self.uuid: str = uuid
@@ -80,7 +84,6 @@ class ApiManager:
         self.device_type = ""
         self.device_version = "10.102.0"
         self.apollo_operation_id: str = secrets.token_hex(64)
-        self.delay_check_operation: int = delay_check_operation
 
     async def _execute_request(
         self, content, operation: str, installation: Optional[Installation] = None
@@ -96,13 +99,13 @@ class ApiManager:
             "extension": '{"mode":"full"}',
         }
         if installation is not None:
-            headers["numinst"] = str(installation.number)
+            headers["numinst"] = installation.number
             headers["panel"] = installation.panel
             headers["X-Capabilities"] = installation.capabilities
 
         if self.authentication_token is not None:
             authorization_value = {
-                "loginTimestamp": self.authentication_milliseconds,
+                "loginTimestamp": self.login_timestamp,
                 "user": self.username,
                 "id": self._generate_id(),
                 "country": self.country,
@@ -114,7 +117,7 @@ class ApiManager:
 
         if operation in ["mkValidateDevice", "RefreshLogin", "mkSendOTP"]:
             authorization_value = {
-                "loginTimestamp": self.authentication_milliseconds,
+                "loginTimestamp": self.login_timestamp,
                 "user": self.username,
                 "id": self._generate_id(),
                 "country": self.country,
@@ -324,7 +327,7 @@ class ApiManager:
             raise LoginError(err.args) from err
 
         self.authentication_token = response["data"]["xSLoginToken"]["hash"]
-        self.authentication_milliseconds = int(datetime.now().timestamp() * 1000)
+        self.login_timestamp = int(datetime.now().timestamp() * 1000)
 
         try:
             token = jwt.decode(
@@ -377,7 +380,7 @@ class ApiManager:
         content = {
             "operationName": "CheckAlarm",
             "variables": {
-                "numinst": str(installation.number),
+                "numinst": installation.number,
                 "panel": installation.panel,
             },
             "query": "query CheckAlarm($numinst: String!, $panel: String!) {\n  xSCheckAlarm(numinst: $numinst, panel: $panel) {\n    res\n    msg\n    referenceId\n  }\n}\n",
@@ -392,7 +395,7 @@ class ApiManager:
         """Get the list of all services available to the user."""
         content = {
             "operationName": "Srv",
-            "variables": {"numinst": str(installation.number), "uuid": self.uuid},
+            "variables": {"numinst": installation.number, "uuid": self.uuid},
             "query": "query Srv($numinst: String!, $uuid: String) {\n  xSSrv(numinst: $numinst, uuid: $uuid) {\n    res\n    msg\n    language\n    installation {\n      id\n      numinst\n      alias\n      status\n      panel\n      sim\n      instIbs\n      services {\n        id\n        idService\n        active\n        visible\n        bde\n        isPremium\n        codOper\n        totalDevice\n        request\n        multipleReq\n        numDevicesMr\n        secretWord\n        minWrapperVersion\n        description\n        unprotectActive\n        unprotectDeviceStatus\n        instDate\n        genericConfig {\n          total\n          attributes {\n            key\n            value\n          }\n        }\n        devices {\n          id\n          code\n          numDevices\n          cost\n          type\n          name\n        }\n        camerasArlo {\n          id\n          model\n          connectedToInstallation\n          usedForAlarmVerification\n          offer\n          name\n          locationHint\n          batteryLevel\n          connectivity\n          createdDate\n          modifiedDate\n          latestThumbnailUri\n        }\n        attributes {\n          name\n          attributes {\n            name\n            value\n            active\n          }\n        }\n        listdiy {\n          idMant\n          state\n        }\n        listprompt {\n          idNot\n          text\n          type\n          customParam\n          alias\n        }\n      }\n      configRepoUser {\n        alarmPartitions {\n          id\n          enterStates\n          leaveStates\n        }\n      }\n      capabilities\n    }\n  }\n}",
         }
         response = await self._execute_request(content, "Srv")
@@ -462,7 +465,7 @@ class ApiManager:
         content = {
             "operationName": "Sentinel",
             "variables": {
-                "numinst": str(installation.number),
+                "numinst": installation.number,
                 "zone": str(service.attributes.attributes[0].value),
             },
             "query": "query Sentinel($numinst: String!, $zone: String!) {\n  xSAllConfort(numinst: $numinst, zone: $zone) {\n    res\n    msg\n    ddi {\n      zone\n      alias\n      zonePrevious\n      aliasPrevious\n      zoneNext\n      aliasNext\n      moreDdis\n      status {\n        airQuality\n        airQualityMsg\n        humidity\n        temperature\n      }\n      forecast {\n        city\n        currentTemp\n        currentHum\n        description\n        forecastImg\n        day1 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day2 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day3 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day4 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day5 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n      }\n    }\n  }\n}\n",
@@ -486,7 +489,7 @@ class ApiManager:
         content = {
             "operationName": "AirQualityGraph",
             "variables": {
-                "numinst": str(installation.number),
+                "numinst": installation.number,
                 "zone": str(service.attributes.attributes[0].value),
             },
             "query": "query AirQualityGraph($numinst: String!, $zone: String!) {\n  xSAirQ(numinst: $numinst, zone: $zone) {\n    res\n    msg\n    graphData {\n      status {\n        avg6h\n        avg6hMsg\n        avg24h\n        avg24hMsg\n        avg7d\n        avg7dMsg\n        avg4w\n        avg4wMsg\n        current\n        currentMsg\n      }\n      daysTotal\n      days {\n        id\n        value\n      }\n      hoursTotal\n      hours {\n        id\n        value\n      }\n      weeksTotal\n      weeks {\n        id\n        value\n      }\n    }\n  }\n}",
@@ -505,7 +508,7 @@ class ApiManager:
         """Check current status of the alarm."""
         content = {
             "operationName": "Status",
-            "variables": {"numinst": str(installation.number)},
+            "variables": {"numinst": installation.number},
             "query": "query Status($numinst: String!) {\n  xSStatus(numinst: $numinst) {\n    status\n    timestampUpdate\n    exceptions {\n      status\n      deviceType\n      alias\n    }\n  }\n}",
         }
         await self._check_authentication_token()
@@ -532,6 +535,7 @@ class ApiManager:
             raw_data = await self._check_alarm_status(installation, reference_id, count)
             count += 1
 
+        self.protom_response = raw_data["protomResponse"]
         return CheckAlarmStatus(
             raw_data["res"],
             raw_data["msg"],
@@ -548,7 +552,7 @@ class ApiManager:
         content = {
             "operationName": "CheckAlarmStatus",
             "variables": {
-                "numinst": str(installation.number),
+                "numinst": installation.number,
                 "panel": installation.panel,
                 "referenceId": reference_id,
                 "idService": "11",
@@ -563,16 +567,16 @@ class ApiManager:
         return response["data"]["xSCheckAlarmStatus"]
 
     async def arm_alarm(
-        self, installation: Installation, mode: AlarmStates, current_status: str
+        self, installation: Installation, mode: SecDirAlarmState
     ) -> tuple[bool, str]:
         """Arms the alarm in the specified mode."""
         content = {
             "operationName": "xSArmPanel",
             "variables": {
                 "request": self.command_map[mode],
-                "numinst": str(installation.number),
+                "numinst": installation.number,
                 "panel": installation.panel,
-                "currentStatus": current_status,
+                "currentStatus": self.protom_response,
             },
             "query": "mutation xSArmPanel($numinst: String!, $request: ArmCodeRequest!, $panel: String!, $currentStatus: String) {\n  xSArmPanel(numinst: $numinst, request: $request, panel: $panel, currentStatus: $currentStatus) {\n    res\n    msg\n    referenceId\n  }\n}\n",
         }
@@ -590,10 +594,11 @@ class ApiManager:
         while (count == 1) or (raw_data.get("res") == "WAIT"):
             await asyncio.sleep(self.delay_check_operation)
             raw_data = await self._check_arm_status(
-                installation, reference_id, mode, count, current_status
+                installation, reference_id, mode, count
             )
             count += 1
 
+        self.protom_response = raw_data["protomResponse"]
         return ArmStatus(
             raw_data["res"],
             raw_data["msg"],
@@ -609,18 +614,17 @@ class ApiManager:
         self,
         installation: Installation,
         reference_id: str,
-        mode: AlarmStates,
+        mode: SecDirAlarmState,
         counter: int,
-        current_status: str,
     ) -> Union[ArmStatus, str]:
         """Check progress of the alarm."""
         content = {
             "operationName": "ArmStatus",
             "variables": {
                 "request": self.command_map[mode],
-                "numinst": str(installation.number),
+                "numinst": installation.number,
                 "panel": installation.panel,
-                "currentStatus": current_status,
+                "currentStatus": self.protom_response,
                 "referenceId": reference_id,
                 "counter": counter,
             },
@@ -631,15 +635,15 @@ class ApiManager:
         raw_data = response["data"]["xSArmStatus"]
         return raw_data
 
-    async def disarm_alarm(self, installation: Installation, current_status: str):
+    async def disarm_alarm(self, installation: Installation):
         """Disarm the alarm."""
         content = {
             "operationName": "xSDisarmPanel",
             "variables": {
-                "request": self.command_map[AlarmStates.TOTAL_DISARMED],
-                "numinst": str(installation.number),
+                "request": self.command_map[SecDirAlarmState.TOTAL_DISARMED],
+                "numinst": installation.number,
                 "panel": installation.panel,
-                "currentStatus": current_status,
+                "currentStatus": self.protom_response,
             },
             "query": "mutation xSDisarmPanel($numinst: String!, $request: DisarmCodeRequest!, $panel: String!) {\n  xSDisarmPanel(numinst: $numinst, request: $request, panel: $panel) {\n    res\n    msg\n    referenceId\n  }\n}\n",
         }
@@ -659,12 +663,12 @@ class ApiManager:
             raw_data = await self._check_disarm_status(
                 installation,
                 reference_id,
-                AlarmStates.TOTAL_DISARMED,
+                SecDirAlarmState.TOTAL_DISARMED,
                 count,
-                current_status,
             )
             count = count + 1
 
+        self.protom_response = raw_data["protomResponse"]
         return DisarmStatus(
             raw_data["error"],
             raw_data["msg"],
@@ -680,18 +684,17 @@ class ApiManager:
         self,
         installation: Installation,
         reference_id: str,
-        arm_type: AlarmStates,
+        arm_type: SecDirAlarmState,
         counter: int,
-        current_status: str,
     ) -> DisarmStatus:
         """Check progress of the alarm."""
         content = {
             "operationName": "DisarmStatus",
             "variables": {
                 "request": self.command_map[arm_type],
-                "numinst": str(installation.number),
+                "numinst": installation.number,
                 "panel": installation.panel,
-                "currentStatus": current_status,
+                "currentStatus": self.protom_response,
                 "referenceId": reference_id,
                 "counter": counter,
             },

--- a/custom_components/securitas/securitas_direct_new_api/const.py
+++ b/custom_components/securitas/securitas_direct_new_api/const.py
@@ -8,17 +8,19 @@ API_ARM_DAY: Final[str] = "ARMDAY1"
 API_ARM_NIGHT: Final[str] = "ARMNIGHT1"
 API_ARM_PERI: Final[str] = "PERI1"
 API_ARM_INTANDPERI: Final[str] = "ARM1PERI1"
+API_ARM_PARTIALINTANDPERI: Final[str] = "ARMDAY1PERI1"
 
 API_DISARM: Final[str] = "DARM1"
 API_DISARM_INTANDPERI: Final[str] = "DARM1DARMPERI"
 
 
-class AlarmStates(IntEnum):
+class SecDirAlarmState(IntEnum):
     """Define possible stats of an SD alarm as seen on the app or website."""
 
     INTERIOR_PARTIAL = auto()
     INTERIOR_TOTAL = auto()
     INTERIOR_DISARMED = auto()
+    INTERIOR_PARTIAL_AND_PERI = auto()
     NIGHT_ARMED = auto()
     EXTERIOR_ARMED = auto()
     EXTERIOR_DISARMED = auto()
@@ -26,28 +28,41 @@ class AlarmStates(IntEnum):
     TOTAL_DISARMED = auto()
 
 
+MAP_STATE_TO_PROTO_STATUS = {
+    SecDirAlarmState.INTERIOR_PARTIAL: "P",
+    SecDirAlarmState.INTERIOR_TOTAL: "T",
+    SecDirAlarmState.INTERIOR_DISARMED: "D",
+    SecDirAlarmState.INTERIOR_PARTIAL_AND_PERI: "",  # FIXME
+    SecDirAlarmState.NIGHT_ARMED: "Q",
+    SecDirAlarmState.EXTERIOR_ARMED: "E",
+    SecDirAlarmState.EXTERIOR_DISARMED: "D",
+    SecDirAlarmState.TOTAL_ARMED: "T",
+    SecDirAlarmState.TOTAL_DISARMED: "D",
+}
+
 # Map alarm states to commands. These "standard" commands assume there are no
 # exterior (perimetral) sensors, so having a state to arm the exterior doesn't
 # make a lot of sense, but the original HA code had this, so I just left it here
 STD_COMMANDS_MAP = {
-    AlarmStates.EXTERIOR_ARMED: API_ARM_PERI,  # see comment above
-    AlarmStates.INTERIOR_PARTIAL: API_ARM_DAY,
-    AlarmStates.INTERIOR_TOTAL: API_ARM,
-    AlarmStates.NIGHT_ARMED: API_ARM_NIGHT,
-    AlarmStates.TOTAL_ARMED: API_ARM,
-    AlarmStates.TOTAL_DISARMED: API_DISARM,
+    SecDirAlarmState.EXTERIOR_ARMED: API_ARM_PERI,  # see comment above
+    SecDirAlarmState.INTERIOR_PARTIAL: API_ARM_DAY,
+    SecDirAlarmState.INTERIOR_TOTAL: API_ARM,
+    SecDirAlarmState.NIGHT_ARMED: API_ARM_NIGHT,
+    SecDirAlarmState.TOTAL_ARMED: API_ARM,
+    SecDirAlarmState.TOTAL_DISARMED: API_DISARM,
 }
 
 # Map alarm states to commands assuming there are exterior (perimetral) sensors.
 PERI_COMMANDS_MAP = {
-    AlarmStates.EXTERIOR_ARMED: API_ARM_PERI,
-    AlarmStates.EXTERIOR_DISARMED: API_DISARM,
-    AlarmStates.INTERIOR_PARTIAL: API_ARM_DAY,
-    AlarmStates.INTERIOR_TOTAL: API_ARM,
-    AlarmStates.INTERIOR_DISARMED: API_DISARM,
-    AlarmStates.NIGHT_ARMED: API_ARM_NIGHT,
-    AlarmStates.TOTAL_ARMED: API_ARM_INTANDPERI,
-    AlarmStates.TOTAL_DISARMED: API_DISARM_INTANDPERI,
+    SecDirAlarmState.EXTERIOR_ARMED: API_ARM_PERI,
+    SecDirAlarmState.EXTERIOR_DISARMED: API_DISARM,
+    SecDirAlarmState.INTERIOR_PARTIAL: API_ARM_DAY,
+    SecDirAlarmState.INTERIOR_TOTAL: API_ARM,
+    SecDirAlarmState.INTERIOR_PARTIAL_AND_PERI: API_ARM_PARTIALINTANDPERI,
+    SecDirAlarmState.INTERIOR_DISARMED: API_DISARM,
+    # AlarmStates.NIGHT_ARMED: API_ARM_NIGHT,
+    SecDirAlarmState.TOTAL_ARMED: API_ARM_INTANDPERI,
+    SecDirAlarmState.TOTAL_DISARMED: API_DISARM_INTANDPERI,
 }
 
 

--- a/custom_components/securitas/securitas_direct_new_api/const.py
+++ b/custom_components/securitas/securitas_direct_new_api/const.py
@@ -28,6 +28,7 @@ class SecDirAlarmState(IntEnum):
     TOTAL_DISARMED = auto()
 
 
+# not used (yet), but I wanted to store this mapping somewhere
 MAP_STATE_TO_PROTO_STATUS = {
     SecDirAlarmState.INTERIOR_PARTIAL: "P",
     SecDirAlarmState.INTERIOR_TOTAL: "T",

--- a/custom_components/securitas/securitas_direct_new_api/domains.py
+++ b/custom_components/securitas/securitas_direct_new_api/domains.py
@@ -2,22 +2,42 @@
 
 
 class ApiDomains:
-    """Define the domain list for each language."""
+    """Define the domain list for each country."""
 
     def __init__(self) -> None:
         """Define default constructor."""
         self.domains = {
-            "default": "https://customers.securitasdirect.{language}/owa-api/graphql",
-            "it": "https://customers.verisure.it/owa-api/graphql",
-            "es": "https://customers.securitasdirect.es/owa-api/graphql",
-            "gb": "https://customers.verisure.co.uk/owa-api/graphql",
-            "br": "https://customers.verisure.com.br/owa-api/graphql",
-            "fr": "https://customers.securitasdirect.fr/owa-api/graphql",
+            "default": "https://customers.securitasdirect.{country}/owa-api/graphql",
+            "BR": "https://customers.verisure.com.br/owa-api/graphql",
+            "CL": "https://customers.verisure.cl/owa-api/graphql",
+            "ES": "https://customers.securitasdirect.es/owa-api/graphql",
+            "FR": "https://customers.securitasdirect.fr/owa-api/graphql",
+            "GB": "https://customers.verisure.co.uk/owa-api/graphql",
+            "IT": "https://customers.verisure.it/owa-api/graphql",
         }
 
-    def get_url(self, language: str) -> str:
-        """Get the API url for the specified language."""
-        result: str = self.domains["default"].format(language=language)
-        if language in self.domains:
-            result = self.domains[language]
+        self.languages = {
+            "default": "en",
+            "BR": "br",  # I know they speak Portuguese, but past code basically did lang=country.lower()
+            "CL": "es",
+            "ES": "es",
+            "FR": "fr",
+            "GB": "en",
+            "IT": "it",
+        }
+
+    def get_url(self, country: str) -> str:
+        """Get the API url for the specified country."""
+        country = country.upper()
+        result: str = self.domains["default"].format(country=country)
+        if country in self.domains:
+            result = self.domains[country]
+        return result
+
+    def get_language(self, country: str) -> str:
+        """Return the language for the specified country."""
+        country = country.upper()
+        result: str = self.languages["default"]
+        if country in self.languages:
+            result = self.languages[country]
         return result

--- a/custom_components/securitas/securitas_direct_new_api/examples/basic_operations.py
+++ b/custom_components/securitas/securitas_direct_new_api/examples/basic_operations.py
@@ -2,13 +2,9 @@
 
 import asyncio
 import logging
-import sys
 from uuid import uuid4
 
 import aiohttp
-
-sys.path.insert(0, "../../")
-
 from securitas_direct_new_api import (
     _LOGGER,
     ApiManager,
@@ -50,17 +46,15 @@ async def main():
 
     user = input("User: ")
     password = input("Password: ")
-    country = "es"
-    language = "es"
+    country = "ES"
     async with aiohttp.ClientSession() as aiohttp_session:
         uuid = generate_uuid()
-        device_id = generate_device_id(language)
+        device_id = generate_device_id(country)
         id_device_indigitall = str(uuid4())
         client = ApiManager(
             user,
             password,
             country,
-            language,
             aiohttp_session,
             device_id,
             uuid,


### PR DESCRIPTION
In the last pull request I somehow messed up pushing all the code to support PERI alarms. This pull request fixes that. Not sure what I did, but sorry for the thrashing.  

The main changes are in alarm_control_panel.py to map from HA states (like STATE_ALARM_ARMED_AWAY to SecDirAlarmState.TOTAL_ARMED). 

The last pull request had the part where the API manager translates that desired state into a command (so the TOTAL_ARMED will send a "ARM1"

This pull request should fix
https://github.com/guerrerotook/securitas-direct-new-api/issues/201

I've been running this code on my installation for a few days without issue