### PR TITLE
fix: add air quality Fair/Poor status mappings

### DIFF
--- a/custom_components/securitas/sensor.py
+++ b/custom_components/securitas/sensor.py
@@ -144,7 +144,8 @@ class SentinelHumidity(SecuritasEntity, SensorEntity):
 
 AIR_QUALITY_LABELS: dict[str, str] = {
     "1": "Good",
-    "2": "Poor",
+    "2": "Fair",
+    "3": "Poor",
 }
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -406,11 +406,12 @@ The `_get_exceptions()` API call uses the same polling pattern as arm/disarm —
 
 ### Sensors (`sensor.py`)
 
-Three sensor types:
+Four sensor types:
 
 - **SentinelTemperature** — Temperature in Celsius
 - **SentinelHumidity** — Humidity as percentage
-- **SentinelAirQuality** — Air quality index with message (e.g. "Good", "Fair", "Poor")
+- **SentinelAirQuality** — Numeric air quality index
+- **SentinelAirQualityStatus** — Categorical air quality label (Good, Fair, Poor)
 
 Sentinel sensors are discovered during platform setup by scanning services for ones whose `request` field matches any name in `SENTINEL_SERVICE_NAMES` (currently "CONFORT", "COMFORTO", "COMFORT"). No API calls are made during setup — entities start with unknown state. Data is populated by `async_update()` using HA's built-in polling at a 30-minute interval (see [Polling intervals](#polling-intervals)).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -410,7 +410,7 @@ Three sensor types:
 
 - **SentinelTemperature** — Temperature in Celsius
 - **SentinelHumidity** — Humidity as percentage
-- **SentinelAirQuality** — Air quality index with message (e.g. "Good")
+- **SentinelAirQuality** — Air quality index with message (e.g. "Good", "Fair", "Poor")
 
 Sentinel sensors are discovered during platform setup by scanning services for ones whose `request` field matches any name in `SENTINEL_SERVICE_NAMES` (currently "CONFORT", "COMFORTO", "COMFORT"). No API calls are made during setup — entities start with unknown state. Data is populated by `async_update()` using HA's built-in polling at a 30-minute interval (see [Polling intervals](#polling-intervals)).
 

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -382,11 +382,24 @@ class TestSentinelAirQualityStatus:
         await sensor.async_update()
         assert sensor._attr_native_value == "Good"
 
-    async def test_status_poor(self):
+    async def test_status_fair(self):
         client = make_client()
         client.get_sentinel = AsyncMock(return_value=_mock_sentinel_with_zone())
         client.get_air_quality = AsyncMock(
             return_value=AirQuality(value=200, status_current=2)
+        )
+        fetcher = _make_fetcher(client=client)
+        sensor = SentinelAirQualityStatus(fetcher, make_installation())
+        sensor.hass = MagicMock()
+
+        await sensor.async_update()
+        assert sensor._attr_native_value == "Fair"
+
+    async def test_status_poor(self):
+        client = make_client()
+        client.get_sentinel = AsyncMock(return_value=_mock_sentinel_with_zone())
+        client.get_air_quality = AsyncMock(
+            return_value=AirQuality(value=300, status_current=3)
         )
         fetcher = _make_fetcher(client=client)
         sensor = SentinelAirQualityStatus(fetcher, make_installation())


### PR DESCRIPTION
## Summary
- Remap air quality status code `2` from "Poor" to "Fair"
- Add status code `3` mapped to "Poor"
- Update docs and tests to cover the three-level scale (Good / Fair / Poor)

Closes #420

## Test plan
- [x] Existing `test_async_update_sets_status_label` passes (code 1 → "Good")
- [x] Renamed `test_status_fair` passes (code 2 → "Fair")
- [x] New `test_status_poor` passes (code 3 → "Poor")
- [x] `test_unknown_status_code` still passes for unmapped codes
- [x] Full test suite (874 tests) passes
- [x] Ruff lint and format clean