### PR TITLE
fix: surface real API error when GraphQL returns errors list with null data

### DIFF
--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -223,15 +223,27 @@ class ApiManager:
                     content,
                 )
             elif isinstance(errors, list) and errors and "data" in response_dict:
-                # Partial GraphQL response: errors list alongside a data key
-                # with a null operation result. Raise with the real API message
-                # so callers don't have to inspect the raw response.
-                raise SecuritasDirectError(
-                    errors[0].get("message", "Unknown GraphQL error"),
-                    response_dict,
-                    headers,
-                    content,
+                # Partial GraphQL response: errors list alongside a data key.
+                # Only raise automatically when the operation result is null/empty
+                # (all data values are None), so callers that handle partial data
+                # themselves are not affected.
+                data = response_dict["data"]
+                all_null = data is None or (
+                    isinstance(data, dict) and all(v is None for v in data.values())
                 )
+                if all_null:
+                    first = errors[0]
+                    message = (
+                        first.get("message", str(first))
+                        if isinstance(first, dict)
+                        else str(first)
+                    )
+                    raise SecuritasDirectError(
+                        message,
+                        response_dict,
+                        headers,
+                        content,
+                    )
 
         return response_dict
 

--- a/tests/test_execute_request.py
+++ b/tests/test_execute_request.py
@@ -200,6 +200,26 @@ class TestExecuteRequest:
         result = await api._execute_request({"query": "test"}, "mkLoginToken")
         assert result == {"errors": [{"message": "Invalid credentials"}]}
 
+    async def test_graphql_errors_list_with_non_null_data_passes_through(self, api):
+        """GraphQL partial response with errors but non-null data is returned as-is for callers to handle."""
+        error_response = json.dumps(
+            {"errors": [{"message": "Partial failure"}], "data": {"test": "ok"}}
+        )
+        response = AsyncMock()
+        response.text = AsyncMock(return_value=error_response)
+        response.status = 200
+
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=response)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        api.http_client.post = MagicMock(return_value=cm)
+
+        result = await api._execute_request({"query": "test"}, "TestOperation")
+        assert result == {
+            "errors": [{"message": "Partial failure"}],
+            "data": {"test": "ok"},
+        }
+
     @pytest.mark.parametrize("status_code", [409, 429, 500, 503])
     async def test_http_error_status_raises_securitas_error(self, api, status_code):
         """HTTP 4xx/5xx responses raise SecuritasDirectError before JSON parsing."""


### PR DESCRIPTION
## Summary

- `_execute_request` only checked `isinstance(errors, dict)` for the error guard, but the GraphQL spec always returns errors as a **list** — so the check was always `False` and real API errors silently passed through
- When the Securitas API returns a partial response like `{"errors": [{"message": "4: Requested data not found error."}], "data": {"xSArmPanel": null}}`, callers would get the confusing generic message `"xSArmPanel response is None"` instead of the actual API error
- Now detects the standard GraphQL partial-response format (errors list **+** `data` key present) and raises `SecuritasDirectError` with the first error's message
- Errors-only responses without a `data` key (e.g. login errors) are still passed through so existing callers handle them as before

## Reproduction

User reported in v3.3.1:
```
ERROR [custom_components.securitas.alarm_control_panel] ('xSArmPanel response is None', {'errors': [{'message': '4: Requested data not found error.', 'name': 'ApiError', 'data': {'res': 'ERROR', 'err': '4', 'status': 404}, 'path': ['xSArmPanel']}], 'data': {'xSArmPanel': None}})
```
The real error (`4: Requested data not found error.`) was hidden behind the generic message.

## Test plan

- [x] New test `test_graphql_errors_list_with_null_data_raises_securitas_error` — verifies partial response raises with the real message
- [x] New test `test_graphql_errors_list_without_data_key_passes_through` — verifies login-style errors-only responses still pass through
- [x] All 465 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)