### PR TITLE
re-introduce scan_interval

### DIFF
--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -66,6 +66,7 @@ STATE_MAP = {
 }
 
 _LOGGER = logging.getLogger(__name__)
+
 SCAN_INTERVAL = timedelta(seconds=1200)
 
 

--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -66,7 +66,7 @@ STATE_MAP = {
 }
 
 _LOGGER = logging.getLogger(__name__)
-# SCAN_INTERVAL = timedelta(seconds=1200)  # FIXME: is this used?
+SCAN_INTERVAL = timedelta(seconds=1200)
 
 
 async def async_setup_entry(


### PR DESCRIPTION
As part of some code clean up I commented a line that appeared to be unused. It turns out that it's needed to setup the scan interval. This pull request reintroduces scan_interval. It should fix https://github.com/guerrerotook/securitas-direct-new-api/issues/218