### PR TITLE
ci: test against both HA dev and stable releases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,7 +62,7 @@ jobs:
           HA_VERSION=$(curl -fsSL "https://pypi.org/pypi/homeassistant/json" \
             | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
           echo "Stable HA version: $HA_VERSION"
-          echo "HA_VERSION=$HA_VERSION" >> $GITHUB_ENV
+          echo "HA_VERSION=$HA_VERSION" >> "$GITHUB_ENV"
 
       - name: Install dependencies (stable)
         if: matrix.ha-channel == 'stable'
@@ -70,7 +70,6 @@ jobs:
           pip install --upgrade pip
           # Pin HA to the stable release via a constraint so phcc can't upgrade it
           echo "homeassistant==$HA_VERSION" > /tmp/ha_stable.txt
-          pip install "homeassistant==$HA_VERSION"
           pip install -r requirements_test.txt --constraint /tmp/ha_stable.txt
 
       - name: Install dependencies (dev)


### PR DESCRIPTION
## Summary

- Adds a matrix strategy to the `test` CI job so tests run against both the HA `dev` build (latest phcc) and the current stable HA release
- For the `stable` channel: fetches the current stable version from the PyPI JSON API, installs it directly, then uses a pip constraint file to prevent phcc from upgrading it
- Uses `fail-fast: false` so both matrix legs always run independently

## Test plan

- [ ] Verify both matrix legs appear in CI on push
- [ ] Verify `stable` leg pins to the published HA release (not a dev build)
- [ ] Verify `dev` leg still tracks the latest phcc build

🤖 Generated with [Claude Code](https://claude.com/claude-code)