### PR TITLE
fix: multiples otp with same final number and get_sentinel_data for humidity and temperature

### DIFF
--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -519,7 +519,6 @@ class ApiManager:
             "operationName": "Sentinel",
             "variables": {
                 "numinst": installation.number,
-                "zone": str(service.attributes[0].value),
             },
             "query": "query Sentinel($numinst: String!) {\n  xSComfort(numinst: $numinst) {\n    res\n    devices {\n      alias\n      status {\n        temperature\n        humidity\n        airQualityCode\n      }\n      zone\n    }\n    forecast {\n      city\n      currentHum\n      currentTemp\n      forecastCode\n      forecastedDays {\n        date\n        forecastCode\n        maxTemp\n        minTemp\n      }\n    }\n  }\n}",
         }
@@ -527,7 +526,6 @@ class ApiManager:
         await self._check_authentication_token()
         await self._check_capabilities_token(installation)
         response = await self._execute_request(content, "Sentinel", installation)
-
 
         if "errors" in response:
             return Sentinel("", "", 0, 0)

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -521,21 +521,34 @@ class ApiManager:
                 "numinst": installation.number,
                 "zone": str(service.attributes[0].value),
             },
-            "query": "query Sentinel($numinst: String!, $zone: String!) {\n  xSAllConfort(numinst: $numinst, zone: $zone) {\n    res\n    msg\n    ddi {\n      zone\n      alias\n      zonePrevious\n      aliasPrevious\n      zoneNext\n      aliasNext\n      moreDdis\n      status {\n        airQuality\n        airQualityMsg\n        humidity\n        temperature\n      }\n      forecast {\n        city\n        currentTemp\n        currentHum\n        description\n        forecastImg\n        day1 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day2 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day3 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day4 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n        day5 {\n          forecastImg\n          maxTemp\n          minTemp\n          value\n        }\n      }\n    }\n  }\n}",
+            "query": "query Sentinel($numinst: String!) {\n  xSComfort(numinst: $numinst) {\n    res\n    devices {\n      alias\n      status {\n        temperature\n        humidity\n        airQualityCode\n      }\n      zone\n    }\n    forecast {\n      city\n      currentHum\n      currentTemp\n      forecastCode\n      forecastedDays {\n        date\n        forecastCode\n        maxTemp\n        minTemp\n      }\n    }\n  }\n}",
         }
+
         await self._check_authentication_token()
         await self._check_capabilities_token(installation)
         response = await self._execute_request(content, "Sentinel", installation)
 
+
         if "errors" in response:
             return Sentinel("", "", 0, 0)
 
-        raw_data = response["data"]["xSAllConfort"][0]["ddi"]["status"]
+        zone = service.attributes[0].value
+        devices = response["data"]["xSComfort"]["devices"]
+        target_device = None
+        
+        for device in devices:
+            if device.get("zone") == zone:
+                target_device = device
+                break
+        
+        if target_device is None:
+            return Sentinel("", "", 0, 0)
+
         return Sentinel(
-            response["data"]["xSAllConfort"][0]["ddi"]["alias"],
-            raw_data["airQualityMsg"],
-            int(raw_data["humidity"]),
-            int(raw_data["temperature"]),
+            target_device["alias"],
+            "",
+            int(target_device["status"]["humidity"]),
+            int(target_device["status"]["temperature"]),
         )
 
     async def get_air_quality_data(


### PR DESCRIPTION
- I've fixed this issue https://github.com/guerrerotook/securitas-direct-new-api/issues/295 for the OTP process with phone numbers, which end the same way.

- `get_sentinel_data` now partially works. The `xSAllConfort` query now seems to no longer exist in its schema. Analyzing the requests made by the website, I obtained this one, from which we retrieve the humidity and temperature. I've already left `air_quality` empty since I only see the code available in this query, not the message. This partially fixes the issue https://github.com/guerrerotook/securitas-direct-new-api/issues/294 since we still don't have `air_quality` (msg) in this method.

- `get_air_quality_data` still needs to be fixed, as it doesn't seem to work, but we can address it in a subsequent PR and quickly release the fixes for `humidity` and `temperature`. I have the error:
```
{"data":{"xSAirQ":null},"errors":[{"data":{"name":"accessPermissionsMiddleware","reason":"accessPermissions: Missing capabilities data"}}]}
```

Note: I'm more of a Java and JS guy, so I don't mind a revision.