### PR TITLE
fix: guard against hass-is-None after entity removal

### DIFF
--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -178,7 +178,8 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
     def __force_state(self, state: str) -> None:
         self._last_status = self._state
         self._state = state
-        self.async_schedule_update_ha_state()
+        if self.hass is not None:
+            self.async_schedule_update_ha_state()
 
     def _notify_error(self, title: str, message: str) -> None:
         """Notify user with persistent notification."""
@@ -241,6 +242,8 @@ class SecuritasAlarm(alarm.AlarmControlPanelEntity):
 
     async def async_update_status(self, now=None) -> None:
         """Update the status of the alarm."""
+        if self.hass is None:
+            return
         if self._operation_in_progress:
             _LOGGER.debug("Skipping status poll - arm/disarm operation in progress")
             return

--- a/custom_components/securitas/button.py
+++ b/custom_components/securitas/button.py
@@ -58,6 +58,8 @@ class SecuritasRefreshButton(ButtonEntity):
 
     async def async_press(self) -> None:
         """Update alarm status when button pressed."""
+        if self.hass is None:
+            return
         try:
             reference_id = await self.client.session.check_alarm(self.installation)
             await asyncio.sleep(ALARM_STATUS_POLL_DELAY)

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -110,7 +110,8 @@ class SecuritasLock(lock.LockEntity):
     def __force_state(self, state: str) -> None:
         self._last_state = self._state
         self._state = state
-        self.async_schedule_update_ha_state()
+        if self.hass is not None:
+            self.async_schedule_update_ha_state()
 
     def _notify_error(self, notification_id, title: str, message: str) -> None:
         """Notify user with persistent notification."""
@@ -146,6 +147,8 @@ class SecuritasLock(lock.LockEntity):
         await self.async_update_status()
 
     async def async_update_status(self, now=None) -> None:
+        if self.hass is None:
+            return
         try:
             self._new_state = await self.get_lock_state()
             if self._new_state != LOCK_STATUS_UNKNOWN:

--- a/custom_components/securitas/sensor.py
+++ b/custom_components/securitas/sensor.py
@@ -96,6 +96,8 @@ class SentinelTemperature(SensorEntity):
 
     async def async_update(self):
         """Update the status of the alarm based on the configuration."""
+        if self.hass is None:
+            return
         sentinel_data: Sentinel = await self._client.session.get_sentinel_data(
             self._service.installation, self._service
         )
@@ -134,6 +136,8 @@ class SentinelHumidity(SensorEntity):
 
     async def async_update(self):
         """Update the status of the alarm based on the configuration."""
+        if self.hass is None:
+            return
         sentinel_data: Sentinel = await self._client.session.get_sentinel_data(
             self._service.installation, self._service
         )
@@ -173,6 +177,8 @@ class SentinelAirQuality(SensorEntity):
 
     async def async_update(self):
         """Update the status of the alarm based on the configuration."""
+        if self.hass is None:
+            return
         air_quality: AirQuality = await self._client.session.get_air_quality_data(
             self._service.installation, self._service
         )

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2286,3 +2286,31 @@ class TestNotifyError:
             service_data["notification_id"]
             == "securitas.securitas_arming_failed_123456"
         )
+
+
+# ===========================================================================
+# hass-is-None guard tests (issue #323)
+# ===========================================================================
+
+
+class TestHassNoneGuardsAlarm:
+    """Verify alarm entity bails out when hass is None (after removal)."""
+
+    async def test_update_status_skips_when_hass_is_none(self):
+        alarm = make_alarm()
+        alarm.hass = None
+        alarm.client.update_overview = AsyncMock()
+
+        await alarm.async_update_status()
+
+        alarm.client.update_overview.assert_not_awaited()
+
+    def test_force_state_skips_schedule_when_hass_is_none(self):
+        alarm = make_alarm()
+        alarm.async_schedule_update_ha_state = MagicMock()
+        alarm.hass = None
+
+        alarm._SecuritasAlarm__force_state(AlarmControlPanelState.ARMING)
+
+        assert alarm._state == AlarmControlPanelState.ARMING
+        alarm.async_schedule_update_ha_state.assert_not_called()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -259,3 +259,22 @@ class TestAsyncSetupEntry:
 
         # Second positional arg or keyword arg should be True
         assert async_add_entities.call_args[0][1] is True
+
+
+# ===========================================================================
+# hass-is-None guard tests (issue #323)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestHassNoneGuardsButton:
+    """Verify button entity bails out when hass is None (after removal)."""
+
+    async def test_async_press_skips_when_hass_is_none(self):
+        button = make_button()
+        button.hass = None
+
+        # Should not raise or call any API methods
+        await button.async_press()
+
+        button.client.session.check_alarm.assert_not_called()

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -148,6 +148,7 @@ class TestSentinelTemperature:
         sensor = SentinelTemperature(
             make_sentinel(temp=22), service, client, make_device()
         )
+        sensor.hass = MagicMock()
         assert sensor._attr_native_value == 22
 
         updated_sentinel = make_sentinel(temp=30)
@@ -212,6 +213,7 @@ class TestSentinelHumidity:
         sensor = SentinelHumidity(
             make_sentinel(humidity=45), service, client, make_device()
         )
+        sensor.hass = MagicMock()
         assert sensor._attr_native_value == 45
 
         updated_sentinel = make_sentinel(humidity=60)
@@ -254,6 +256,7 @@ class TestSentinelAirQuality:
         sensor = SentinelAirQuality(
             air_quality, make_sentinel(), service, client, make_device()
         )
+        sensor.hass = MagicMock()
         assert sensor._attr_native_value == "Good"
 
         updated_air_quality = make_air_quality(value=40, message="Poor")
@@ -542,3 +545,67 @@ class TestSecuritasLockRemoval:
 
         # Should not raise
         await lock.async_will_remove_from_hass()
+
+
+# ===========================================================================
+# hass-is-None guard tests (issue #323)
+# ===========================================================================
+
+
+class TestHassNoneGuards:
+    """Verify entities bail out when hass is None (after removal)."""
+
+    async def test_lock_update_status_skips_when_hass_is_none(self):
+        lock = make_lock()
+        lock.hass = None
+        lock.client.session.get_lock_current_mode = AsyncMock()
+
+        await lock.async_update_status()
+
+        lock.client.session.get_lock_current_mode.assert_not_awaited()
+
+    def test_lock_force_state_skips_schedule_when_hass_is_none(self):
+        lock = make_lock()
+        lock.async_schedule_update_ha_state = MagicMock()
+        lock.hass = None
+
+        lock._SecuritasLock__force_state("1")
+
+        assert lock._state == "1"
+        lock.async_schedule_update_ha_state.assert_not_called()
+
+    async def test_temperature_update_skips_when_hass_is_none(self):
+        client = make_client()
+        sensor = SentinelTemperature(
+            make_sentinel(temp=22), make_service(), client, make_device()
+        )
+        sensor.hass = None
+        client.session.get_sentinel_data = AsyncMock()
+
+        await sensor.async_update()
+
+        client.session.get_sentinel_data.assert_not_awaited()
+
+    async def test_humidity_update_skips_when_hass_is_none(self):
+        client = make_client()
+        sensor = SentinelHumidity(
+            make_sentinel(humidity=45), make_service(), client, make_device()
+        )
+        sensor.hass = None
+        client.session.get_sentinel_data = AsyncMock()
+
+        await sensor.async_update()
+
+        client.session.get_sentinel_data.assert_not_awaited()
+
+    async def test_air_quality_update_skips_when_hass_is_none(self):
+        client = make_client()
+        sensor = SentinelAirQuality(
+            make_air_quality(), make_sentinel(), make_service(), client, make_device()
+        )
+        sensor.hass = None
+        client.session.get_air_quality_data = AsyncMock()
+
+        await sensor.async_update()
+
+        client.session.get_air_quality_data.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes #323 — entities continue trying to update after HA removes them during reload/restart, causing `RuntimeError: Attribute hass is None` log spam.

- Add `if self.hass is None: return` guards to timer callbacks and polling update methods in all entity types (alarm, lock, sensors, button)
- Guard `__force_state()` in alarm and lock to skip `async_schedule_update_ha_state()` when hass is gone
- Add 8 tests verifying entities bail out cleanly when hass is None

## Files changed

- `alarm_control_panel.py` — guard `async_update_status()` and `__force_state()`
- `lock.py` — guard `async_update_status()` and `__force_state()`
- `sensor.py` — guard `async_update()` in all 3 sensor classes
- `button.py` — guard `async_press()`

## Test plan

- [x] All 551 tests pass
- [x] `ruff check` and `ruff format` clean
- [ ] Verify no more `hass is None` errors in logs after HA restart/reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)