### PR TITLE
chore: add French, Italian, and Portuguese translations

### DIFF
--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -1,0 +1,62 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Le service est déjà configuré"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "username": "Nom d'utilisateur",
+                    "password": "Mot de passe",
+                    "use_2FA": "Utiliser la 2FA",
+                    "country": "Code pays",
+                    "code": "Code PIN (laisser vide pour ne pas utiliser de PIN)",
+                    "code_arm_required": "Exiger également le code PIN (s'il y en a un) pour armer l'alarme",
+                    "PERI_alarm": "Y a-t-il une alarme périmétrique ?",
+                    "check_alarm_panel": "Vérifier l'état du panneau d'alarme à chaque requête",
+                    "scan_interval": "Intervalle de mise à jour (sec)",
+                    "delay_check_operation": "Délai pour vérifier les opérations d'armement et de désarmement (sec)"
+                },
+                "description": "Connexion à Securitas Direct.",
+                "title": "Connexion"
+            },
+            "phone_list": {
+                "description": "Veuillez sélectionner le téléphone pour recevoir le code 2FA",
+                "title": "Securitas Direct 2FA"
+            },
+            "otp_challenge": {
+                "description": "Entrez le code reçu sur votre téléphone",
+                "title": "Securitas Direct 2FA"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "code": "Code PIN (laisser vide pour ne pas utiliser de PIN)",
+                    "code_arm_required": "Exiger également le code PIN (s'il y en a un) pour armer l'alarme",
+                    "PERI_alarm": "Y a-t-il une alarme périmétrique ?",
+                    "check_alarm_panel": "Vérifier l'état du panneau d'alarme à chaque requête (non recommandé)",
+                    "scan_interval": "Intervalle de mise à jour (sec)",
+                    "delay_check_operation": "Délai pour vérifier les opérations d'armement et de désarmement (sec)"
+                }
+            },
+            "mappings": {
+                "title": "Correspondance des états d'alarme",
+                "description": "Associer chaque action d'alarme Home Assistant à un mode d'alarme Securitas. Sélectionner « Non utilisé » pour désactiver un bouton.",
+                "data": {
+                    "map_home": "Maison",
+                    "map_away": "Absent",
+                    "map_night": "Nuit",
+                    "map_custom": "Personnalisé"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "invalid_pin_code": {
+            "message": "Code PIN non valide pour {entity_id}"
+        }
+    }
+}

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -1,0 +1,62 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Il servizio è già configurato"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "username": "Nome utente",
+                    "password": "Password",
+                    "use_2FA": "Usa 2FA",
+                    "country": "Codice paese",
+                    "code": "Codice PIN (lasciare vuoto per non usare un PIN)",
+                    "code_arm_required": "Richiedere anche il codice PIN (se presente) per attivare l'allarme",
+                    "PERI_alarm": "È presente un allarme perimetrale?",
+                    "check_alarm_panel": "Controlla lo stato del pannello di allarme ad ogni richiesta",
+                    "scan_interval": "Intervallo di aggiornamento (sec)",
+                    "delay_check_operation": "Ritardo per verificare le operazioni di attivazione e disattivazione (sec)"
+                },
+                "description": "Accedi a Securitas Direct.",
+                "title": "Accesso"
+            },
+            "phone_list": {
+                "description": "Seleziona il telefono per ricevere il codice 2FA",
+                "title": "Securitas Direct 2FA"
+            },
+            "otp_challenge": {
+                "description": "Inserisci il codice ricevuto sul tuo telefono",
+                "title": "Securitas Direct 2FA"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "code": "Codice PIN (lasciare vuoto per non usare un PIN)",
+                    "code_arm_required": "Richiedere anche il codice PIN (se presente) per attivare l'allarme",
+                    "PERI_alarm": "È presente un allarme perimetrale?",
+                    "check_alarm_panel": "Controlla lo stato del pannello di allarme ad ogni richiesta (non consigliato)",
+                    "scan_interval": "Intervallo di aggiornamento (sec)",
+                    "delay_check_operation": "Ritardo per verificare le operazioni di attivazione e disattivazione (sec)"
+                }
+            },
+            "mappings": {
+                "title": "Mappatura degli stati di allarme",
+                "description": "Associa ogni azione di allarme di Home Assistant a una modalità di allarme Securitas. Imposta su « Non utilizzato » per disattivare un pulsante.",
+                "data": {
+                    "map_home": "Casa",
+                    "map_away": "Fuori casa",
+                    "map_night": "Notte",
+                    "map_custom": "Personalizzato"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "invalid_pin_code": {
+            "message": "Codice PIN non valido per {entity_id}"
+        }
+    }
+}

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -1,0 +1,62 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "O serviço já está configurado"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "username": "Nome de usuário",
+                    "password": "Senha",
+                    "use_2FA": "Usar 2FA",
+                    "country": "Código do país",
+                    "code": "Código PIN (deixar vazio para não usar PIN)",
+                    "code_arm_required": "Exigir também o código PIN (se houver) para armar o alarme",
+                    "PERI_alarm": "Existe um alarme perimetral?",
+                    "check_alarm_panel": "Verificar o status do painel de alarme em cada solicitação",
+                    "scan_interval": "Intervalo de atualização (seg)",
+                    "delay_check_operation": "Atraso para verificar as operações de armar e desarmar (seg)"
+                },
+                "description": "Fazer login no Securitas Direct.",
+                "title": "Login"
+            },
+            "phone_list": {
+                "description": "Selecione o telefone para receber o código 2FA",
+                "title": "Securitas Direct 2FA"
+            },
+            "otp_challenge": {
+                "description": "Digite o código recebido no seu telefone",
+                "title": "Securitas Direct 2FA"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "code": "Código PIN (deixar vazio para não usar PIN)",
+                    "code_arm_required": "Exigir também o código PIN (se houver) para armar o alarme",
+                    "PERI_alarm": "Existe um alarme perimetral?",
+                    "check_alarm_panel": "Verificar o status do painel de alarme em cada solicitação (não recomendado)",
+                    "scan_interval": "Intervalo de atualização (seg)",
+                    "delay_check_operation": "Atraso para verificar as operações de armar e desarmar (seg)"
+                }
+            },
+            "mappings": {
+                "title": "Mapeamento dos estados do alarme",
+                "description": "Associe cada ação de alarme do Home Assistant a um modo de alarme Securitas. Selecione « Não utilizado » para desativar um botão.",
+                "data": {
+                    "map_home": "Casa",
+                    "map_away": "Ausente",
+                    "map_night": "Noite",
+                    "map_custom": "Personalizado"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "invalid_pin_code": {
+            "message": "Código PIN inválido para {entity_id}"
+        }
+    }
+}

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -1,0 +1,62 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "O serviço já está configurado"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "username": "Nome de utilizador",
+                    "password": "Palavra-passe",
+                    "use_2FA": "Usar 2FA",
+                    "country": "Código do país",
+                    "code": "Código PIN (deixar vazio para não usar PIN)",
+                    "code_arm_required": "Exigir também o código PIN (se existir) para armar o alarme",
+                    "PERI_alarm": "Existe um alarme perimetral?",
+                    "check_alarm_panel": "Verificar o estado do painel de alarme em cada pedido",
+                    "scan_interval": "Intervalo de atualização (seg)",
+                    "delay_check_operation": "Atraso para verificar as operações de armar e desarmar (seg)"
+                },
+                "description": "Iniciar sessão no Securitas Direct.",
+                "title": "Iniciar sessão"
+            },
+            "phone_list": {
+                "description": "Selecione o telefone para receber o código 2FA",
+                "title": "Securitas Direct 2FA"
+            },
+            "otp_challenge": {
+                "description": "Introduza o código recebido no seu telefone",
+                "title": "Securitas Direct 2FA"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "code": "Código PIN (deixar vazio para não usar PIN)",
+                    "code_arm_required": "Exigir também o código PIN (se existir) para armar o alarme",
+                    "PERI_alarm": "Existe um alarme perimetral?",
+                    "check_alarm_panel": "Verificar o estado do painel de alarme em cada pedido (não recomendado)",
+                    "scan_interval": "Intervalo de atualização (seg)",
+                    "delay_check_operation": "Atraso para verificar as operações de armar e desarmar (seg)"
+                }
+            },
+            "mappings": {
+                "title": "Mapeamento dos estados do alarme",
+                "description": "Associe cada ação de alarme do Home Assistant a um modo de alarme Securitas. Selecione « Não utilizado » para desativar um botão.",
+                "data": {
+                    "map_home": "Casa",
+                    "map_away": "Ausente",
+                    "map_night": "Noite",
+                    "map_custom": "Personalizado"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "invalid_pin_code": {
+            "message": "Código PIN inválido para {entity_id}"
+        }
+    }
+}


### PR DESCRIPTION
Added translation (auto-translated) for each supported country language

## Summary
- Add `fr.json` translation for French (FR)
- Add `it.json` translation for Italian (IT)
- Add `pt.json` translation for Portuguese (BR, PT)

This covers all supported country languages. English and Spanish translations already existed.

## Test plan
- [ ] Verify translations display correctly in HA UI for each language

🤖 Generated with [Claude Code](https://claude.com/claude-code)