### PR TITLE
fix: only disarm before re-arming when in a confirmed armed state

### DIFF
--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -287,8 +287,10 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
             _LOGGER.error("No command configured for mode %s", mode)
             return
 
-        # Disarm first if currently in a confirmed armed state
-        if self._state in (
+        # Disarm first if previously in a confirmed armed state.
+        # Note: self._state is already ARMING (set by caller via
+        # __force_state), so check _last_status for the actual prior state.
+        if self._last_status in (
             AlarmControlPanelState.ARMED_HOME,
             AlarmControlPanelState.ARMED_AWAY,
             AlarmControlPanelState.ARMED_NIGHT,
@@ -301,9 +303,9 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
                 )
             except SecuritasDirectError as err:
                 _LOGGER.warning(
-                    "Failed to disarm before re-arming (state: %s, alarm may "
-                    "already be disarmed), continuing with arm: %s",
-                    self._state,
+                    "Failed to disarm before re-arming (last_status: %s, alarm "
+                    "may already be disarmed), continuing with arm: %s",
+                    self._last_status,
                     err.args,
                 )
             else:


### PR DESCRIPTION
## Summary

- Only attempt disarm-before-rearm when entity state is a confirmed armed state (`ARMED_HOME`, `ARMED_AWAY`, `ARMED_NIGHT`, `ARMED_CUSTOM_BYPASS`)
- Previously used `not in (DISARMED, DISARMING)` which matched transitional states like `ARMING` or stale states, causing unnecessary 404 errors from the API
- Changed disarm failure from aborting the arm to logging a warning and continuing, since failure likely means the alarm is already disarmed

## Test plan

- [x] Verified arming from a disarmed state no longer attempts a disarm first
- [x] Verified the arm command proceeds even if the disarm-before-rearm fails (404 from API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)