### PR TITLE
fix: prevent crash when service attributes are null 

### DIFF
--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -474,12 +474,11 @@ class ApiManager:
         # result = json.loads(json_services)
         item: dict = {}
         for item in raw_data:
-            if (
-                item["attributes"] is not None
-                and item["attributes"]["attributes"] is not None
-            ):
-                attribute_list: list[Attribute] = []
-                for attribute_item in item["attributes"]["attributes"]:
+            attribute_list: list[Attribute] = []
+
+            attributes = item.get("attributes")
+            if attributes and attributes.get("attributes"):
+                for attribute_item in attributes["attributes"]:
                     attribute_list.append(
                         Attribute(
                             attribute_item["name"],
@@ -487,6 +486,8 @@ class ApiManager:
                             bool(attribute_item["active"]),
                         )
                     )
+        
+
             result.append(
                 Service(
                     int(item["idService"]),


### PR DESCRIPTION
Fixes Issue #297

Disclamer: im not a python dev, im a .net dev. please review my changes to fit properly into the language... either way ive tested in my ha instance and now works. idk if the attributes on null is a AR endpoint specific problemn or what...