### PR TITLE
fix: store and use refresh token for session renewal

### DIFF
--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -375,6 +375,9 @@ class ApiManager:
                 self.authentication_token_exp = datetime.fromtimestamp(
                     token["exp"]
                 )
+            self.login_timestamp = int(datetime.now().timestamp() * 1000)
+        else:
+            return False
         if refresh_data.get("refreshToken"):
             self.refresh_token_value = refresh_data["refreshToken"]
 


### PR DESCRIPTION
## Summary

- Store `refreshToken` from `login()` and `validate_device()` API responses (was always returned but discarded)
- Add all 9 missing required variables to the `refresh_token()` GraphQL call
- Store new `hash`, expiry, and `refreshToken` from refresh response
- Fix `refresh_token()` return type (was returning raw string, now returns `bool`)
- Use `refresh_token()` instead of full `login()` when auth token expires, with fallback to `login()` on failure
- Decode JWT and set `authentication_token_exp` in `validate_device()` (was left at `datetime.min`)
- Check `res == "OK"` before storing tokens in `refresh_token()` to avoid persisting failed refresh data
- Return `False` on JWT decode failure in `refresh_token()` to trigger login fallback
- Catch broad exceptions in `_check_authentication_token` so malformed responses fall back to `login()`

The `refreshToken` is a long-lived JWT (~180 days) that enables lightweight session renewal every ~15 minutes without re-sending credentials.

## Test plan

- [x] Verified `refreshToken` is returned in `xSLoginToken` response and stored
- [x] Verified `RefreshLogin` is called instead of `mkLoginToken` when auth token expires
- [x] Verified `RefreshLogin` returns new `hash` and `refreshToken`, both stored correctly
- [x] Verified subsequent API calls work with refreshed token
- [x] Verified fallback to `login()` would trigger if refresh fails (via code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)