### PR TITLE
fix: prevent infinite login retry loop on account-blocked 403

### DIFF
--- a/custom_components/securitas/config_flow.py
+++ b/custom_components/securitas/config_flow.py
@@ -57,6 +57,7 @@ from .securitas_direct_new_api import (
     STATE_LABELS,
     STD_DEFAULTS,
     STD_OPTIONS,
+    AccountBlockedError,
     Attribute,
     Attributes,
     Installation,
@@ -319,6 +320,12 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except Login2FAError:
             # 2FA required — proceed to device validation for phone list
             return await self._start_2fa_flow()
+        except AccountBlockedError:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self._user_schema(user_input),
+                errors={"base": "account_blocked"},
+            )
         except LoginError:
             return self.async_show_form(
                 step_id="user",
@@ -383,6 +390,12 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.securitas.login()
         except Login2FAError:
             return await self._start_2fa_flow()
+        except AccountBlockedError:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self._user_schema(self.config),
+                errors={"base": "account_blocked"},
+            )
         except LoginError:
             return self.async_show_form(
                 step_id="user",

--- a/custom_components/securitas/securitas_direct_new_api/__init__.py
+++ b/custom_components/securitas/securitas_direct_new_api/__init__.py
@@ -32,6 +32,7 @@ from .dataTypes import (  # noqa: F401
 )
 from .domains import ApiDomains  # noqa: F401
 from .exceptions import (  # noqa: F401
+    AccountBlockedError,
     ArmingExceptionError,
     Login2FAError,
     LoginError,

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -298,7 +298,8 @@ class ApiManager(SecuritasHttpClient):
             if result_json is not None:
                 # Check for account-blocked error (60052)
                 if self._is_account_blocked(result_json):
-                    raise AccountBlockedError(err.args) from err
+                    message = str(err.args[0]) if err.args else "Account is blocked"
+                    raise AccountBlockedError(message, result_json) from err
                 if result_json.get("data"):
                     data = result_json["data"]
                     if data.get("xSLoginToken"):

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -30,6 +30,7 @@ from .dataTypes import (
     ThumbnailResponse,
 )
 from .exceptions import (
+    AccountBlockedError,
     ArmingExceptionError,
     Login2FAError,
     LoginError,
@@ -135,6 +136,16 @@ class ApiManager(SecuritasHttpClient):
             self.refresh_token_value = ""
             self.authentication_token_exp = datetime.min
             self.login_timestamp = 0
+
+    @staticmethod
+    def _is_account_blocked(result_json: dict) -> bool:
+        """Check if a login response indicates the account is blocked (error 60052)."""
+        errors = result_json.get("errors")
+        if isinstance(errors, list) and errors:
+            first = errors[0]
+            if isinstance(first, dict) and isinstance(first.get("data"), dict):
+                return first["data"].get("err") == "60052"
+        return False
 
     def _extract_otp_data(self, data) -> tuple[str | None, list[OtpPhone]]:
         if not data:
@@ -285,6 +296,9 @@ class ApiManager(SecuritasHttpClient):
         except SecuritasDirectError as err:
             result_json: dict | None = err.args[1] if len(err.args) > 1 else None
             if result_json is not None:
+                # Check for account-blocked error (60052)
+                if self._is_account_blocked(result_json):
+                    raise AccountBlockedError(err.args) from err
                 if result_json.get("data"):
                     data = result_json["data"]
                     if data.get("xSLoginToken"):

--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -295,21 +295,21 @@ class ApiManager(SecuritasHttpClient):
             response = await self._execute_request(content, "mkLoginToken")
         except SecuritasDirectError as err:
             result_json: dict | None = err.args[1] if len(err.args) > 1 else None
+            message = str(err.args[0]) if err.args else "Login failed"
             if result_json is not None:
                 # Check for account-blocked error (60052)
                 if self._is_account_blocked(result_json):
-                    message = str(err.args[0]) if err.args else "Account is blocked"
                     raise AccountBlockedError(message, result_json) from err
                 if result_json.get("data"):
                     data = result_json["data"]
                     if data.get("xSLoginToken"):
                         if data["xSLoginToken"].get("needDeviceAuthorization"):
                             # needs a 2FA
-                            raise Login2FAError(err.args) from err
-                    raise LoginError(err.args) from err
+                            raise Login2FAError(message, result_json) from err
+                    raise LoginError(message, result_json) from err
                 # Has response dict = server responded with error
                 # → login failure.
-                raise LoginError(err.args) from err
+                raise LoginError(message, result_json) from err
             # No response dict = network/connection error
             # → let propagate.
             raise

--- a/custom_components/securitas/securitas_direct_new_api/exceptions.py
+++ b/custom_components/securitas/securitas_direct_new_api/exceptions.py
@@ -60,6 +60,10 @@ class TokenRefreshError(LoginError):
     """Exception raised when the token needs refreshing."""
 
 
+class AccountBlockedError(LoginError):
+    """Exception raised when the user account is blocked by Securitas."""
+
+
 class Login2FAError(LoginError):
     """Exception raised when a 2FA authentication is needed."""
 

--- a/custom_components/securitas/securitas_direct_new_api/http_client.py
+++ b/custom_components/securitas/securitas_direct_new_api/http_client.py
@@ -34,6 +34,16 @@ _LOGGER = logging.getLogger(__name__)
 API_CALLBY = "OWA_10"
 API_ID_PREFIX = "OWA_______________"
 
+# Operations that ARE the authentication — never retry auth on these
+_AUTH_OPERATIONS = frozenset(
+    {
+        "mkLoginToken",
+        "RefreshLogin",
+        "mkSendOTP",
+        "mkValidateDevice",
+    }
+)
+
 # Keys whose values should be replaced with a placeholder in debug logs
 _LOG_TRUNCATE_KEYS = {"hours", "image"}
 
@@ -332,12 +342,6 @@ class SecuritasHttpClient:
                     # Never retry auth for login/refresh operations — they ARE
                     # the authentication, so retrying would loop forever
                     # (e.g. error 60052 "account blocked" returns status 403).
-                    _AUTH_OPERATIONS = {
-                        "mkLoginToken",
-                        "RefreshLogin",
-                        "mkSendOTP",
-                        "mkValidateDevice",
-                    }
                     if (
                         error_status == 403
                         and not _retried

--- a/custom_components/securitas/securitas_direct_new_api/http_client.py
+++ b/custom_components/securitas/securitas_direct_new_api/http_client.py
@@ -328,8 +328,21 @@ class SecuritasHttpClient:
                         ):
                             error_status = 400
 
-                    # Session expired server-side: re-authenticate and retry once
-                    if error_status == 403 and not _retried:
+                    # Session expired server-side: re-authenticate and retry once.
+                    # Never retry auth for login/refresh operations — they ARE
+                    # the authentication, so retrying would loop forever
+                    # (e.g. error 60052 "account blocked" returns status 403).
+                    _AUTH_OPERATIONS = {
+                        "mkLoginToken",
+                        "RefreshLogin",
+                        "mkSendOTP",
+                        "mkValidateDevice",
+                    }
+                    if (
+                        error_status == 403
+                        and not _retried
+                        and operation not in _AUTH_OPERATIONS
+                    ):
                         _LOGGER.debug(
                             "[auth] Session expired server-side, re-authenticating"
                         )

--- a/custom_components/securitas/strings.json
+++ b/custom_components/securitas/strings.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "error": {
+            "account_blocked": "Your account has been blocked by Securitas. Use 'Forgot password' on the Securitas website to reset your password and unblock your account, then try again",
             "invalid_auth": "Invalid username or password",
             "cannot_connect": "Unable to connect to Securitas Direct",
             "invalid_otp": "Invalid verification code",

--- a/custom_components/securitas/translations/en.json
+++ b/custom_components/securitas/translations/en.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "error": {
+            "account_blocked": "Your account has been blocked by Securitas. Use 'Forgot password' on the Securitas website to reset your password and unblock your account, then try again",
             "invalid_auth": "Invalid username or password",
             "cannot_connect": "Unable to connect to Securitas Direct",
             "invalid_otp": "Invalid verification code",

--- a/custom_components/securitas/translations/es.json
+++ b/custom_components/securitas/translations/es.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "error": {
+            "account_blocked": "Su cuenta ha sido bloqueada por Securitas. Use 'Olvidé mi contraseña' en el sitio web de Securitas para restablecer su contraseña y desbloquear su cuenta, luego inténtelo de nuevo",
             "invalid_auth": "Usuario o contraseña incorrectos",
             "cannot_connect": "No se puede conectar a Securitas Direct",
             "invalid_otp": "Código de verificación no válido",

--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "error": {
+            "account_blocked": "Votre compte a été bloqué par Securitas. Utilisez « Mot de passe oublié » sur le site Securitas pour réinitialiser votre mot de passe et débloquer votre compte, puis réessayez",
             "invalid_auth": "Nom d'utilisateur ou mot de passe incorrect",
             "cannot_connect": "Impossible de se connecter à Securitas Direct",
             "invalid_otp": "Code de vérification non valide",

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "error": {
+            "account_blocked": "Il tuo account è stato bloccato da Securitas. Usa 'Password dimenticata' sul sito Securitas per reimpostare la password e sbloccare il tuo account, poi riprova",
             "invalid_auth": "Nome utente o password non validi",
             "cannot_connect": "Impossibile connettersi a Securitas Direct",
             "invalid_otp": "Codice di verifica non valido",

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "error": {
+            "account_blocked": "Sua conta foi bloqueada pela Securitas. Use 'Esqueci minha senha' no site da Securitas para redefinir sua senha e desbloquear sua conta, depois tente novamente",
             "invalid_auth": "Nome de usuário ou senha inválidos",
             "cannot_connect": "Não foi possível conectar ao Securitas Direct",
             "invalid_otp": "Código de verificação inválido",

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "error": {
+            "account_blocked": "A sua conta foi bloqueada pela Securitas. Use 'Esqueci a palavra-passe' no site da Securitas para redefinir a sua palavra-passe e desbloquear a sua conta, depois tente novamente",
             "invalid_auth": "Nome de utilizador ou palavra-passe inválidos",
             "cannot_connect": "Não é possível ligar ao Securitas Direct",
             "invalid_otp": "Código de verificação inválido",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from custom_components.securitas.securitas_direct_new_api.exceptions import (
+    AccountBlockedError,
     Login2FAError,
     LoginError,
     SecuritasDirectError,
@@ -366,6 +367,26 @@ class TestLoginEdgeCases:
 
         assert api.authentication_token == ""
         assert api.login_timestamp > 0
+
+    async def test_account_blocked_raises_account_blocked_error(
+        self, api, mock_execute
+    ):
+        """Error 60052 (account blocked) raises AccountBlockedError, not LoginError."""
+        blocked_response = {
+            "errors": [
+                {
+                    "message": "Utilisateur bloqué.",
+                    "data": {"res": "ERROR", "err": "60052", "status": 403},
+                }
+            ],
+            "data": {"xSLoginToken": None},
+        }
+        mock_execute.side_effect = SecuritasDirectError(
+            "Utilisateur bloqué.", blocked_response
+        )
+
+        with pytest.raises(AccountBlockedError):
+            await api.login()
 
 
 # ── Additional validate_device edge cases ────────────────────────────────────

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,6 +22,7 @@ from custom_components.securitas import (
     DOMAIN,
 )
 from custom_components.securitas.securitas_direct_new_api import (
+    AccountBlockedError,
     Attribute,
     Login2FAError,
     LoginError,
@@ -336,6 +337,21 @@ async def test_step_user_connection_error_shows_cannot_connect(hass):
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_step_user_account_blocked_shows_account_blocked(hass):
+    """Account blocked (error 60052) should re-show the form with account_blocked error."""
+    mock_hub = _hub_factory()
+    mock_hub.login.side_effect = AccountBlockedError("account blocked")
+
+    with _patches(mock_hub):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_CREDENTIALS
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "account_blocked"}
 
 
 async def test_step_user_generates_device_ids(hass):

--- a/tests/test_execute_request.py
+++ b/tests/test_execute_request.py
@@ -598,6 +598,36 @@ class TestExecuteRequest:
         # Login was called once for the retry, then it raised on the second 403
         api.login.assert_awaited_once()
 
+    async def test_login_403_does_not_retry_auth(self, api):
+        """GraphQL 403 on mkLoginToken must NOT trigger re-auth (would loop forever)."""
+        blocked_response = json.dumps(
+            {
+                "errors": [
+                    {
+                        "message": "User blocked.",
+                        "data": {"res": "ERROR", "err": "60052", "status": 403},
+                    }
+                ],
+                "data": {"xSLoginToken": None},
+            }
+        )
+
+        resp = AsyncMock()
+        resp.text = AsyncMock(return_value=blocked_response)
+        resp.status = 200
+        resp.headers = {}
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        api.http_client.post = MagicMock(return_value=cm)
+        api.login = AsyncMock()
+
+        with pytest.raises(SecuritasDirectError, match="User blocked"):
+            await api._execute_request({"query": "test"}, "mkLoginToken")
+
+        # login must NOT be called — re-auth on auth operations would loop
+        api.login.assert_not_awaited()
+
 
 # ── generate_uuid tests ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- When `mkLoginToken` returns a GraphQL 403 (e.g. error 60052 "account blocked"), the session-expired retry logic creates an infinite loop: `_execute_request → _check_authentication_token → login → _execute_request` (with `_retried=False` each time)
- This fires ~20 requests in 2 seconds until the Incapsula WAF blocks the user's IP entirely
- Fix: skip the re-auth retry for authentication operations (`mkLoginToken`, `RefreshLogin`, `mkSendOTP`, `mkValidateDevice`) — they ARE the authentication, so retrying auth when auth fails is circular
- Show a specific "account blocked" error message in the UI instead of the misleading "Invalid username or password", with translations for all 6 languages

Fixes #426

## Test plan
- [x] New test `test_login_403_does_not_retry_auth` verifies a 403 on `mkLoginToken` raises immediately without calling `login()` again
- [x] New test `test_account_blocked_raises_account_blocked_error` verifies error 60052 raises `AccountBlockedError`
- [x] New test `test_step_user_account_blocked_shows_account_blocked` verifies the config flow shows the correct error
- [x] Existing `test_expired_session_403_retries_after_reauth` still passes (non-auth operations still retry correctly)
- [x] Full test suite passes (887 tests)