### PR TITLE
Rearchitect Smart Lock Entity to Populate Information from API

### DIFF
--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -22,9 +22,10 @@ from . import (
 from .securitas_direct_new_api import (
     Installation,
     SecuritasDirectError,
+    SmartLock,
     SmartLockMode,
 )
-
+from .securitas_direct_new_api.apimanager import SMARTLOCK_DEVICE_ID
 from .securitas_direct_new_api.dataTypes import Service
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ LOCK_STATUS_LOCKING = "4"
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up Securitas Direct based on config_entry."""
+    """Set up Securitas Direct lock entities from config entry."""
     client: SecuritasHub = hass.data[DOMAIN][SecuritasHub.__name__]
     locks = []
     securitas_devices: list[SecuritasDirectDevice] = hass.data[DOMAIN].get(
@@ -53,16 +54,64 @@ async def async_setup_entry(
     )
     for device in securitas_devices:
         services: list[Service] = await client.get_services(device.installation)
-        for service in services:
-            _LOGGER.debug("Service: %s", service.request)
-            if service.request == DOORLOCK_SERVICE:
-                locks.append(
-                    SecuritasLock(
-                        device.installation,
-                        client=client,
-                        hass=hass,
+        has_doorlock = any(s.request == DOORLOCK_SERVICE for s in services)
+        if not has_doorlock:
+            continue
+
+        # Discover individual lock devices from the API
+        lock_modes: list[SmartLockMode] = (
+            await client.session.get_lock_current_mode(device.installation)
+        )
+
+        if not lock_modes:
+            # Fallback: API didn't return any lock info, create a single lock
+            # with default device ID for backward compatibility
+            _LOGGER.warning(
+                "No lock devices discovered for installation %s, "
+                "using default device ID",
+                device.installation.number,
+            )
+            lock_config = await client.session.get_smart_lock_config(
+                device.installation
+            )
+            locks.append(
+                SecuritasLock(
+                    installation=device.installation,
+                    client=client,
+                    hass=hass,
+                    device_id=SMARTLOCK_DEVICE_ID,
+                    lock_config=lock_config,
+                    initial_status=LOCK_STATUS_UNKNOWN,
+                )
+            )
+            continue
+
+        for lock_mode in lock_modes:
+            device_id = lock_mode.deviceId or SMARTLOCK_DEVICE_ID
+            # Fetch per-lock config (location, serial, etc.)
+            try:
+                lock_config: SmartLock = (
+                    await client.session.get_smart_lock_config(
+                        device.installation, device_id=device_id
                     )
                 )
+            except SecuritasDirectError:
+                _LOGGER.warning(
+                    "Could not fetch config for lock device %s, using defaults",
+                    device_id,
+                )
+                lock_config = SmartLock(deviceId=device_id)
+
+            locks.append(
+                SecuritasLock(
+                    installation=device.installation,
+                    client=client,
+                    hass=hass,
+                    device_id=device_id,
+                    lock_config=lock_config,
+                    initial_status=lock_mode.lockStatus,
+                )
+            )
 
     if not locks:
         _LOGGER.debug("No Securitas Direct %s services found", DOORLOCK_SERVICE)
@@ -77,14 +126,28 @@ class SecuritasLock(lock.LockEntity):
         installation: Installation,
         client: SecuritasHub,
         hass: HomeAssistant,
+        device_id: str,
+        lock_config: SmartLock | None = None,
+        initial_status: str = LOCK_STATUS_LOCKED,
     ) -> None:
-        self._state = LOCK_STATUS_LOCKED
-        self._last_state = LOCK_STATUS_LOCKED
-        self._new_state: str = LOCK_STATUS_LOCKED
+        self._device_id: str = device_id
+        self._lock_config: SmartLock | None = lock_config
+        self._state = (
+            initial_status
+            if initial_status != LOCK_STATUS_UNKNOWN
+            else LOCK_STATUS_LOCKED
+        )
+        self._last_state = self._state
+        self._new_state: str = self._state
         self._changed_by: str = ""
         self._device: str = installation.address
-        self.entity_id: str = f"securitas_direct.{installation.number}"
-        self._attr_unique_id: str | None = f"securitas_direct.{installation.number}"
+        # Unique ID includes deviceId to support multiple locks per installation
+        self._attr_unique_id: str | None = (
+            f"securitas_direct.{installation.number}.lock.{device_id}"
+        )
+        self.entity_id: str = (
+            f"securitas_direct.{installation.number}_lock_{device_id}"
+        )
         self._time: datetime.datetime = datetime.datetime.now()
         self._message: str = ""
         self.installation: Installation = installation
@@ -100,12 +163,28 @@ class SecuritasLock(lock.LockEntity):
         else:
             self._update_unsub = None
 
+        # Build DeviceInfo from lock config instead of installation-level data
+        lock_name = (
+            lock_config.location
+            if lock_config and lock_config.location
+            else f"{installation.alias} Lock {device_id}"
+        )
+        lock_model = (
+            lock_config.family if lock_config and lock_config.family else None
+        )
+        lock_serial = (
+            lock_config.serialNumber
+            if lock_config and lock_config.serialNumber
+            else None
+        )
+
         self._attr_device_info: DeviceInfo | None = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Securitas Direct",
-            model=installation.panel,
-            name=installation.alias,
-            hw_version=installation.type,
+            model=lock_model,
+            name=lock_name,
+            serial_number=lock_serial,
+            via_device=(DOMAIN, f"securitas_direct.{installation.number}"),
         )
 
     def __force_state(self, state: str) -> None:
@@ -131,7 +210,9 @@ class SecuritasLock(lock.LockEntity):
     @property
     def name(self) -> str:  # type: ignore[override]
         """Return the name of the device."""
-        return self.installation.alias
+        if self._lock_config and self._lock_config.location:
+            return self._lock_config.location
+        return f"{self.installation.alias} Lock {self._device_id}"
 
     @property
     def changed_by(self) -> str:  # type: ignore[override]
@@ -158,31 +239,29 @@ class SecuritasLock(lock.LockEntity):
             _LOGGER.error("Error updating Securitas lock state: %s", err)
 
     async def get_lock_state(self) -> str:
-        smartlock_status: SmartLockMode = (
+        lock_modes: list[SmartLockMode] = (
             await self.client.session.get_lock_current_mode(self.installation)
         )
-        return smartlock_status.lockStatus
+        # Find the entry matching this lock's device ID
+        for mode in lock_modes:
+            if mode.deviceId == self._device_id:
+                return mode.lockStatus
+        # Fallback: if only one lock returned without matching deviceId, use it
+        if len(lock_modes) == 1:
+            return lock_modes[0].lockStatus
+        return LOCK_STATUS_UNKNOWN
 
     @property
     def is_locked(self) -> bool:  # type: ignore[override]
-        if self._state == LOCK_STATUS_LOCKED:
-            return True
-        else:
-            return False
+        return self._state == LOCK_STATUS_LOCKED
 
     @property
     def is_open(self) -> bool:  # type: ignore[override]
-        if self._state == LOCK_STATUS_OPEN:
-            return True
-        else:
-            return False
+        return self._state == LOCK_STATUS_OPEN
 
     @property
     def is_locking(self) -> bool:  # type: ignore[override]
-        if self._state == LOCK_STATUS_LOCKING:
-            return True
-        else:
-            return False
+        return self._state == LOCK_STATUS_LOCKING
 
     @property
     def is_unlocking(self) -> bool:  # type: ignore[override]
@@ -190,10 +269,7 @@ class SecuritasLock(lock.LockEntity):
 
     @property
     def is_opening(self) -> bool:  # type: ignore[override]
-        if self._state == LOCK_STATUS_OPENING:
-            return True
-        else:
-            return False
+        return self._state == LOCK_STATUS_OPENING
 
     @property
     def is_jammed(self) -> bool:  # type: ignore[override]
@@ -202,7 +278,9 @@ class SecuritasLock(lock.LockEntity):
     async def async_lock(self, **kwargs):
         self.__force_state(LOCK_STATUS_LOCKING)
         try:
-            await self.client.session.change_lock_mode(self.installation, True)
+            await self.client.session.change_lock_mode(
+                self.installation, True, device_id=self._device_id
+            )
         except SecuritasDirectError as err:
             _LOGGER.error("Lock operation failed: %s", err.args[0] if err.args else err)
             return
@@ -212,7 +290,9 @@ class SecuritasLock(lock.LockEntity):
     async def async_unlock(self, **kwargs):
         self.__force_state(LOCK_STATUS_OPENING)
         try:
-            await self.client.session.change_lock_mode(self.installation, False)
+            await self.client.session.change_lock_mode(
+                self.installation, False, device_id=self._device_id
+            )
         except SecuritasDirectError as err:
             _LOGGER.error(
                 "Unlock operation failed: %s", err.args[0] if err.args else err

--- a/custom_components/securitas/securitas_direct_new_api/__init__.py
+++ b/custom_components/securitas/securitas_direct_new_api/__init__.py
@@ -23,6 +23,7 @@ from .dataTypes import (  # noqa: F401
     Installation,
     OtpPhone,
     Service,
+    SmartLock,
     SStatus,
     SmartLockMode,
     SmartLockModeStatus,

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -1251,7 +1251,13 @@ class ApiManager:
         disarm_data = self._extract_response_data(response, "xSDisarmStatus")
         return disarm_data
 
-    async def get_smart_lock_config(self, installation: Installation) -> SmartLock:
+    async def get_smart_lock_config(
+        self,
+        installation: Installation,
+        device_id: str = SMARTLOCK_DEVICE_ID,
+        device_type: str = SMARTLOCK_DEVICE_TYPE,
+        key_type: str = SMARTLOCK_KEY_TYPE,
+    ) -> SmartLock:
         content = {
             "operationName": "xSGetSmartlockConfig",
             "variables": {
@@ -1259,9 +1265,9 @@ class ApiManager:
                 "panel": installation.panel,
                 "devices": [
                     {
-                        "deviceType": SMARTLOCK_DEVICE_TYPE,
-                        "deviceId": SMARTLOCK_DEVICE_ID,
-                        "keytype": SMARTLOCK_KEY_TYPE,
+                        "deviceType": device_type,
+                        "deviceId": device_id,
+                        "keytype": key_type,
                     }
                 ],
             },
@@ -1275,17 +1281,30 @@ class ApiManager:
 
         if "errors" in response:
             _LOGGER.error(response)
-            return SmartLock(None, None, None)
+            return SmartLock()
 
         if "data" in response:
             raw_data = response["data"]["xSGetSmartlockConfig"]
             if raw_data is None:
-                return SmartLock(None, None, None)
-            return SmartLock(raw_data["res"], raw_data["location"], raw_data["type"])
+                return SmartLock()
+            return SmartLock(
+                res=raw_data.get("res"),
+                location=raw_data.get("location"),
+                type=raw_data.get("type"),
+                deviceId=device_id,
+                referenceId=raw_data.get("referenceId"),
+                zoneId=raw_data.get("zoneId"),
+                serialNumber=raw_data.get("serialNumber"),
+                family=raw_data.get("family"),
+                label=raw_data.get("label"),
+                features=raw_data.get("features"),
+            )
 
-        return SmartLock(None, None, None)
+        return SmartLock()
 
-    async def get_lock_current_mode(self, installation: Installation) -> SmartLockMode:
+    async def get_lock_current_mode(
+        self, installation: Installation
+    ) -> list[SmartLockMode]:
         content = {
             "operationName": "xSGetLockCurrentMode",
             "variables": {
@@ -1301,29 +1320,39 @@ class ApiManager:
 
         if "errors" in response:
             _LOGGER.error(response)
-            return SmartLockMode(None, "0")
+            return []
 
         if "data" in response:
             raw_data = response["data"]["xSGetLockCurrentMode"]
             if raw_data is None:
-                return SmartLockMode(None, "0")
-            lock_status = "0"
-            if raw_data.get("smartlockInfo"):
-                lock_status = raw_data["smartlockInfo"][0]["lockStatus"]
-            return SmartLockMode(raw_data["res"], lock_status)
+                return []
+            result: list[SmartLockMode] = []
+            for lock_info in raw_data.get("smartlockInfo") or []:
+                result.append(
+                    SmartLockMode(
+                        res=raw_data["res"],
+                        lockStatus=lock_info.get("lockStatus", "0"),
+                        deviceId=lock_info.get("deviceId", ""),
+                    )
+                )
+            return result
 
-        return SmartLockMode(None, "0")
+        return []
 
     async def change_lock_mode(
-        self, installation: Installation, lock: bool
+        self,
+        installation: Installation,
+        lock: bool,
+        device_id: str = SMARTLOCK_DEVICE_ID,
+        device_type: str = SMARTLOCK_DEVICE_TYPE,
     ) -> SmartLockModeStatus:
         content = {
             "operationName": "xSChangeSmartlockMode",
             "variables": {
                 "numinst": installation.number,
                 "panel": installation.panel,
-                "deviceType": SMARTLOCK_DEVICE_TYPE,
-                "deviceId": SMARTLOCK_DEVICE_ID,
+                "deviceType": device_type,
+                "deviceId": device_id,
                 "lock": lock,
             },
             "query": "mutation xSChangeSmartlockMode($numinst: String!, $panel: String!, $deviceId: String!, $deviceType: String!, $lock: Boolean!) {\n  xSChangeSmartlockMode(\n    numinst: $numinst\n    panel: $panel\n    deviceId: $deviceId\n    deviceType: $deviceType\n    lock: $lock\n  ) {\n    res\n    msg\n    referenceId\n  }\n}",
@@ -1351,6 +1380,7 @@ class ApiManager:
                 installation,
                 reference_id,
                 count,
+                device_id=device_id,
             )
 
         raw_data = await self._poll_operation(_check)
@@ -1369,12 +1399,13 @@ class ApiManager:
         installation: Installation,
         reference_id: str,
         counter: int,
+        device_id: str = SMARTLOCK_DEVICE_ID,
     ) -> dict[str, Any]:
         content = {
             "operationName": "xSChangeSmartlockModeStatus",
             "variables": {
                 "counter": counter,
-                "deviceId": SMARTLOCK_DEVICE_ID,
+                "deviceId": device_id,
                 "numinst": installation.number,
                 "panel": installation.panel,
                 "referenceId": reference_id,

--- a/custom_components/securitas/securitas_direct_new_api/dataTypes.py
+++ b/custom_components/securitas/securitas_direct_new_api/dataTypes.py
@@ -152,12 +152,20 @@ class SmartLock:
     res: str | None = None
     location: str | None = None
     type: int | None = None
+    deviceId: str | None = None
+    referenceId: str | None = None
+    zoneId: str | None = None
+    serialNumber: str | None = None
+    family: str | None = None
+    label: str | None = None
+    features: dict | None = None
 
 
 @dataclass
 class SmartLockMode:
     res: str | None = None
     lockStatus: str = ""
+    deviceId: str = ""
 
 
 @dataclass

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -10,6 +10,7 @@ from custom_components.securitas.securitas_direct_new_api.dataTypes import (
     Installation,
     Sentinel,
     Service,
+    SmartLock,
     SmartLockMode,
     SmartLockModeStatus,
 )
@@ -93,7 +94,25 @@ def make_device():
     return SecuritasDirectDevice(make_installation())
 
 
-def make_lock():
+def make_lock_config(
+    device_id="01",
+    location="Front Door",
+    family="DR",
+    serial_number="SN001",
+):
+    """Create a test SmartLock config."""
+    return SmartLock(
+        res="OK",
+        location=location,
+        type=1,
+        deviceId=device_id,
+        family=family,
+        serialNumber=serial_number,
+        label="lock1",
+    )
+
+
+def make_lock(device_id="01", lock_config=None):
     """Create a SecuritasLock with mocked dependencies."""
     installation = make_installation()
     client = MagicMock()
@@ -103,11 +122,20 @@ def make_lock():
     hass.async_create_task = MagicMock()
     hass.services = MagicMock()
 
+    if lock_config is None:
+        lock_config = make_lock_config(device_id=device_id)
+
     with patch(
         "custom_components.securitas.lock.async_track_time_interval"
     ) as mock_track:
         mock_track.return_value = MagicMock()
-        lock_entity = SecuritasLock(installation=installation, client=client, hass=hass)
+        lock_entity = SecuritasLock(
+            installation=installation,
+            client=client,
+            hass=hass,
+            device_id=device_id,
+            lock_config=lock_config,
+        )
     return lock_entity
 
 
@@ -375,9 +403,42 @@ class TestSecuritasLockInit:
             lock._state = state
             assert lock.is_unlocking is False
 
-    def test_name_returns_installation_alias(self):
+    def test_name_returns_lock_config_location(self):
         lock = make_lock()
-        assert lock.name == "Home"
+        assert lock.name == "Front Door"
+
+    def test_name_falls_back_when_no_location(self):
+        config = SmartLock(deviceId="01")
+        lock = make_lock(lock_config=config)
+        assert lock.name == "Home Lock 01"
+
+    def test_unique_id_contains_device_id(self):
+        lock = make_lock(device_id="02")
+        assert "lock.02" in lock._attr_unique_id
+
+    def test_unique_id_contains_installation_number(self):
+        lock = make_lock()
+        assert "123456" in lock._attr_unique_id
+
+    def test_device_info_uses_lock_config(self):
+        config = make_lock_config(
+            device_id="01",
+            location="Front Door",
+            family="DR",
+            serial_number="SN001",
+        )
+        lock = make_lock(lock_config=config)
+        assert lock._attr_device_info["name"] == "Front Door"
+        assert lock._attr_device_info["model"] == "DR"
+        assert lock._attr_device_info["serial_number"] == "SN001"
+        assert lock._attr_device_info["manufacturer"] == "Securitas Direct"
+
+    def test_device_info_via_device_links_to_installation(self):
+        lock = make_lock()
+        assert lock._attr_device_info["via_device"] == (
+            "securitas",
+            "securitas_direct.123456",
+        )
 
 
 class TestSecuritasLockActions:
@@ -444,7 +505,7 @@ class TestSecuritasLockActions:
         original_schedule = MagicMock()
         lock.async_schedule_update_ha_state = original_schedule
 
-        async def capture_state(installation, lock_mode):
+        async def capture_state(installation, lock_mode, **kwargs):
             """Capture state at the moment the API call is made."""
             observed_states.append(lock._state)
             return SmartLockModeStatus()
@@ -465,7 +526,7 @@ class TestSecuritasLockActions:
 
         lock.async_schedule_update_ha_state = MagicMock()
 
-        async def capture_state(installation, lock_mode):
+        async def capture_state(installation, lock_mode, **kwargs):
             observed_states.append(lock._state)
             return SmartLockModeStatus()
 
@@ -476,14 +537,40 @@ class TestSecuritasLockActions:
         assert observed_states == ["3"]
         assert lock._state == "1"
 
+    async def test_async_lock_passes_device_id(self):
+        lock = make_lock(device_id="02")
+        lock.async_schedule_update_ha_state = MagicMock()
+        lock.client.session.change_lock_mode = AsyncMock(
+            return_value=SmartLockModeStatus()
+        )
+
+        await lock.async_lock()
+
+        lock.client.session.change_lock_mode.assert_awaited_once_with(
+            lock.installation, True, device_id="02"
+        )
+
+    async def test_async_unlock_passes_device_id(self):
+        lock = make_lock(device_id="03")
+        lock.async_schedule_update_ha_state = MagicMock()
+        lock.client.session.change_lock_mode = AsyncMock(
+            return_value=SmartLockModeStatus()
+        )
+
+        await lock.async_unlock()
+
+        lock.client.session.change_lock_mode.assert_awaited_once_with(
+            lock.installation, False, device_id="03"
+        )
+
 
 class TestSecuritasLockUpdateStatus:
     """Tests for SecuritasLock async_update_status."""
 
     async def test_async_update_status_updates_state_from_api(self):
-        lock = make_lock()
+        lock = make_lock(device_id="01")
         lock.client.session.get_lock_current_mode = AsyncMock(
-            return_value=SmartLockMode(res="OK", lockStatus="1")
+            return_value=[SmartLockMode(res="OK", lockStatus="1", deviceId="01")]
         )
 
         await lock.async_update_status()
@@ -491,12 +578,12 @@ class TestSecuritasLockUpdateStatus:
         assert lock._state == "1"
 
     async def test_async_update_status_ignores_zero_status(self):
-        lock = make_lock()
+        lock = make_lock(device_id="01")
         # Initial state is "2" (locked)
         assert lock._state == "2"
 
         lock.client.session.get_lock_current_mode = AsyncMock(
-            return_value=SmartLockMode(res="OK", lockStatus="0")
+            return_value=[SmartLockMode(res="OK", lockStatus="0", deviceId="01")]
         )
 
         await lock.async_update_status()
@@ -505,9 +592,9 @@ class TestSecuritasLockUpdateStatus:
         assert lock._state == "2"
 
     async def test_async_update_status_updates_on_non_zero(self):
-        lock = make_lock()
+        lock = make_lock(device_id="01")
         lock.client.session.get_lock_current_mode = AsyncMock(
-            return_value=SmartLockMode(res="OK", lockStatus="3")
+            return_value=[SmartLockMode(res="OK", lockStatus="3", deviceId="01")]
         )
 
         await lock.async_update_status()
@@ -516,15 +603,71 @@ class TestSecuritasLockUpdateStatus:
 
     async def test_async_update_delegates_to_update_status(self):
         """async_update just calls async_update_status."""
-        lock = make_lock()
+        lock = make_lock(device_id="01")
         lock.client.session.get_lock_current_mode = AsyncMock(
-            return_value=SmartLockMode(res="OK", lockStatus="1")
+            return_value=[SmartLockMode(res="OK", lockStatus="1", deviceId="01")]
         )
 
         await lock.async_update()
 
         lock.client.session.get_lock_current_mode.assert_awaited_once()
         assert lock._state == "1"
+
+    async def test_async_update_matches_correct_device_id(self):
+        """When multiple locks returned, matches by device_id."""
+        lock = make_lock(device_id="02")
+        lock.client.session.get_lock_current_mode = AsyncMock(
+            return_value=[
+                SmartLockMode(res="OK", lockStatus="2", deviceId="01"),
+                SmartLockMode(res="OK", lockStatus="1", deviceId="02"),
+            ]
+        )
+
+        await lock.async_update_status()
+
+        # Should use status from device "02", not "01"
+        assert lock._state == "1"
+
+    async def test_async_update_fallback_single_lock_no_match(self):
+        """When only one lock returned and deviceId doesn't match, use it anyway."""
+        lock = make_lock(device_id="99")
+        lock.client.session.get_lock_current_mode = AsyncMock(
+            return_value=[SmartLockMode(res="OK", lockStatus="1", deviceId="01")]
+        )
+
+        await lock.async_update_status()
+
+        assert lock._state == "1"
+
+    async def test_async_update_returns_unknown_when_no_match(self):
+        """When multiple locks but none match, return unknown (state unchanged)."""
+        lock = make_lock(device_id="99")
+        # Initial state is "2" (locked)
+        assert lock._state == "2"
+
+        lock.client.session.get_lock_current_mode = AsyncMock(
+            return_value=[
+                SmartLockMode(res="OK", lockStatus="1", deviceId="01"),
+                SmartLockMode(res="OK", lockStatus="1", deviceId="02"),
+            ]
+        )
+
+        await lock.async_update_status()
+
+        # "0" (UNKNOWN) is ignored, so state stays "2"
+        assert lock._state == "2"
+
+    async def test_async_update_empty_list_keeps_state(self):
+        """When API returns empty list, state stays unchanged."""
+        lock = make_lock(device_id="01")
+        assert lock._state == "2"
+
+        lock.client.session.get_lock_current_mode = AsyncMock(return_value=[])
+
+        await lock.async_update_status()
+
+        # Empty list → get_lock_state returns "0" → ignored → state stays "2"
+        assert lock._state == "2"
 
 
 class TestSecuritasLockRemoval:

--- a/tests/test_smart_lock.py
+++ b/tests/test_smart_lock.py
@@ -61,6 +61,42 @@ class TestGetSmartLockConfig:
         assert result.res == "OK"
         assert result.location == "Front Door"
         assert result.type == 1
+        assert result.referenceId == "ref1"
+        assert result.zoneId == "z1"
+        assert result.serialNumber == "SN001"
+        assert result.family == "DR"
+        assert result.label == "lock1"
+
+    async def test_success_with_explicit_device_id(
+        self, authed_api, mock_execute, installation
+    ):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetSmartlockConfig": {
+                    "res": "OK",
+                    "location": "Back Door",
+                    "type": 2,
+                    "referenceId": "ref2",
+                    "zoneId": "z2",
+                    "serialNumber": "SN002",
+                    "family": "DR",
+                    "label": "lock2",
+                    "features": None,
+                }
+            }
+        }
+
+        result = await authed_api.get_smart_lock_config(
+            installation, device_id="02"
+        )
+
+        assert result.res == "OK"
+        assert result.deviceId == "02"
+        assert result.location == "Back Door"
+        assert result.serialNumber == "SN002"
+        # Verify the device_id was sent in the request
+        call_args = mock_execute.call_args[0][0]
+        assert call_args["variables"]["devices"][0]["deviceId"] == "02"
 
     async def test_error_in_response_returns_empty_smart_lock(
         self, authed_api, mock_execute, installation
@@ -103,7 +139,7 @@ class TestGetSmartLockConfig:
 
 
 class TestGetLockCurrentMode:
-    async def test_success_returns_locked_status(
+    async def test_success_returns_list_with_locked_status(
         self, authed_api, mock_execute, installation
     ):
         mock_execute.return_value = {
@@ -117,11 +153,13 @@ class TestGetLockCurrentMode:
 
         result = await authed_api.get_lock_current_mode(installation)
 
-        assert isinstance(result, SmartLockMode)
-        assert result.res == "OK"
-        assert result.lockStatus == "2"
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].res == "OK"
+        assert result[0].lockStatus == "2"
+        assert result[0].deviceId == "01"
 
-    async def test_success_returns_open_status(
+    async def test_success_returns_list_with_open_status(
         self, authed_api, mock_execute, installation
     ):
         mock_execute.return_value = {
@@ -135,31 +173,70 @@ class TestGetLockCurrentMode:
 
         result = await authed_api.get_lock_current_mode(installation)
 
-        assert isinstance(result, SmartLockMode)
-        assert result.res == "OK"
-        assert result.lockStatus == "1"
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].res == "OK"
+        assert result[0].lockStatus == "1"
 
-    async def test_error_in_response_returns_default_mode(
+    async def test_multiple_locks_returned(
+        self, authed_api, mock_execute, installation
+    ):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetLockCurrentMode": {
+                    "res": "OK",
+                    "smartlockInfo": [
+                        {"lockStatus": "2", "deviceId": "01"},
+                        {"lockStatus": "1", "deviceId": "02"},
+                    ],
+                }
+            }
+        }
+
+        result = await authed_api.get_lock_current_mode(installation)
+
+        assert len(result) == 2
+        assert result[0].deviceId == "01"
+        assert result[0].lockStatus == "2"
+        assert result[1].deviceId == "02"
+        assert result[1].lockStatus == "1"
+
+    async def test_error_in_response_returns_empty_list(
         self, authed_api, mock_execute, installation
     ):
         mock_execute.return_value = {"errors": [{"message": "Something went wrong"}]}
 
         result = await authed_api.get_lock_current_mode(installation)
 
-        assert isinstance(result, SmartLockMode)
-        assert result.res is None
-        assert result.lockStatus == "0"
+        assert isinstance(result, list)
+        assert len(result) == 0
 
-    async def test_none_data_returns_default_mode(
+    async def test_none_data_returns_empty_list(
         self, authed_api, mock_execute, installation
     ):
         mock_execute.return_value = {"data": {"xSGetLockCurrentMode": None}}
 
         result = await authed_api.get_lock_current_mode(installation)
 
-        assert isinstance(result, SmartLockMode)
-        assert result.res is None
-        assert result.lockStatus == "0"
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    async def test_empty_smartlock_info_returns_empty_list(
+        self, authed_api, mock_execute, installation
+    ):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetLockCurrentMode": {
+                    "res": "OK",
+                    "smartlockInfo": [],
+                }
+            }
+        }
+
+        result = await authed_api.get_lock_current_mode(installation)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
 
 
 # ── change_lock_mode() ──────────────────────────────────────────────────────
@@ -231,6 +308,43 @@ class TestChangeLockMode:
         assert result.message == ""
         assert result.protomResponse == "D"
         assert result.status == "unlocked"
+
+    async def test_lock_with_custom_device_id(
+        self, authed_api, mock_execute, installation
+    ):
+        mock_execute.side_effect = [
+            {
+                "data": {
+                    "xSChangeSmartlockMode": {
+                        "res": "OK",
+                        "msg": "",
+                        "referenceId": "ref789",
+                    }
+                }
+            },
+            {
+                "data": {
+                    "xSChangeSmartlockModeStatus": {
+                        "res": "OK",
+                        "msg": "",
+                        "protomResponse": "D",
+                        "status": "locked",
+                    }
+                }
+            },
+        ]
+
+        result = await authed_api.change_lock_mode(
+            installation, lock=True, device_id="02"
+        )
+
+        assert result.status == "locked"
+        # Verify device_id was passed in the initial request
+        call_args = mock_execute.call_args_list[0][0][0]
+        assert call_args["variables"]["deviceId"] == "02"
+        # Verify device_id was passed in the status poll
+        poll_args = mock_execute.call_args_list[1][0][0]
+        assert poll_args["variables"]["deviceId"] == "02"
 
     async def test_non_ok_initial_response_raises_error(
         self, authed_api, mock_execute, installation


### PR DESCRIPTION
## Overview

Smart locks were not consistent with every other component in this integration. Three specific issues:

1. **Hardcoded device identifiers:** `change_lock_mode()` and `_check_change_lock_mode()` unconditionally used the module-level constants `SMARTLOCK_DEVICE_ID = "01"` and `SMARTLOCK_DEVICE_TYPE = "DR"` in their API request variables, regardless of what device was actually being operated. My personal installation had a `SMARTLOCK_DEVICE_ID` of `02` so all smart lock operations were failing.

2. **Single lock per installation assumed:** `get_lock_current_mode()` returned a single `SmartLockMode` by reading `smartlockInfo[0]` and discarding everything else. If an installation had multiple locks, only the first would ever be seen.

3. **Lock entity identity and metadata came from the alarm panel, not the lock:** The lock entity's `unique_id` was `securitas_direct.{installation.number}`, causing HA to merge both entities under the same device. `DeviceInfo` showed the alarm panel model and alias, not the lock's location or serial number. The `xSGetSmartlockConfig` API, which returns location, serial number, family, and zone, was never called during setup.

## Changes

**`dataTypes.py`** — Expanded `SmartLock` with the fields `xSGetSmartlockConfig` already returns (`deviceId`, `referenceId`, `zoneId`, `serialNumber`, `family`, `label`, `features`). Added `deviceId: str` to `SmartLockMode`, which the `xSGetLockCurrentMode` response already includes per entry but was being discarded.

**`apimanager.py`**
- `get_lock_current_mode()` now returns `list[SmartLockMode]`, iterating every entry in `smartlockInfo`. Each entry carries its own `deviceId` and `lockStatus`. Returns `[]` on error or empty response.
- `get_smart_lock_config()` accepts a `device_id` parameter (default `SMARTLOCK_DEVICE_ID` for backward compatibility) and populates all new `SmartLock` fields from the response.
- `change_lock_mode()` and `_check_change_lock_mode()` accept a `device_id` parameter, which is passed down through to the API request variables. The hardcoded constant is kept as a fallback.

**`securitas_direct_new_api/__init__.py`** Exports `SmartLock` from the package (it was previously only importable via the internal `dataTypes` module).

**`lock.py`** — Rearchitected setup and entity:
- `async_setup_entry` calls `get_lock_current_mode()` to discover all physical lock devices and their initial state, then calls `get_smart_lock_config(device_id=...)` for each to fetch metadata. One `SecuritasLock` entity is created per discovered device.
- `SecuritasLock` now takes `device_id`, `lock_config`, and `initial_status` as constructor arguments. `unique_id` is `securitas_direct.{installation.number}.lock.{device_id}`, scoped to the individual lock. `DeviceInfo` uses `lock_config.location` as the name, `lock_config.family` as the model, and `lock_config.serialNumber` as the serial number, linked to the parent alarm panel device via `via_device`.
- `get_lock_state()` finds the matching entry in the returned list by `deviceId`, with a fallback to the only entry if the list has length 1.
- `async_lock()` / `async_unlock()` pass `device_id=self._device_id` to `change_lock_mode()`.

**Tests** — `test_smart_lock.py` and `test_ha_platforms.py` updated throughout. New test cases cover: multiple locks returned from `get_lock_current_mode`, explicit `device_id` parameter in `get_smart_lock_config` and `change_lock_mode`, per-lock `unique_id` and `DeviceInfo` fields, correct device ID matching during state polling, and the single-lock fallback path.

## Backward compatibility

All new parameters default to the existing constants, so single-lock installations with APIs that return `deviceId: "01"` continue to work without any change in behaviour. If `get_lock_current_mode()` returns an empty list, setup falls back to creating one entity with the default device ID.

## Dynamic Testing

I have tested the changes on my Verisure Italy installation and the smart lock operates as expected, without needing to change the hardcoded `SMARTLOCK_DEVICE_ID`.

## AI Disclaimer

Parts of the code and tests in this PR were written with the assistance of AI. All changes have been reviewed and tested by a human.