### PR TITLE
fix: handle null hours in air quality API response

### DIFF
--- a/custom_components/securitas/securitas_direct_new_api/apimanager.py
+++ b/custom_components/securitas/securitas_direct_new_api/apimanager.py
@@ -528,15 +528,14 @@ class ApiManager(SecuritasHttpClient):
         if aq_data is None:
             return None
 
-        # Use hours[-1].value for the most recent hourly reading
-        hours = aq_data.get("hours", [])
-        if not hours:
-            return None
-
-        try:
-            value = int(hours[-1].get("value", 0))
-        except (ValueError, TypeError):
-            return None
+        # Use hours[-1].value for the most recent hourly reading (may be null)
+        value: int | None = None
+        hours = aq_data.get("hours") or []
+        if hours:
+            try:
+                value = int(hours[-1].get("value", 0))
+            except (ValueError, TypeError):
+                pass
 
         status = aq_data.get("status", {})
         return AirQuality(

--- a/custom_components/securitas/securitas_direct_new_api/dataTypes.py
+++ b/custom_components/securitas/securitas_direct_new_api/dataTypes.py
@@ -113,7 +113,7 @@ class Sentinel:
 class AirQuality:
     """Air Quality from xSAirQuality API."""
 
-    value: int
+    value: int | None
     status_current: int = 0
 
 

--- a/custom_components/securitas/sensor.py
+++ b/custom_components/securitas/sensor.py
@@ -209,7 +209,7 @@ class SentinelAirQuality(SecuritasEntity, SensorEntity):
         if self.hass is None:
             return
         air_quality = await self._fetcher.fetch()
-        if air_quality is not None:
+        if air_quality is not None and air_quality.value is not None:
             self._attr_native_value = air_quality.value
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -410,10 +410,12 @@ Four sensor types:
 
 - **SentinelTemperature** — Temperature in Celsius
 - **SentinelHumidity** — Humidity as percentage
-- **SentinelAirQuality** — Numeric air quality index
+- **SentinelAirQuality** — Numeric air quality index (may remain unknown if the installation only provides status data)
 - **SentinelAirQualityStatus** — Categorical air quality label (Good, Fair, Poor)
 
 Sentinel sensors are discovered during platform setup by scanning services for ones whose `request` field matches any name in `SENTINEL_SERVICE_NAMES` (currently "CONFORT", "COMFORTO", "COMFORT"). No API calls are made during setup — entities start with unknown state. Data is populated by `async_update()` using HA's built-in polling at a 30-minute interval (see [Polling intervals](#polling-intervals)).
+
+**Air quality data model:** The `xSAirQuality` API may return hourly readings (`hours` array) and/or a categorical status code. Some installations provide both; others return `hours: null` with only the status. `AirQuality.value` is `int | None` to handle this — the status sensor works regardless, while the numeric sensor only updates when hourly data is available.
 
 ### Binary sensors (`binary_sensor.py`)
 

--- a/tests/mock_graphql.py
+++ b/tests/mock_graphql.py
@@ -503,19 +503,22 @@ def graphql_sentinel(
     }
 
 
+_UNSET = object()
+
+
 def graphql_air_quality(
     *,
     hour_value: str = "114",
     hour_id: str = "18:00",
     status_current: int = 1,
-    hours: list | None = ...,
+    hours: list | None | object = _UNSET,
 ) -> dict:
     """xSAirQuality response.
 
     Pass ``hours=None`` to simulate installations that only provide status
     data (e.g. issue #428 — Chipre).  The default builds a two-element list.
     """
-    if hours is ...:
+    if hours is _UNSET:
         hours = [
             {"id": "17:00", "value": "110"},
             {"id": hour_id, "value": hour_value},

--- a/tests/mock_graphql.py
+++ b/tests/mock_graphql.py
@@ -508,8 +508,18 @@ def graphql_air_quality(
     hour_value: str = "114",
     hour_id: str = "18:00",
     status_current: int = 1,
+    hours: list | None = ...,
 ) -> dict:
-    """xSAirQuality response."""
+    """xSAirQuality response.
+
+    Pass ``hours=None`` to simulate installations that only provide status
+    data (e.g. issue #428 — Chipre).  The default builds a two-element list.
+    """
+    if hours is ...:
+        hours = [
+            {"id": "17:00", "value": "110"},
+            {"id": hour_id, "value": hour_value},
+        ]
     return {
         "data": {
             "xSAirQuality": {
@@ -518,10 +528,7 @@ def graphql_air_quality(
                     "status": {
                         "current": status_current,
                     },
-                    "hours": [
-                        {"id": "17:00", "value": "110"},
-                        {"id": hour_id, "value": hour_value},
-                    ],
+                    "hours": hours,
                 },
             }
         }

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -352,6 +352,20 @@ class TestSentinelAirQuality:
         await sensor.async_update()
         assert sensor._attr_native_value is None
 
+    async def test_async_update_with_null_value(self):
+        """When hours is null, value is None — sensor should not update."""
+        client = make_client()
+        client.get_sentinel = AsyncMock(return_value=_mock_sentinel_with_zone())
+        client.get_air_quality = AsyncMock(
+            return_value=AirQuality(value=None, status_current=1)
+        )
+        fetcher = _make_fetcher(client=client)
+        sensor = SentinelAirQuality(fetcher, make_installation())
+        sensor.hass = MagicMock()
+
+        await sensor.async_update()
+        assert sensor._attr_native_value is None
+
     def test_unique_id_contains_airquality(self):
         service = make_service()
         installation = make_installation()
@@ -407,6 +421,20 @@ class TestSentinelAirQualityStatus:
 
         await sensor.async_update()
         assert sensor._attr_native_value == "Poor"
+
+    async def test_status_works_when_value_is_none(self):
+        """Issue #428: status should show 'Good' even when hours is null."""
+        client = make_client()
+        client.get_sentinel = AsyncMock(return_value=_mock_sentinel_with_zone())
+        client.get_air_quality = AsyncMock(
+            return_value=AirQuality(value=None, status_current=1)
+        )
+        fetcher = _make_fetcher(client=client)
+        sensor = SentinelAirQualityStatus(fetcher, make_installation())
+        sensor.hass = MagicMock()
+
+        await sensor.async_update()
+        assert sensor._attr_native_value == "Good"
 
     async def test_unknown_status_code(self, caplog):
         """Unknown codes fall back to the raw code string and log a warning."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -557,25 +557,33 @@ class TestGetAirQualityData:
 
         assert result is None
 
-    async def test_returns_none_when_no_hours(
+    async def test_returns_status_when_hours_null(
         self, authed_api, mock_execute, installation
     ):
-        """Returns None when hours list is empty."""
-        mock_execute.return_value = {
-            "data": {
-                "xSAirQuality": {
-                    "res": "OK",
-                    "data": {
-                        "status": {"current": 1},
-                        "hours": [],
-                    },
-                }
-            }
-        }
+        """Returns status even when hours is null (issue #428 — Chipre)."""
+        from tests.mock_graphql import graphql_air_quality
+
+        mock_execute.return_value = graphql_air_quality(status_current=1, hours=None)
 
         result = await authed_api.get_air_quality_data(installation, "1")
 
-        assert result is None
+        assert result is not None
+        assert result.value is None
+        assert result.status_current == 1
+
+    async def test_returns_status_when_hours_empty(
+        self, authed_api, mock_execute, installation
+    ):
+        """Returns status even when hours list is empty."""
+        from tests.mock_graphql import graphql_air_quality
+
+        mock_execute.return_value = graphql_air_quality(status_current=1, hours=[])
+
+        result = await authed_api.get_air_quality_data(installation, "1")
+
+        assert result is not None
+        assert result.value is None
+        assert result.status_current == 1
 
     async def test_returns_none_when_xsairquality_null(
         self, authed_api, mock_execute, installation


### PR DESCRIPTION
## Summary

Fixes #428 — Air quality sensors show "unknown" for installations where the `xSAirQuality` API returns `hours: null`.

Some installations (e.g. Chipre) return valid status data (`current: 1` = Good) but with `hours: null` instead of an array of hourly readings. The parser was bailing out on null/empty hours, discarding the status and leaving both sensors permanently unknown.

- `AirQuality.value` is now `int | None` to represent missing hourly data
- `get_air_quality_data` returns status even when hours is null/empty
- The numeric air quality sensor only updates when hourly data is available
- The status sensor ("Good"/"Fair"/"Poor") works regardless

## Test plan

- [x] Added `test_returns_status_when_hours_null` — exact Chipre API response shape
- [x] Added `test_returns_status_when_hours_empty` — empty list variant
- [x] Added `test_async_update_with_null_value` — numeric sensor handles None value
- [x] Added `test_status_works_when_value_is_none` — status sensor shows "Good" with null hours
- [x] All 887 existing tests still pass
- [x] ruff format + ruff check clean