### PR TITLE
feat: add Mushroom-compatible alarm chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ To add the badge, click **Add Badge → Search for "Securitas Alarm Badge"** and
 
 ### Mushroom Chip
 
-A **Securitas Alarm Chip** (`securitas-alarm-chip`) is available for use inside a [Mushroom Chips Card](https://github.com/piitaya/lovelace-mushroom). It shows the same state-specific icon and color as the badge, in a Mushroom-compatible pill shape.
+A **Securitas Alarm Chip** is available for use inside a [Mushroom Chips Card](https://github.com/piitaya/lovelace-mushroom). Use `type: securitas-alarm` in your Mushroom chips config. It shows the same state-specific icon and color as the badge, in a Mushroom-compatible pill shape.
 
 Tapping the chip opens the full alarm card in a popup overlay. Gesture actions (hold, double-tap) are supported via YAML — see [Gesture Actions](#gesture-actions) below.
 
@@ -261,15 +261,15 @@ chips:
 
 ### Gesture Actions
 
-The **alarm card**, **badge**, and **chip** all support configurable tap, hold, and double-tap actions. These are set in the card/badge editor under the **Tap action**, **Hold action**, and **Double-tap action** sections.
+The **alarm card**, **badge**, and **chip** all support configurable tap, hold, and double-tap actions. For the **card** and **badge**, these can be set in the visual editor under the **Tap action**, **Hold action**, and **Double-tap action** sections. For the **chip**, these actions are configured in YAML (see [below](#chip-gesture-actions)).
 
 ![Gesture Actions](./docs/images/card-gestures.png)
 
-| Action     | Badge default   | Chip default    | Card default |
-| ---------- | --------------- | --------------- | ------------ |
-| Tap        | Open alarm card | Open alarm card | _(none)_     |
-| Hold       | _(none)_        | _(none)_        | _(none)_     |
-| Double-tap | _(none)_        | _(none)_        | _(none)_     |
+| Action     | Badge default | Chip default    | Card default |
+| ---------- | ------------- | --------------- | ------------ |
+| Tap        | Open alarm card | Open alarm card | _(none)_   |
+| Hold       | Arm / Disarm  | _(none)_        | _(none)_     |
+| Double-tap | _(none)_      | _(none)_        | _(none)_     |
 
 Each action can be set to one of the following:
 

--- a/README.md
+++ b/README.md
@@ -246,17 +246,30 @@ By default, tapping the badge opens the full alarm card in a popup overlay. You 
 
 To add the badge, click **Add Badge → Search for "Securitas Alarm Badge"** and pick your alarm panel entity from the dropdown.
 
+### Mushroom Chip
+
+A **Securitas Alarm Chip** (`securitas-alarm-chip`) is available for use inside a [Mushroom Chips Card](https://github.com/piitaya/lovelace-mushroom). It shows the same state-specific icon and color as the badge, in a Mushroom-compatible pill shape.
+
+Tapping the chip opens the full alarm card in a popup overlay. Gesture actions (hold, double-tap) are supported via YAML — see [Gesture Actions](#gesture-actions) below.
+
+```yaml
+type: custom:mushroom-chips-card
+chips:
+  - type: securitas-alarm
+    entity: alarm_control_panel.my_alarm
+```
+
 ### Gesture Actions
 
-Both the **alarm card** and the **badge** support configurable tap, hold, and double-tap actions. These are set in the card/badge editor under the **Tap action**, **Hold action**, and **Double-tap action** sections.
+The **alarm card**, **badge**, and **chip** all support configurable tap, hold, and double-tap actions. These are set in the card/badge editor under the **Tap action**, **Hold action**, and **Double-tap action** sections.
 
 ![Gesture Actions](./docs/images/card-gestures.png)
 
-| Action     | Badge default   | Card default |
-| ---------- | --------------- | ------------ |
-| Tap        | Open alarm card | _(none)_     |
-| Hold       | _(none)_        | _(none)_     |
-| Double-tap | _(none)_        | _(none)_     |
+| Action     | Badge default   | Chip default    | Card default |
+| ---------- | --------------- | --------------- | ------------ |
+| Tap        | Open alarm card | Open alarm card | _(none)_     |
+| Hold       | _(none)_        | _(none)_        | _(none)_     |
+| Double-tap | _(none)_        | _(none)_        | _(none)_     |
 
 Each action can be set to one of the following:
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,31 @@ Each action can be set to one of the following:
 
 Example: set **Hold** to **Disarm** on the badge to disarm with a long press, without opening the card popup.
 
+The card and badge have a visual editor for gesture actions. The chip only supports YAML configuration:
+
+```yaml
+type: custom:mushroom-chips-card
+chips:
+  - type: securitas-alarm
+    entity: alarm_control_panel.my_alarm
+    tap_action:
+      action: more-info           # default — opens alarm card popup
+    hold_action:
+      action: arm_or_disarm       # arms when disarmed, disarms when armed
+    double_tap_action:
+      action: navigate
+      navigation_path: /lovelace/security
+```
+
+Available actions:
+
+| Action           | YAML value                                                           |
+| ---------------- | -------------------------------------------------------------------- |
+| None             | `action: none`                                                       |
+| Open alarm card  | `action: more-info`                                                  |
+| Navigate         | `action: navigate` + `navigation_path: /path`                       |
+| Arm or Disarm    | `action: arm_or_disarm` (optionally + `arm_state: armed_away` etc.) |
+
 ## Sentinel Sensors
 
 If your installation includes Sentinel devices, the integration automatically creates temperature, humidity, and air quality sensors for each one.

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -1688,15 +1688,147 @@ class SecuritasAlarmBadge extends HTMLElement {
   }
 }
 
+// ── Mushroom-compatible chip ─────────────────────────────────────────────────
+
+class SecuritasAlarmChip extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._dialogOpen = false;
+    this._pinOverlay = null;
+    this._pinState   = null;
+    this._pin        = "";
+    this._gestureCleanup = null;
+  }
+
+  disconnectedCallback() {
+    if (this._gestureCleanup) { this._gestureCleanup(); this._gestureCleanup = null; }
+    if (this._pinOverlay) { this._pinOverlay.remove(); this._pinOverlay = null; this._pinState = null; this._pin = ""; }
+  }
+
+  setConfig(config) {
+    if (!config.entity) throw new Error("Please define an entity");
+    this._config = config;
+    if (this._hass) this._tryRender();
+  }
+
+  set config(config) { this.setConfig(config); }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._tryRender();
+    if (this._dialogCard) this._dialogCard.hass = hass;
+  }
+
+  _tryRender() {
+    if (!this._hass || !this._config) return;
+    const stateObj = this._hass.states[this._config.entity];
+    const newKey = stateObj
+      ? `${stateObj.state}|${stateObj.attributes.force_arm_available}`
+      : "missing";
+    if (newKey !== this._lastKey) {
+      this._lastKey = newKey;
+      this._render();
+    }
+  }
+
+  _render() {
+    if (!this._hass || !this._config) return;
+
+    const stateObj = this._hass.states[this._config.entity];
+    if (!stateObj) {
+      this.shadowRoot.innerHTML = `<ha-icon icon="mdi:shield-alert" style="color:var(--error-color)"></ha-icon>`;
+      return;
+    }
+
+    const state = stateObj.state;
+    const cfg = stateObj.attributes.force_arm_available
+      ? { icon: "mdi:alert", color: "var(--warning-color, #FF9800)" }
+      : STATE_CFG[state] || { icon: "mdi:shield", color: "var(--disabled-color,#9E9E9E)" };
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: flex;
+          --chip-height: 36px;
+          --chip-padding: 0 10px;
+          --chip-border-radius: 19px;
+          --chip-icon-size: 18px;
+        }
+        .chip {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: var(--chip-height);
+          padding: var(--chip-padding);
+          border-radius: var(--chip-border-radius);
+          background: var(--ha-card-background, var(--card-background-color, #fff));
+          box-shadow: var(--chip-box-shadow, 0 2px 4px rgba(0,0,0,0.06));
+          cursor: pointer;
+          transition: transform 0.1s;
+          user-select: none;
+          -webkit-user-select: none;
+        }
+        .chip:active { transform: scale(0.95); }
+        .chip ha-icon {
+          --mdc-icon-size: var(--chip-icon-size);
+          color: ${cfg.color};
+        }
+      </style>
+      <div class="chip" id="chip">
+        <ha-icon icon="${cfg.icon}"></ha-icon>
+      </div>`;
+
+    if (this._gestureCleanup) { this._gestureCleanup(); this._gestureCleanup = null; }
+
+    const chipEl = this.shadowRoot.getElementById("chip");
+    const gestureConfig = {
+      tap_action:        this._config.tap_action        || { action: "more-info" },
+      hold_action:       this._config.hold_action       || { action: "none" },
+      double_tap_action: this._config.double_tap_action || { action: "none" },
+    };
+
+    this._gestureCleanup = attachGesture(
+      chipEl,
+      gestureConfig,
+      this._hass,
+      this._config.entity,
+      this,
+      {
+        onMoreInfo:    () => this._openDialog(),
+        startPinEntry: (svcAction) => SecuritasAlarmBadge.prototype._startBadgePinEntry.call(this, svcAction),
+      },
+    );
+  }
+
+  _openDialog() {
+    SecuritasAlarmBadge.prototype._openDialog.call(this);
+  }
+
+  _submitBadgePin(closeFn) {
+    SecuritasAlarmBadge.prototype._submitBadgePin.call(this, closeFn);
+  }
+
+  getCardSize() { return 1; }
+}
+
 if (!customElements.get("securitas-alarm-card"))   customElements.define("securitas-alarm-card", SecuritasAlarmCard);
 if (!customElements.get("securitas-alarm-card-editor")) customElements.define("securitas-alarm-card-editor", SecuritasAlarmCardEditor);
 if (!customElements.get("securitas-alarm-badge"))  customElements.define("securitas-alarm-badge", SecuritasAlarmBadge);
+if (!customElements.get("securitas-alarm-chip"))   customElements.define("securitas-alarm-chip", SecuritasAlarmChip);
+if (!customElements.get("mushroom-securitas-alarm-chip")) customElements.define("mushroom-securitas-alarm-chip", class extends SecuritasAlarmChip {});
 
 window.customCards = window.customCards || [];
 window.customCards.push({
   type:        "securitas-alarm-card",
   name:        TRANSLATIONS.en.card_name,
   description: TRANSLATIONS.en.card_description,
+  preview:     false,
+});
+window.customCards.push({
+  type:        "securitas-alarm-chip",
+  name:        "Securitas Alarm Chip",
+  description: "Mushroom-compatible alarm chip — shows alarm state with force-arm support.",
   preview:     false,
 });
 window.customBadges = window.customBadges || [];

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -1709,6 +1709,7 @@ class SecuritasAlarmChip extends HTMLElement {
   setConfig(config) {
     if (!config.entity) throw new Error("Please define an entity");
     this._config = config;
+    this._lastKey = null;  // force re-render on config change
     if (this._hass) this._tryRender();
   }
 


### PR DESCRIPTION
## Summary

- Adds a `SecuritasAlarmChip` web component that works inside Mushroom's chips card
- Registered as both `securitas-alarm-chip` (standalone) and `mushroom-securitas-alarm-chip` (Mushroom naming convention)
- Same state-specific icons/colors as the badge, force-arm alert override, gesture actions, and popup alarm card on tap
- README updated with Mushroom Chip section and usage instructions

### Usage

```yaml
type: custom:mushroom-chips-card
chips:
  - type: securitas-alarm
    entity: alarm_control_panel.my_alarm
```

## Test plan

- [ ] Add chip to a Mushroom chips card and verify it renders with the correct icon/color per alarm state
- [ ] Tap chip and verify the alarm card popup opens
- [ ] Verify force-arm alert icon (amber triangle) appears when force_arm_available is true
- [ ] Verify gesture actions (hold, double-tap) work when configured via YAML