### PR TITLE
[xSAirQ] Fix AirQualityGraph operation

### DIFF
--- a/custom_components/securitas/sensor.py
+++ b/custom_components/securitas/sensor.py
@@ -78,7 +78,7 @@ class SentinelTemperature(SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Temperature Sensor",
-            model=service.id_service,
+            model=str(service.id_service) if service.id_service is not None else None,
             name=service.description,
             via_device=parent_device,
         )
@@ -117,7 +117,7 @@ class SentinelHumidity(SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Humidity Sensor",
-            model=service.id_service,
+            model=str(service.id_service) if service.id_service is not None else None,
             name=service.description,
             via_device=parent_device,
         )
@@ -157,14 +157,14 @@ class SentinelAirQuality(SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Air Quality Sensor",
-            model=service.id_service,
+            model=str(service.id_service) if service.id_service is not None else None,
             name=service.description,
             via_device=parent_device,
         )
 
     async def async_update(self):
         """Update the status of the alarm based on the configuration."""
-        air_quality: Sentinel = await self._client.session.get_air_quality_data(
+        air_quality: AirQuality = await self._client.session.get_air_quality_data(
             self._service.installation, self._service
         )
         self._update_sensor_data(air_quality)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 requests>=2.26.0
+homeassistant~=2024.5.2
+voluptuous~=0.13.1
+aiohttp~=3.9.5
+PyJWT~=2.8.0


### PR DESCRIPTION
Fixes the AirQualityGraph operation.

```shell
2024-05-09 14:36:14.192 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up securitas platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 356, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/securitas/sensor.py", line 50, in async_setup_entry
    air_quality: AirQuality = await client.session.get_air_quality_data(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/securitas/securitas_direct_new_api/apimanager.py", line 502, in get_air_quality_data
    response = await self._execute_request(content, "AirQualityGraph")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/securitas/securitas_direct_new_api/apimanager.py", line 170, in _execute_request
    raise SecuritasDirectError(
custom_components.securitas.securitas_direct_new_api.exceptions.SecuritasDirectError: ("Cannot read properties of undefined (reading 'total')",
{'errors': [
      {'message': "Cannot read properties of undefined (reading 'total')", 
        'locations': [{'line': 2, 'column': 3}], 
        'path': ['xSAirQ'], 
        'extensions': {'code': 'INTERNAL_SERVER_ERROR'}, 
        'data': {}}], 
  'data': {'xSAirQ': None}}, 
{'app': '{"appVersion": "10.102.0", "origin": "native"}', 
        'User-Agent': 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.124 Safari/537.36 Edg/102.0.1245.41', 
'X-APOLLO-OPERATION-ID': '<X-APOLLO-OPERATION-ID>',
'X-APOLLO-OPERATION-NAME': 'AirQualityGraph', 
'extension': '{"mode":"full"}', 
'auth': '{"loginTimestamp": 1715258167440, 
          "user": "<USER>", 
          "id": "<OWA>", 
          "country": "ES", 
          "lang": "es", 
          "callby": "OWA_10", 
          "hash": "<HAS>"}'},
{'operationName': 'AirQualityGraph', 
 'variables': {'numinst': '5281378', 'zone': 'JZ01'}, 
 'query': 'query AirQualityGraph($numinst: String!, $zone: String!) {\n  xSAirQ(numinst: $numinst, zone: $zone) {\n    res\n    msg\n    graphData {\n      status {\n        avg6h\n        avg6hMsg\n        avg24h\n        avg24hMsg\n        avg7d\n        avg7dMsg\n        avg4w\n        avg4wMsg\n        current\n        currentMsg\n      }\n      daysTotal\n      days {\n        id\n        value\n      }\n      hoursTotal\n      hours {\n        id\n        value\n      }\n      weeksTotal\n      weeks {\n        id\n        value\n      }\n    }\n  }\n}'}
```

@guerrerotook PTAL whenever you got some free cycles, thanks