### PR TITLE
feat: Danalock config API support with auto-detection and deferred retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,11 @@ If your installation includes Sentinel devices, the integration automatically cr
 
 If your installation includes smart door locks, the integration creates lock entities that you can lock and unlock from Home Assistant. Multiple locks per installation are supported — each lock gets its own entity.
 
+Both Smartlock and Danalock-type locks are supported. The integration auto-detects which configuration API your lock uses, so no manual configuration is needed.
+
 Lock features (latch hold-back time, auto-lock settings) are fetched from the lock configuration. When the lock supports latch hold-back, the entity exposes an "Open" action that unlatches the door without unlocking.
+
+If the lock configuration cannot be fetched during startup (e.g. due to a temporary API outage), the lock entity is still created and works for lock/unlock operations. The integration retries the configuration fetch in the background, and the "Open" button will appear once the configuration is successfully retrieved.
 
 ## Cameras
 

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -524,7 +524,11 @@ def _schedule_lock_config_retry(
             return
 
         try:
-            config = await hub.get_lock_config(installation, lock_entity.device_id)
+            config = await hub.get_lock_config(
+                installation,
+                lock_entity.device_id,
+                priority=hub.api_queue.BACKGROUND,
+            )
         except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
             config = None
 

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -519,6 +519,10 @@ def _schedule_lock_config_retry(
     delay = _LOCK_CONFIG_RETRY_DELAYS[attempt]
 
     async def _retry(_now) -> None:
+        # Guard: entity may have been removed while the timer was pending.
+        if lock_entity.hass is None:
+            return
+
         try:
             config = await hub.get_lock_config(installation, lock_entity.device_id)
         except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
@@ -543,7 +547,8 @@ def _schedule_lock_config_retry(
                 hass, hub, installation, lock_entity, attempt + 1
             )
 
-    async_call_later(hass, delay, _retry)
+    unsub = async_call_later(hass, delay, _retry)
+    lock_entity.add_config_retry_unsub(unsub)
 
 
 async def _discover_locks(

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -1,5 +1,7 @@
 """Support for Securitas Direct alarms."""
 
+from __future__ import annotations
+
 import asyncio
 from collections import OrderedDict
 import logging
@@ -493,6 +495,57 @@ async def _discover_cameras(
             )
 
 
+_LOCK_CONFIG_RETRY_DELAYS = (60, 120, 300)  # seconds between retries
+
+
+def _schedule_lock_config_retry(
+    hass: HomeAssistant,
+    hub: SecuritasHub,
+    installation: Installation,
+    lock_entity,
+    attempt: int = 0,
+) -> None:
+    """Schedule a background retry to fetch lock config."""
+    from homeassistant.helpers.event import async_call_later
+
+    if attempt >= len(_LOCK_CONFIG_RETRY_DELAYS):
+        _LOGGER.info(
+            "Lock config retry exhausted for %s device %s",
+            installation.number,
+            lock_entity.device_id,
+        )
+        return
+
+    delay = _LOCK_CONFIG_RETRY_DELAYS[attempt]
+
+    async def _retry(_now) -> None:
+        try:
+            config = await hub.get_lock_config(installation, lock_entity.device_id)
+        except Exception:  # noqa: BLE001
+            config = None
+
+        if config is not None:
+            _LOGGER.info(
+                "Lock config retry succeeded for %s device %s (attempt %d)",
+                installation.number,
+                lock_entity.device_id,
+                attempt + 1,
+            )
+            lock_entity.update_lock_config(config)
+        else:
+            _LOGGER.debug(
+                "Lock config retry %d failed for %s device %s, scheduling next retry",
+                attempt + 1,
+                installation.number,
+                lock_entity.device_id,
+            )
+            _schedule_lock_config_retry(
+                hass, hub, installation, lock_entity, attempt + 1
+            )
+
+    async_call_later(hass, delay, _retry)
+
+
 async def _discover_locks(
     hass: HomeAssistant,
     hub: SecuritasHub,
@@ -541,10 +594,10 @@ async def _discover_locks(
             device_id = mode.deviceId or SMARTLOCK_DEVICE_ID
             lock_config: SmartLock | None = None
             try:
-                lock_config = await hub.get_smart_lock_config(installation, device_id)
+                lock_config = await hub.get_lock_config(installation, device_id)
             except Exception:  # pylint: disable=broad-exception-caught
                 _LOGGER.debug(
-                    "Could not fetch smart lock config for %s device %s",
+                    "Could not fetch lock config for %s device %s",
                     installation.number,
                     device_id,
                 )
@@ -560,6 +613,11 @@ async def _discover_locks(
             )
         lock_add(locks, False)
         schedule_initial_updates(hass, locks)
+
+        # Schedule deferred config retry for locks without config.
+        for lk in locks:
+            if lk.lock_config is None:
+                _schedule_lock_config_retry(hass, hub, installation, lk)
 
 
 async def _async_discover_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -521,7 +521,7 @@ def _schedule_lock_config_retry(
     async def _retry(_now) -> None:
         try:
             config = await hub.get_lock_config(installation, lock_entity.device_id)
-        except Exception:  # noqa: BLE001
+        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
             config = None
 
         if config is not None:

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -41,6 +41,7 @@ from .securitas_direct_new_api import (
     OperationStatus,
     OtpPhone,
     SStatus,
+    SmartLock,
     SecuritasDirectError,
     Service,
 )
@@ -164,6 +165,9 @@ class SecuritasHub:
         self._camera_capturing: set[str] = set()  # keys of cameras currently capturing
         self._full_images: dict[str, bytes] = {}
         self._full_timestamps: dict[str, str] = {}
+        self._lock_config_type: dict[
+            str, str
+        ] = {}  # "{numinst}_{device_id}" -> "smartlock"|"danalock"
 
     async def login(self):
         """Login to Securitas."""
@@ -825,6 +829,74 @@ class SecuritasHub:
             device_id,
             priority=ApiQueue.FOREGROUND,
         )
+
+    async def get_lock_config(
+        self, installation: Installation, device_id: str
+    ) -> SmartLock | None:
+        """Fetch lock config, auto-detecting Smartlock vs Danalock API.
+
+        Tries xSGetSmartlockConfig first (fast, single call).  If that
+        fails, falls back to the Danalock two-phase polling API.  Caches
+        which API type works so subsequent calls skip detection.
+        """
+        cache_key = f"{installation.number}_{device_id}"
+
+        # If we already know this is a Danalock, skip straight to it.
+        if self._lock_config_type.get(cache_key) == "danalock":
+            try:
+                config = await self._api_queue.submit(
+                    self.session.get_danalock_config,
+                    installation,
+                    device_id,
+                    priority=ApiQueue.FOREGROUND,
+                )
+                if config and config.res == "OK":
+                    return config
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Danalock config fetch failed for %s device %s",
+                    installation.number,
+                    device_id,
+                )
+            return None
+
+        # Try Smartlock first (most common, single API call).
+        try:
+            config = await self._api_queue.submit(
+                self.session.get_smart_lock_config,
+                installation,
+                device_id,
+                priority=ApiQueue.FOREGROUND,
+            )
+            if config and config.res == "OK":
+                self._lock_config_type[cache_key] = "smartlock"
+                return config
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Smartlock config fetch failed for %s device %s, trying Danalock",
+                installation.number,
+                device_id,
+            )
+
+        # Fall back to Danalock two-phase polling API.
+        try:
+            config = await self._api_queue.submit(
+                self.session.get_danalock_config,
+                installation,
+                device_id,
+                priority=ApiQueue.FOREGROUND,
+            )
+            if config and config.res == "OK":
+                self._lock_config_type[cache_key] = "danalock"
+                return config
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Danalock config fetch also failed for %s device %s",
+                installation.number,
+                device_id,
+            )
+
+        return None
 
     @property
     def api_queue(self) -> ApiQueue:

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -408,7 +408,7 @@ class SecuritasHub:
                 thumbnail.signal_type,
                 priority=ApiQueue.BACKGROUND,
             )
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001  # pylint: disable=broad-exception-caught
             _LOGGER.warning(
                 "[hub] Could not fetch full image for %s",
                 camera_device.name,
@@ -837,48 +837,30 @@ class SecuritasHub:
 
         Tries xSGetSmartlockConfig first (fast, single call).  If that
         fails, falls back to the Danalock two-phase polling API.  Caches
-        which API type works so subsequent calls skip detection.
+        a "danalock" result so subsequent calls skip the Smartlock attempt.
         """
         cache_key = f"{installation.number}_{device_id}"
+        is_danalock = self._lock_config_type.get(cache_key) == "danalock"
 
-        # If we already know this is a Danalock, skip straight to it.
-        if self._lock_config_type.get(cache_key) == "danalock":
+        # Try Smartlock first unless we already know this is a Danalock.
+        if not is_danalock:
             try:
                 config = await self._api_queue.submit(
-                    self.session.get_danalock_config,
+                    self.session.get_smart_lock_config,
                     installation,
                     device_id,
                     priority=ApiQueue.FOREGROUND,
                 )
                 if config and config.res == "OK":
                     return config
-            except Exception:  # noqa: BLE001
+            except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
                 _LOGGER.debug(
-                    "Danalock config fetch failed for %s device %s",
+                    "Smartlock config fetch failed for %s device %s, trying Danalock",
                     installation.number,
                     device_id,
                 )
-            return None
 
-        # Try Smartlock first (most common, single API call).
-        try:
-            config = await self._api_queue.submit(
-                self.session.get_smart_lock_config,
-                installation,
-                device_id,
-                priority=ApiQueue.FOREGROUND,
-            )
-            if config and config.res == "OK":
-                self._lock_config_type[cache_key] = "smartlock"
-                return config
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug(
-                "Smartlock config fetch failed for %s device %s, trying Danalock",
-                installation.number,
-                device_id,
-            )
-
-        # Fall back to Danalock two-phase polling API.
+        # Fall back to (or go directly to) Danalock two-phase polling API.
         try:
             config = await self._api_queue.submit(
                 self.session.get_danalock_config,
@@ -889,7 +871,7 @@ class SecuritasHub:
             if config and config.res == "OK":
                 self._lock_config_type[cache_key] = "danalock"
                 return config
-        except Exception:  # noqa: BLE001
+        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
             _LOGGER.debug(
                 "Danalock config fetch also failed for %s device %s",
                 installation.number,

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -408,7 +408,7 @@ class SecuritasHub:
                 thumbnail.signal_type,
                 priority=ApiQueue.BACKGROUND,
             )
-        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
             _LOGGER.warning(
                 "[hub] Could not fetch full image for %s",
                 camera_device.name,
@@ -862,12 +862,7 @@ class SecuritasHub:
 
         # Fall back to (or go directly to) Danalock two-phase polling API.
         try:
-            config = await self._api_queue.submit(
-                self.session.get_danalock_config,
-                installation,
-                device_id,
-                priority=ApiQueue.FOREGROUND,
-            )
+            config = await self._get_danalock_config(installation, device_id)
             if config and config.res == "OK":
                 self._lock_config_type[cache_key] = "danalock"
                 return config
@@ -878,6 +873,47 @@ class SecuritasHub:
                 device_id,
             )
 
+        return None
+
+    async def _get_danalock_config(
+        self, installation: Installation, device_id: str
+    ) -> SmartLock | None:
+        """Fetch Danalock config via queue-submitted submit + poll calls."""
+        reference_id = await self._api_queue.submit(
+            self.session.submit_danalock_config_request,
+            installation,
+            device_id,
+            priority=ApiQueue.FOREGROUND,
+        )
+
+        max_attempts = 10
+        for counter in range(1, max_attempts + 1):
+            raw = await self._api_queue.submit(
+                self.session.check_danalock_config_status,
+                installation,
+                reference_id,
+                counter,
+                priority=ApiQueue.FOREGROUND,
+            )
+            if raw.get("res") == "WAIT":
+                continue
+
+            if raw.get("res") != "OK":
+                _LOGGER.debug(
+                    "Danalock config polling returned %s for %s device %s",
+                    raw.get("msg"),
+                    installation.number,
+                    device_id,
+                )
+                return None
+
+            return self.session.parse_danalock_config_response(raw, device_id)
+
+        _LOGGER.debug(
+            "Danalock config polling timed out for %s device %s",
+            installation.number,
+            device_id,
+        )
         return None
 
     @property

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -831,7 +831,11 @@ class SecuritasHub:
         )
 
     async def get_lock_config(
-        self, installation: Installation, device_id: str
+        self,
+        installation: Installation,
+        device_id: str,
+        *,
+        priority: int = ApiQueue.FOREGROUND,
     ) -> SmartLock | None:
         """Fetch lock config, auto-detecting Smartlock vs Danalock API.
 
@@ -849,7 +853,7 @@ class SecuritasHub:
                     self.session.get_smart_lock_config,
                     installation,
                     device_id,
-                    priority=ApiQueue.FOREGROUND,
+                    priority=priority,
                 )
                 if config and config.res == "OK":
                     return config
@@ -858,11 +862,14 @@ class SecuritasHub:
                     "Smartlock config fetch failed for %s device %s, trying Danalock",
                     installation.number,
                     device_id,
+                    exc_info=True,
                 )
 
         # Fall back to (or go directly to) Danalock two-phase polling API.
         try:
-            config = await self._get_danalock_config(installation, device_id)
+            config = await self._get_danalock_config(
+                installation, device_id, priority=priority
+            )
             if config and config.res == "OK":
                 self._lock_config_type[cache_key] = "danalock"
                 return config
@@ -871,29 +878,34 @@ class SecuritasHub:
                 "Danalock config fetch also failed for %s device %s",
                 installation.number,
                 device_id,
+                exc_info=True,
             )
 
         return None
 
     async def _get_danalock_config(
-        self, installation: Installation, device_id: str
+        self,
+        installation: Installation,
+        device_id: str,
+        *,
+        priority: int = ApiQueue.FOREGROUND,
     ) -> SmartLock | None:
         """Fetch Danalock config via queue-submitted submit + poll calls."""
         reference_id = await self._api_queue.submit(
             self.session.submit_danalock_config_request,
             installation,
             device_id,
-            priority=ApiQueue.FOREGROUND,
+            priority=priority,
         )
 
-        max_attempts = 10
+        max_attempts = self._max_poll_attempts(timeout_seconds=30)
         for counter in range(1, max_attempts + 1):
             raw = await self._api_queue.submit(
                 self.session.check_danalock_config_status,
                 installation,
                 reference_id,
                 counter,
-                priority=ApiQueue.FOREGROUND,
+                priority=priority,
             )
             if raw.get("res") == "WAIT":
                 continue

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -117,6 +117,7 @@ class SecuritasLock(SecuritasEntity, lock.LockEntity):
         self._scan_seconds = scan_seconds
         self._update_unsub: Callable[[], None] | None = None
         self._operation_in_progress: bool = False
+        self._config_retry_unsubs: list[Callable[[], None]] = []
 
     @property
     def lock_config(self) -> SmartLock | None:
@@ -133,21 +134,24 @@ class SecuritasLock(SecuritasEntity, lock.LockEntity):
         self._lock_config = lock_config
         if lock_config.location:
             self._attr_name = lock_config.location
-        if lock_config.family or lock_config.serialNumber:
-            self._attr_device_info = DeviceInfo(
-                identifiers={
-                    (
-                        DOMAIN,
-                        f"v4_securitas_direct.{self.installation.number}_lock_{self._device_id}",
-                    )
-                },
-                via_device=(DOMAIN, f"v4_securitas_direct.{self.installation.number}"),
-                name=self._attr_name,
-                manufacturer="Securitas Direct",
-                model=lock_config.family or None,
-                serial_number=lock_config.serialNumber or None,
-            )
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (
+                    DOMAIN,
+                    f"v4_securitas_direct.{self.installation.number}_lock_{self._device_id}",
+                )
+            },
+            via_device=(DOMAIN, f"v4_securitas_direct.{self.installation.number}"),
+            name=self._attr_name,
+            manufacturer="Securitas Direct",
+            model=lock_config.family or None,
+            serial_number=lock_config.serialNumber or None,
+        )
         self.async_write_ha_state()
+
+    def add_config_retry_unsub(self, unsub: Callable[[], None]) -> None:
+        """Track a config retry cancel handle for cleanup on removal."""
+        self._config_retry_unsubs.append(unsub)
 
     async def async_added_to_hass(self) -> None:
         """Register timer when entity is added to HA."""
@@ -166,6 +170,9 @@ class SecuritasLock(SecuritasEntity, lock.LockEntity):
         if self._update_unsub:
             self._update_unsub()  # Unsubscribe from updates
             self._update_unsub = None
+        for unsub in self._config_retry_unsubs:
+            unsub()
+        self._config_retry_unsubs.clear()
 
     async def async_update(self) -> None:
         """Update lock state."""

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -118,6 +118,37 @@ class SecuritasLock(SecuritasEntity, lock.LockEntity):
         self._update_unsub: Callable[[], None] | None = None
         self._operation_in_progress: bool = False
 
+    @property
+    def lock_config(self) -> SmartLock | None:
+        """Return the current lock configuration."""
+        return self._lock_config
+
+    @property
+    def device_id(self) -> str:
+        """Return the device ID."""
+        return self._device_id
+
+    def update_lock_config(self, lock_config: SmartLock) -> None:
+        """Update lock configuration after deferred retry."""
+        self._lock_config = lock_config
+        if lock_config.location:
+            self._attr_name = lock_config.location
+        if lock_config.family or lock_config.serialNumber:
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (
+                        DOMAIN,
+                        f"v4_securitas_direct.{self.installation.number}_lock_{self._device_id}",
+                    )
+                },
+                via_device=(DOMAIN, f"v4_securitas_direct.{self.installation.number}"),
+                name=self._attr_name,
+                manufacturer="Securitas Direct",
+                model=lock_config.family or None,
+                serial_number=lock_config.serialNumber or None,
+            )
+        self.async_write_ha_state()
+
     async def async_added_to_hass(self) -> None:
         """Register timer when entity is added to HA."""
         if self._scan_seconds > 0:

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -874,42 +874,16 @@ class ApiManager(SecuritasHttpClient):
         )
         return self._extract_response_data(response, "xSGetDanalockConfigStatus")
 
-    async def get_danalock_config(
-        self,
-        installation: Installation,
-        device_id: str = SMARTLOCK_DEVICE_ID,
+    @staticmethod
+    def parse_danalock_config_response(
+        raw: dict[str, Any], device_id: str = SMARTLOCK_DEVICE_ID
     ) -> SmartLock:
-        """Fetch Danalock config using two-phase polling.
-
-        Sends the config request, then polls for the result until the
-        backend responds with res != "WAIT".
-        """
-        reference_id = await self.submit_danalock_config_request(
-            installation, device_id
+        """Parse a successful Danalock config status response into SmartLock."""
+        return SmartLock(
+            res=raw.get("res"),
+            deviceId=raw.get("deviceNumber") or device_id,
+            features=_parse_lock_features(raw.get("features")),
         )
-
-        max_attempts = 10
-        for counter in range(1, max_attempts + 1):
-            raw = await self.check_danalock_config_status(
-                installation, reference_id, counter
-            )
-            if raw.get("res") == "WAIT":
-                await asyncio.sleep(self.delay_check_operation)
-                continue
-
-            if raw.get("res") != "OK":
-                raise SecuritasDirectError(
-                    raw.get("msg", "Danalock config polling failed"),
-                    {"data": {"xSGetDanalockConfigStatus": raw}},
-                )
-
-            return SmartLock(
-                res=raw.get("res"),
-                deviceId=raw.get("deviceNumber") or device_id,
-                features=_parse_lock_features(raw.get("features")),
-            )
-
-        raise SecuritasDirectError("Danalock config polling timed out")
 
     async def get_lock_current_mode(
         self, installation: Installation

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -43,6 +43,8 @@ from .graphql_queries import (
     CHANGE_LOCK_MODE_STATUS_QUERY,
     CHECK_ALARM_QUERY,
     CHECK_ALARM_STATUS_QUERY,
+    DANALOCK_CONFIG_QUERY,
+    DANALOCK_CONFIG_STATUS_QUERY,
     DEVICE_LIST_QUERY,
     DISARM_PANEL_MUTATION,
     DISARM_STATUS_QUERY,
@@ -76,6 +78,24 @@ SMARTLOCK_KEY_TYPE = "0"
 
 # Service ID used when polling CheckAlarmStatus
 ALARM_STATUS_SERVICE_ID = "11"
+
+
+def _parse_lock_features(raw_features: dict | None) -> LockFeatures | None:
+    """Parse lock features from a raw API response dict."""
+    if not raw_features:
+        return None
+    autolock = None
+    if raw_autolock := raw_features.get("autolock"):
+        autolock = LockAutolock(
+            active=raw_autolock.get("active"),
+            timeout=raw_autolock.get("timeout"),
+        )
+    return LockFeatures(
+        holdBackLatchTime=raw_features.get("holdBackLatchTime", 0),
+        calibrationType=raw_features.get("calibrationType", 0),
+        autolock=autolock,
+    )
+
 
 # Extra settle delay after a lock-mode change completes (multiples of delay_check_operation)
 
@@ -799,20 +819,6 @@ class ApiManager(SecuritasHttpClient):
         if raw_data is None:
             return SmartLock()
 
-        features = None
-        if raw_features := raw_data.get("features"):
-            autolock = None
-            if raw_autolock := raw_features.get("autolock"):
-                autolock = LockAutolock(
-                    active=raw_autolock.get("active"),
-                    timeout=raw_autolock.get("timeout"),
-                )
-            features = LockFeatures(
-                holdBackLatchTime=raw_features.get("holdBackLatchTime", 0),
-                calibrationType=raw_features.get("calibrationType", 0),
-                autolock=autolock,
-            )
-
         return SmartLock(
             res=raw_data.get("res"),
             location=raw_data.get("location"),
@@ -821,8 +827,89 @@ class ApiManager(SecuritasHttpClient):
             serialNumber=raw_data.get("serialNumber") or "",
             family=raw_data.get("family") or "",
             label=raw_data.get("label") or "",
-            features=features,
+            features=_parse_lock_features(raw_data.get("features")),
         )
+
+    async def submit_danalock_config_request(
+        self,
+        installation: Installation,
+        device_id: str = SMARTLOCK_DEVICE_ID,
+    ) -> str:
+        """Send Danalock config request and return referenceId."""
+        content = {
+            "operationName": "xSGetDanalockConfig",
+            "variables": {
+                "numinst": installation.number,
+                "panel": installation.panel,
+                "deviceType": SMARTLOCK_DEVICE_TYPE,
+                "deviceId": device_id,
+            },
+            "query": DANALOCK_CONFIG_QUERY,
+        }
+        data = await self._execute_graphql(
+            content, "xSGetDanalockConfig", "xSGetDanalockConfig", installation
+        )
+        if "referenceId" not in data:
+            raise SecuritasDirectError("No referenceId in Danalock config response")
+        return data["referenceId"]
+
+    async def check_danalock_config_status(
+        self,
+        installation: Installation,
+        reference_id: str,
+        counter: int,
+    ) -> dict[str, Any]:
+        """Check progress of Danalock config request."""
+        content = {
+            "operationName": "xSGetDanalockConfigStatus",
+            "variables": {
+                "numinst": installation.number,
+                "referenceId": reference_id,
+                "counter": counter,
+            },
+            "query": DANALOCK_CONFIG_STATUS_QUERY,
+        }
+        response = await self._execute_request(
+            content, "xSGetDanalockConfigStatus", installation
+        )
+        return self._extract_response_data(response, "xSGetDanalockConfigStatus")
+
+    async def get_danalock_config(
+        self,
+        installation: Installation,
+        device_id: str = SMARTLOCK_DEVICE_ID,
+    ) -> SmartLock:
+        """Fetch Danalock config using two-phase polling.
+
+        Sends the config request, then polls for the result until the
+        backend responds with res != "WAIT".
+        """
+        reference_id = await self.submit_danalock_config_request(
+            installation, device_id
+        )
+
+        max_attempts = 10
+        for counter in range(1, max_attempts + 1):
+            raw = await self.check_danalock_config_status(
+                installation, reference_id, counter
+            )
+            if raw.get("res") == "WAIT":
+                await asyncio.sleep(self.delay_check_operation)
+                continue
+
+            if raw.get("res") != "OK":
+                raise SecuritasDirectError(
+                    raw.get("msg", "Danalock config polling failed"),
+                    {"data": {"xSGetDanalockConfigStatus": raw}},
+                )
+
+            return SmartLock(
+                res=raw.get("res"),
+                deviceId=raw.get("deviceNumber") or device_id,
+                features=_parse_lock_features(raw.get("features")),
+            )
+
+        raise SecuritasDirectError("Danalock config polling timed out")
 
     async def get_lock_current_mode(
         self, installation: Installation

--- a/custom_components/securitas/securitas_direct_new_api/graphql_queries.py
+++ b/custom_components/securitas/securitas_direct_new_api/graphql_queries.py
@@ -247,7 +247,7 @@ GET_PHOTO_IMAGES_QUERY = (
 
 DANALOCK_CONFIG_QUERY = (
     "query xSGetDanalockConfig($numinst: String!, $panel: String!,"
-    " $deviceId: String!, $deviceType: String) {\n"
+    " $deviceId: String!, $deviceType: String!) {\n"
     "  xSGetDanalockConfig(\n    numinst: $numinst\n    panel: $panel\n"
     "    deviceId: $deviceId\n    deviceType: $deviceType\n"
     "  ) {\n    res\n    msg\n    referenceId\n  }\n}"
@@ -258,11 +258,7 @@ DANALOCK_CONFIG_STATUS_QUERY = (
     " $referenceId: String!, $counter: Int!) {\n"
     "  xSGetDanalockConfigStatus(\n    numinst: $numinst\n"
     "    referenceId: $referenceId\n    counter: $counter\n"
-    "  ) {\n    res\n    msg\n    action\n    deviceNumber\n"
-    "    asyncCylinder\n    batteryLowPercenteage\n"
-    "    lockBeforePartialArm\n    lockBeforeFullArm\n"
-    "    unlockAfterDisarm\n    lockBeforePerimeterArm\n"
-    "    periodicBitExtension\n    autoLockTime\n"
+    "  ) {\n    res\n    msg\n    deviceNumber\n"
     "    features {\n      holdBackLatchTime\n      calibrationType\n"
     "      autolock {\n        active\n        timeout\n      }\n"
     "    }\n  }\n}"

--- a/custom_components/securitas/securitas_direct_new_api/graphql_queries.py
+++ b/custom_components/securitas/securitas_direct_new_api/graphql_queries.py
@@ -244,3 +244,26 @@ GET_PHOTO_IMAGES_QUERY = (
     " devices { id idSignal code name quality"
     " images { id image type } } } }"
 )
+
+DANALOCK_CONFIG_QUERY = (
+    "query xSGetDanalockConfig($numinst: String!, $panel: String!,"
+    " $deviceId: String!, $deviceType: String) {\n"
+    "  xSGetDanalockConfig(\n    numinst: $numinst\n    panel: $panel\n"
+    "    deviceId: $deviceId\n    deviceType: $deviceType\n"
+    "  ) {\n    res\n    msg\n    referenceId\n  }\n}"
+)
+
+DANALOCK_CONFIG_STATUS_QUERY = (
+    "query xSGetDanalockConfigStatus($numinst: String!,"
+    " $referenceId: String!, $counter: Int!) {\n"
+    "  xSGetDanalockConfigStatus(\n    numinst: $numinst\n"
+    "    referenceId: $referenceId\n    counter: $counter\n"
+    "  ) {\n    res\n    msg\n    action\n    deviceNumber\n"
+    "    asyncCylinder\n    batteryLowPercenteage\n"
+    "    lockBeforePartialArm\n    lockBeforeFullArm\n"
+    "    unlockAfterDisarm\n    lockBeforePerimeterArm\n"
+    "    periodicBitExtension\n    autoLockTime\n"
+    "    features {\n      holdBackLatchTime\n      calibrationType\n"
+    "      autolock {\n        active\n        timeout\n      }\n"
+    "    }\n  }\n}"
+)

--- a/tests/test_smart_lock.py
+++ b/tests/test_smart_lock.py
@@ -8,6 +8,9 @@ from custom_components.securitas.securitas_direct_new_api.dataTypes import (
     SmartLock,
     SmartLockMode,
 )
+from custom_components.securitas.securitas_direct_new_api.exceptions import (
+    SecuritasDirectError,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -333,3 +336,247 @@ class TestGetLockCurrentMode:
         result = await authed_api.get_lock_current_mode(installation)
 
         assert result[0].statusTimestamp == "1772728828235"
+
+
+# ── submit_danalock_config_request() ──────────────────────────────────────
+
+
+class TestSubmitDanalockConfigRequest:
+    async def test_returns_reference_id(self, authed_api, mock_execute, installation):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetDanalockConfig": {
+                    "res": "OK",
+                    "msg": "alarm-manager.processed.request",
+                    "referenceId": "abc-123",
+                }
+            }
+        }
+
+        result = await authed_api.submit_danalock_config_request(installation)
+
+        assert result == "abc-123"
+
+    async def test_variables_passed_correctly(
+        self, authed_api, mock_execute, installation
+    ):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetDanalockConfig": {
+                    "res": "OK",
+                    "msg": "",
+                    "referenceId": "ref-1",
+                }
+            }
+        }
+
+        await authed_api.submit_danalock_config_request(installation, "02")
+
+        call_args = mock_execute.call_args[0][0]
+        assert call_args["variables"]["deviceId"] == "02"
+        assert call_args["variables"]["deviceType"] == "DR"
+        assert call_args["variables"]["numinst"] == installation.number
+        assert call_args["variables"]["panel"] == installation.panel
+
+    async def test_no_reference_id_raises(self, authed_api, mock_execute, installation):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetDanalockConfig": {
+                    "res": "OK",
+                    "msg": "",
+                }
+            }
+        }
+
+        with pytest.raises(SecuritasDirectError, match="referenceId"):
+            await authed_api.submit_danalock_config_request(installation)
+
+
+# ── check_danalock_config_status() ────────────────────────────────────────
+
+
+class TestCheckDanalockConfigStatus:
+    async def test_returns_wait_response(self, authed_api, mock_execute, installation):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetDanalockConfigStatus": {
+                    "res": "WAIT",
+                    "msg": "peripherals.processing.request",
+                    "features": None,
+                }
+            }
+        }
+
+        result = await authed_api.check_danalock_config_status(installation, "ref-1", 1)
+
+        assert result["res"] == "WAIT"
+
+    async def test_counter_passed_in_variables(
+        self, authed_api, mock_execute, installation
+    ):
+        mock_execute.return_value = {
+            "data": {
+                "xSGetDanalockConfigStatus": {
+                    "res": "WAIT",
+                    "msg": "",
+                }
+            }
+        }
+
+        await authed_api.check_danalock_config_status(installation, "ref-1", 3)
+
+        call_args = mock_execute.call_args[0][0]
+        assert call_args["variables"]["counter"] == 3
+        assert call_args["variables"]["referenceId"] == "ref-1"
+
+
+# ── get_danalock_config() ─────────────────────────────────────────────────
+
+
+class TestGetDanalockConfig:
+    async def test_success_after_wait(self, authed_api, mock_execute, installation):
+        """Polling returns WAIT, then OK with features."""
+        mock_execute.side_effect = [
+            # submit_danalock_config_request
+            {
+                "data": {
+                    "xSGetDanalockConfig": {
+                        "res": "OK",
+                        "msg": "alarm-manager.processed.request",
+                        "referenceId": "ref-1",
+                    }
+                }
+            },
+            # check_danalock_config_status (counter=1) -> WAIT
+            {
+                "data": {
+                    "xSGetDanalockConfigStatus": {
+                        "res": "WAIT",
+                        "msg": "peripherals.processing.request",
+                        "features": None,
+                    }
+                }
+            },
+            # check_danalock_config_status (counter=2) -> OK
+            {
+                "data": {
+                    "xSGetDanalockConfigStatus": {
+                        "res": "OK",
+                        "msg": "peripherals.lock-configuration-request.success",
+                        "deviceNumber": "001",
+                        "features": {
+                            "holdBackLatchTime": 3,
+                            "calibrationType": 0,
+                            "autolock": {"active": None, "timeout": None},
+                        },
+                    }
+                }
+            },
+        ]
+
+        result = await authed_api.get_danalock_config(installation)
+
+        assert isinstance(result, SmartLock)
+        assert result.res == "OK"
+        assert result.features is not None
+        assert result.features.holdBackLatchTime == 3
+        assert result.features.calibrationType == 0
+
+    async def test_success_immediate(self, authed_api, mock_execute, installation):
+        """Config returns OK on first poll (no WAIT)."""
+        mock_execute.side_effect = [
+            # submit
+            {
+                "data": {
+                    "xSGetDanalockConfig": {
+                        "res": "OK",
+                        "msg": "",
+                        "referenceId": "ref-2",
+                    }
+                }
+            },
+            # check (counter=1) -> OK immediately
+            {
+                "data": {
+                    "xSGetDanalockConfigStatus": {
+                        "res": "OK",
+                        "msg": "success",
+                        "deviceNumber": "001",
+                        "features": {
+                            "holdBackLatchTime": 5,
+                            "calibrationType": 1,
+                            "autolock": {"active": True, "timeout": "1800"},
+                        },
+                    }
+                }
+            },
+        ]
+
+        result = await authed_api.get_danalock_config(installation)
+
+        assert result.features.holdBackLatchTime == 5
+        assert result.features.autolock is not None
+        assert result.features.autolock.active is True
+        assert result.features.autolock.timeout == "1800"
+
+    async def test_timeout_raises(self, authed_api, mock_execute, installation):
+        """Polling returns WAIT forever -> raises error."""
+        responses = [
+            # submit
+            {
+                "data": {
+                    "xSGetDanalockConfig": {
+                        "res": "OK",
+                        "msg": "",
+                        "referenceId": "ref-3",
+                    }
+                }
+            },
+        ]
+        # 10 WAIT responses (max_attempts = 10)
+        for _ in range(10):
+            responses.append(
+                {
+                    "data": {
+                        "xSGetDanalockConfigStatus": {
+                            "res": "WAIT",
+                            "msg": "peripherals.processing.request",
+                        }
+                    }
+                }
+            )
+        mock_execute.side_effect = responses
+
+        with pytest.raises(SecuritasDirectError, match="timed out"):
+            await authed_api.get_danalock_config(installation)
+
+    async def test_no_features_returns_none_features(
+        self, authed_api, mock_execute, installation
+    ):
+        """Danalock config with no features field."""
+        mock_execute.side_effect = [
+            {
+                "data": {
+                    "xSGetDanalockConfig": {
+                        "res": "OK",
+                        "msg": "",
+                        "referenceId": "ref-4",
+                    }
+                }
+            },
+            {
+                "data": {
+                    "xSGetDanalockConfigStatus": {
+                        "res": "OK",
+                        "msg": "success",
+                        "deviceNumber": "001",
+                        "features": None,
+                    }
+                }
+            },
+        ]
+
+        result = await authed_api.get_danalock_config(installation)
+
+        assert result.res == "OK"
+        assert result.features is None

--- a/tests/test_smart_lock.py
+++ b/tests/test_smart_lock.py
@@ -430,51 +430,24 @@ class TestCheckDanalockConfigStatus:
         assert call_args["variables"]["referenceId"] == "ref-1"
 
 
-# ── get_danalock_config() ─────────────────────────────────────────────────
+# ── parse_danalock_config_response() ──────────────────────────────────────
 
 
-class TestGetDanalockConfig:
-    async def test_success_after_wait(self, authed_api, mock_execute, installation):
-        """Polling returns WAIT, then OK with features."""
-        mock_execute.side_effect = [
-            # submit_danalock_config_request
-            {
-                "data": {
-                    "xSGetDanalockConfig": {
-                        "res": "OK",
-                        "msg": "alarm-manager.processed.request",
-                        "referenceId": "ref-1",
-                    }
-                }
+class TestParseDanalockConfigResponse:
+    def test_parses_features(self, authed_api):
+        """Features from Danalock config status are parsed into SmartLock."""
+        raw = {
+            "res": "OK",
+            "msg": "peripherals.lock-configuration-request.success",
+            "deviceNumber": "001",
+            "features": {
+                "holdBackLatchTime": 3,
+                "calibrationType": 0,
+                "autolock": {"active": None, "timeout": None},
             },
-            # check_danalock_config_status (counter=1) -> WAIT
-            {
-                "data": {
-                    "xSGetDanalockConfigStatus": {
-                        "res": "WAIT",
-                        "msg": "peripherals.processing.request",
-                        "features": None,
-                    }
-                }
-            },
-            # check_danalock_config_status (counter=2) -> OK
-            {
-                "data": {
-                    "xSGetDanalockConfigStatus": {
-                        "res": "OK",
-                        "msg": "peripherals.lock-configuration-request.success",
-                        "deviceNumber": "001",
-                        "features": {
-                            "holdBackLatchTime": 3,
-                            "calibrationType": 0,
-                            "autolock": {"active": None, "timeout": None},
-                        },
-                    }
-                }
-            },
-        ]
+        }
 
-        result = await authed_api.get_danalock_config(installation)
+        result = authed_api.parse_danalock_config_response(raw)
 
         assert isinstance(result, SmartLock)
         assert result.res == "OK"
@@ -482,101 +455,51 @@ class TestGetDanalockConfig:
         assert result.features.holdBackLatchTime == 3
         assert result.features.calibrationType == 0
 
-    async def test_success_immediate(self, authed_api, mock_execute, installation):
-        """Config returns OK on first poll (no WAIT)."""
-        mock_execute.side_effect = [
-            # submit
-            {
-                "data": {
-                    "xSGetDanalockConfig": {
-                        "res": "OK",
-                        "msg": "",
-                        "referenceId": "ref-2",
-                    }
-                }
+    def test_parses_autolock(self, authed_api):
+        """Autolock config is parsed correctly."""
+        raw = {
+            "res": "OK",
+            "deviceNumber": "001",
+            "features": {
+                "holdBackLatchTime": 5,
+                "calibrationType": 1,
+                "autolock": {"active": True, "timeout": "1800"},
             },
-            # check (counter=1) -> OK immediately
-            {
-                "data": {
-                    "xSGetDanalockConfigStatus": {
-                        "res": "OK",
-                        "msg": "success",
-                        "deviceNumber": "001",
-                        "features": {
-                            "holdBackLatchTime": 5,
-                            "calibrationType": 1,
-                            "autolock": {"active": True, "timeout": "1800"},
-                        },
-                    }
-                }
-            },
-        ]
+        }
 
-        result = await authed_api.get_danalock_config(installation)
+        result = authed_api.parse_danalock_config_response(raw)
 
         assert result.features.holdBackLatchTime == 5
         assert result.features.autolock is not None
         assert result.features.autolock.active is True
         assert result.features.autolock.timeout == "1800"
 
-    async def test_timeout_raises(self, authed_api, mock_execute, installation):
-        """Polling returns WAIT forever -> raises error."""
-        responses = [
-            # submit
-            {
-                "data": {
-                    "xSGetDanalockConfig": {
-                        "res": "OK",
-                        "msg": "",
-                        "referenceId": "ref-3",
-                    }
-                }
-            },
-        ]
-        # 10 WAIT responses (max_attempts = 10)
-        for _ in range(10):
-            responses.append(
-                {
-                    "data": {
-                        "xSGetDanalockConfigStatus": {
-                            "res": "WAIT",
-                            "msg": "peripherals.processing.request",
-                        }
-                    }
-                }
-            )
-        mock_execute.side_effect = responses
-
-        with pytest.raises(SecuritasDirectError, match="timed out"):
-            await authed_api.get_danalock_config(installation)
-
-    async def test_no_features_returns_none_features(
-        self, authed_api, mock_execute, installation
-    ):
+    def test_no_features_returns_none_features(self, authed_api):
         """Danalock config with no features field."""
-        mock_execute.side_effect = [
-            {
-                "data": {
-                    "xSGetDanalockConfig": {
-                        "res": "OK",
-                        "msg": "",
-                        "referenceId": "ref-4",
-                    }
-                }
-            },
-            {
-                "data": {
-                    "xSGetDanalockConfigStatus": {
-                        "res": "OK",
-                        "msg": "success",
-                        "deviceNumber": "001",
-                        "features": None,
-                    }
-                }
-            },
-        ]
+        raw = {
+            "res": "OK",
+            "msg": "success",
+            "deviceNumber": "001",
+            "features": None,
+        }
 
-        result = await authed_api.get_danalock_config(installation)
+        result = authed_api.parse_danalock_config_response(raw)
 
         assert result.res == "OK"
         assert result.features is None
+
+    def test_device_id_from_device_number(self, authed_api):
+        """deviceNumber from response is used as deviceId."""
+        raw = {"res": "OK", "deviceNumber": "002", "features": None}
+
+        result = authed_api.parse_danalock_config_response(raw)
+
+        assert result.deviceId == "002"
+
+    def test_device_id_fallback(self, authed_api):
+        """Falls back to provided device_id when deviceNumber is missing."""
+        raw = {"res": "OK", "features": None}
+
+        result = authed_api.parse_danalock_config_response(raw, "03")
+
+        assert result.deviceId == "03"


### PR DESCRIPTION
## Summary

- Add Danalock two-phase polling config API (`xSGetDanalockConfig` + `xSGetDanalockConfigStatus`) alongside existing Smartlock direct config API
- Auto-detect which config API each lock uses (try Smartlock first, fall back to Danalock)
- Add deferred background retry (60s, 120s, 300s) when lock config fetch fails during startup, so the "Open" button appears once the API recovers
- Extract shared lock features parsing into `_parse_lock_features()` helper

Fixes #313, fixes #416

## Test plan

- [x] All 25 smart lock tests pass (9 new Danalock tests added)
- [x] All 67 hub tests pass (no regressions)
- [x] Ruff lint and format clean
- [ ] User with Danalock installation (e.g. #313 reporter) confirms lock config is fetched and "Open" button appears
- [ ] User with Smartlock installation confirms no change in behavior
- [ ] User who reported #416 confirms lock is now detected after transient API errors