### PR TITLE
Add Portugal support and fix 2FA authentication

### DIFF
--- a/custom_components/securitas/securitas_direct_new_api/domains.py
+++ b/custom_components/securitas/securitas_direct_new_api/domains.py
@@ -17,6 +17,7 @@ class ApiDomains:
             "IE": "https://customers.verisure.ie/owa-api/graphql",
             "IT": "https://customers.verisure.it/owa-api/graphql",
             "AR": "https://customers.verisure.com.ar/owa-api/graphql",
+            "PT": "https://customers.securitasdirect.pt/owa-api/graphql",
         }
 
         self.languages = {
@@ -29,6 +30,7 @@ class ApiDomains:
             "IE": "en",
             "IT": "it",
             "AR": "ar",
+            "PT": "pt",
         }
 
     def get_url(self, country: str) -> str:


### PR DESCRIPTION
Changes:
  - Added Portugal API endpoint and language configuration
  - Fixed 2FA detection to properly raise Login2FAError when needed
  - Fixed null token handling during 2FA authentication flow
  - Added safer dictionary access to prevent KeyError exceptions

Tested with a Portuguese Securitas Direct account with 2FA enabled. All operations (arm, disarm, status check) working correctly.

Fixes issues for Portuguese users who couldn't use the integration.