### PR TITLE
feat: translate persistent notifications, exceptions, and Lovelace cards

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -71,7 +71,8 @@ from .coordinators import (
 from .hub import (  # noqa: F401 — re-exported for backwards compatibility
     SecuritasDirectDevice,
     SecuritasHub,
-    _notify_error,
+    _async_notify,
+    _notify,
 )
 from .log_filter import SensitiveDataFilter
 from .securitas_direct_new_api import (
@@ -155,13 +156,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry.entry_id,
             config_entry.version,
         )
-        _notify_error(
-            hass,
-            "migration_required",
-            "Securitas Direct",
-            "Your Securitas Direct configuration uses an old format. "
-            "Please remove the integration entry and re-add it.",
-        )
+        _notify(hass, "migration_required", "migration_required")
         return False
     return True
 
@@ -248,14 +243,12 @@ async def _get_or_create_session(
             try:
                 await client.login()
             except TwoFactorRequiredError:
-                msg = (
-                    "Securitas Direct need a 2FA SMS code."
-                    "Please login again with your phone"
-                )
-                _notify_error(hass, "2fa_error", "Securitas Direct", msg)
+                _notify(hass, "2fa_error", "two_factor_required")
                 raise
             except AuthenticationError as err:
-                _notify_error(hass, "login_error", "Securitas Direct", str(err))
+                _notify(
+                    hass, "login_error", "login_failed", {"error": str(err)}
+                )
                 _LOGGER.error(
                     "Could not log in to Securitas: %s",
                     err.log_detail(),

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -246,9 +246,7 @@ async def _get_or_create_session(
                 _notify(hass, "2fa_error", "two_factor_required")
                 raise
             except AuthenticationError as err:
-                _notify(
-                    hass, "login_error", "login_failed", {"error": str(err)}
-                )
+                _notify(hass, "login_error", "login_failed", {"error": str(err)})
                 _LOGGER.error(
                     "Could not log in to Securitas: %s",
                     err.log_detail(),

--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -22,8 +22,6 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
-from homeassistant.helpers.translation import async_get_translations
-
 from . import (
     CONF_CODE_ARM_REQUIRED,
     CONF_FORCE_ARM_NOTIFICATIONS,
@@ -37,6 +35,7 @@ from . import (
 )
 from .coordinators import AlarmCoordinator, AlarmStatusData
 from .entity import securitas_device_info
+from .notification_translations import get_notification_strings
 from .securitas_direct_new_api import (
     ArmingExceptionError,
     Installation,
@@ -692,9 +691,7 @@ class SecuritasAlarm(  # type: ignore[override]
 
     def _notify_arm_exceptions_from_event(self, event: Event) -> None:
         """Send notifications about arming exceptions from event data."""
-        self.hass.async_create_task(
-            self._async_notify_arm_exceptions(event)
-        )
+        self.hass.async_create_task(self._async_notify_arm_exceptions(event))
 
     async def _async_notify_arm_exceptions(self, event: Event) -> None:
         """Send translated persistent + mobile notifications for an arming exception."""
@@ -706,19 +703,16 @@ class SecuritasAlarm(  # type: ignore[override]
             sensor_list = "- (unknown sensor)"
             short_details = "open sensor"
 
-        translations = await async_get_translations(
-            self.hass, self.hass.config.language, "notifications", {DOMAIN}
-        )
-        base = f"component.{DOMAIN}.notifications.arm_blocked_open_sensors"
-        title = translations.get(f"{base}.title", "")
-        persistent_message = translations.get(f"{base}.message", "").replace(
+        entry = get_notification_strings(self.hass, "arm_blocked_open_sensors")
+        title = entry.get("title", "")
+        persistent_message = entry.get("message", "").replace(
             "{sensor_list}", sensor_list
         )
-        mobile_message = translations.get(f"{base}.mobile_message", "").replace(
+        mobile_message = entry.get("mobile_message", "").replace(
             "{sensor_list}", short_details
         )
-        force_arm_label = translations.get(f"{base}.force_arm_action", "")
-        cancel_label = translations.get(f"{base}.cancel_action", "")
+        force_arm_label = entry.get("force_arm_action", "")
+        cancel_label = entry.get("cancel_action", "")
 
         await self.hass.services.async_call(
             domain="persistent_notification",
@@ -743,8 +737,7 @@ class SecuritasAlarm(  # type: ignore[override]
                         "actions": [
                             {
                                 "action": (
-                                    "SECURITAS_FORCE_ARM"
-                                    f"_{self.installation.number}"
+                                    f"SECURITAS_FORCE_ARM_{self.installation.number}"
                                 ),
                                 "title": force_arm_label,
                             },

--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -506,15 +506,15 @@ class SecuritasAlarm(  # type: ignore[override]
             self._attr_extra_state_attributes["waf_blocked"] = True
         else:
             if self._attr_extra_state_attributes.pop("waf_blocked", None):
-                # Dismiss the rate-limited persistent notification
+                # Dismiss the rate-limited persistent notification — must match
+                # the ID created by the `rate_limited` _notify call.
                 self.hass.async_create_task(
                     self.hass.services.async_call(
                         domain="persistent_notification",
                         service="dismiss",
                         service_data={
                             "notification_id": (
-                                f"{DOMAIN}.securitas_rate_limited"
-                                f"_{self.installation.number}"
+                                f"{DOMAIN}.rate_limited_{self.installation.number}"
                             ),
                         },
                     )

--- a/custom_components/securitas/alarm_control_panel.py
+++ b/custom_components/securitas/alarm_control_panel.py
@@ -20,7 +20,9 @@ from homeassistant.helpers.entity_platform import (
     async_get_current_platform,
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from homeassistant.helpers.translation import async_get_translations
 
 from . import (
     CONF_CODE_ARM_REQUIRED,
@@ -31,6 +33,7 @@ from . import (
     DOMAIN,
     SecuritasDirectDevice,
     SecuritasHub,
+    _notify,
 )
 from .coordinators import AlarmCoordinator, AlarmStatusData
 from .entity import securitas_device_info
@@ -204,25 +207,6 @@ class SecuritasAlarm(  # type: ignore[override]
         if self.hass is not None:
             self.async_schedule_update_ha_state()
 
-    def _notify_error(self, title: str, message: str) -> None:
-        """Send persistent notification with auto-generated ID."""
-        import re
-
-        notification_id = re.sub(r"\W+", "_", title.lower()).strip("_")
-        self.hass.async_create_task(
-            self.hass.services.async_call(
-                domain="persistent_notification",
-                service="create",
-                service_data={
-                    "title": title,
-                    "message": message,
-                    "notification_id": (
-                        f"{DOMAIN}.{notification_id}_{self._installation.number}"
-                    ),
-                },
-            )
-        )
-
     async def async_added_to_hass(self) -> None:
         """Register event listeners when added to HA."""
         await super().async_added_to_hass()
@@ -353,12 +337,19 @@ class SecuritasAlarm(  # type: ignore[override]
             protom_response=result.protom_response,
         )
 
-    def _handle_arm_disarm_error(self, err: SecuritasDirectError, context: str) -> None:
+    def _handle_arm_disarm_error(
+        self, err: SecuritasDirectError, translation_key: str
+    ) -> None:
         """Handle errors from arm or disarm operations."""
         if getattr(err, "http_status", None) == 403:
             self._set_waf_blocked(True)
         else:
-            self._notify_error(f"Securitas: {context}", err.message)
+            _notify(
+                self.hass,
+                f"{translation_key}_{self.installation.number}",
+                translation_key,
+                {"error": err.message},
+            )
 
     async def _async_arm(
         self, state: AlarmControlPanelState, code: str | None = None
@@ -455,10 +446,10 @@ class SecuritasAlarm(  # type: ignore[override]
                 raise  # Arming exceptions need special handling upstream
             except SecuritasDirectError as err:
                 if err.http_status == 403:
-                    self._notify_error(
-                        "Securitas: Rate limited",
-                        "Too many requests — blocked by Securitas servers. "
-                        "Please wait a few minutes before trying again.",
+                    _notify(
+                        self.hass,
+                        f"rate_limited_{self.installation.number}",
+                        "rate_limited",
                     )
                     raise
                 if err.http_status == 409:
@@ -482,16 +473,15 @@ class SecuritasAlarm(  # type: ignore[override]
                 last_err = err
 
         if last_err and last_err.http_status == 400:
-            raise SecuritasDirectError(
-                "This alarm mode is not supported by your panel. "
-                "Check the state mappings in the integration options "
-                "(Settings → Devices & Services → Securitas → Configure).",
-                http_status=400,
-            )
-        raise last_err or SecuritasDirectError(
-            "No supported command found for this panel. "
-            "Check the state mappings in the integration options "
-            "(Settings → Devices & Services → Securitas → Configure).",
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="unsupported_alarm_mode",
+            ) from last_err
+        if last_err:
+            raise last_err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="no_supported_command",
         )
 
     async def _send_single_command(
@@ -557,8 +547,12 @@ class SecuritasAlarm(  # type: ignore[override]
             _LOGGER.error(
                 "Disarm failed for %s: %s", self.installation.number, err.log_detail()
             )
-            self._handle_arm_disarm_error(err, "Error disarming")
+            self._handle_arm_disarm_error(err, "disarm_failed")
             self.async_write_ha_state()
+        except HomeAssistantError:
+            self._state = self._last_state
+            self.async_write_ha_state()
+            raise
         finally:
             self._operation_in_progress = False
 
@@ -602,8 +596,12 @@ class SecuritasAlarm(  # type: ignore[override]
             _LOGGER.error(
                 "Arm failed for %s: %s", self.installation.number, err.log_detail()
             )
-            self._handle_arm_disarm_error(err, "Arming failed")
+            self._handle_arm_disarm_error(err, "arm_failed")
             self.async_write_ha_state()
+        except HomeAssistantError:
+            self._state = self._last_state
+            self.async_write_ha_state()
+            raise
         finally:
             self._operation_in_progress = False
 
@@ -661,20 +659,10 @@ class SecuritasAlarm(  # type: ignore[override]
 
     def _notify_force_arm_expired(self) -> None:
         """Update the persistent notification to indicate force-arm expired."""
-        self.hass.async_create_task(
-            self.hass.services.async_call(
-                domain="persistent_notification",
-                service="create",
-                service_data={
-                    "title": "Securitas: Alarm not armed",
-                    "message": (
-                        "The force-arm option has expired. "
-                        "The alarm was **not armed**. "
-                        "Please try arming again."
-                    ),
-                    "notification_id": self._arming_exception_notification_id,
-                },
-            )
+        _notify(
+            self.hass,
+            f"arming_exception_{self.installation.number}",
+            "force_arm_expired",
         )
 
     @property
@@ -704,6 +692,12 @@ class SecuritasAlarm(  # type: ignore[override]
 
     def _notify_arm_exceptions_from_event(self, event: Event) -> None:
         """Send notifications about arming exceptions from event data."""
+        self.hass.async_create_task(
+            self._async_notify_arm_exceptions(event)
+        )
+
+    async def _async_notify_arm_exceptions(self, event: Event) -> None:
+        """Send translated persistent + mobile notifications for an arming exception."""
         zones = event.data.get("zones", [])
         if zones:
             sensor_list = "\n".join(f"- {z}" for z in zones)
@@ -712,57 +706,58 @@ class SecuritasAlarm(  # type: ignore[override]
             sensor_list = "- (unknown sensor)"
             short_details = "open sensor"
 
-        title = "Securitas: Arm blocked — open sensor(s)"
-        persistent_message = (
-            f"Arming was blocked because the following sensor(s) are open:\n"
-            f"{sensor_list}\n\n"
-            f"To arm anyway, tap **Force Arm** on the alarm card "
-            f"or on your mobile notification."
+        translations = await async_get_translations(
+            self.hass, self.hass.config.language, "notifications", {DOMAIN}
         )
-        mobile_message = f"Arm blocked — open sensor(s): {short_details}. Arm anyway?"
+        base = f"component.{DOMAIN}.notifications.arm_blocked_open_sensors"
+        title = translations.get(f"{base}.title", "")
+        persistent_message = translations.get(f"{base}.message", "").replace(
+            "{sensor_list}", sensor_list
+        )
+        mobile_message = translations.get(f"{base}.mobile_message", "").replace(
+            "{sensor_list}", short_details
+        )
+        force_arm_label = translations.get(f"{base}.force_arm_action", "")
+        cancel_label = translations.get(f"{base}.cancel_action", "")
 
-        self.hass.async_create_task(
-            self.hass.services.async_call(
-                domain="persistent_notification",
-                service="create",
-                service_data={
-                    "title": title,
-                    "message": persistent_message,
-                    "notification_id": self._arming_exception_notification_id,
-                },
-            )
+        await self.hass.services.async_call(
+            domain="persistent_notification",
+            service="create",
+            service_data={
+                "title": title,
+                "message": persistent_message,
+                "notification_id": self._arming_exception_notification_id,
+            },
         )
 
         notify_group = self.client.config.get(CONF_NOTIFY_GROUP)
         if notify_group:
-            self.hass.async_create_task(
-                self.hass.services.async_call(
-                    domain="notify",
-                    service=notify_group,
-                    service_data={
-                        "title": title,
-                        "message": mobile_message,
-                        "data": {
-                            "tag": self._arming_exception_notification_id,
-                            "actions": [
-                                {
-                                    "action": (
-                                        "SECURITAS_FORCE_ARM"
-                                        f"_{self.installation.number}"
-                                    ),
-                                    "title": "Force Arm",
-                                },
-                                {
-                                    "action": (
-                                        "SECURITAS_CANCEL_FORCE_ARM"
-                                        f"_{self.installation.number}"
-                                    ),
-                                    "title": "Cancel",
-                                },
-                            ],
-                        },
+            await self.hass.services.async_call(
+                domain="notify",
+                service=notify_group,
+                service_data={
+                    "title": title,
+                    "message": mobile_message,
+                    "data": {
+                        "tag": self._arming_exception_notification_id,
+                        "actions": [
+                            {
+                                "action": (
+                                    "SECURITAS_FORCE_ARM"
+                                    f"_{self.installation.number}"
+                                ),
+                                "title": force_arm_label,
+                            },
+                            {
+                                "action": (
+                                    "SECURITAS_CANCEL_FORCE_ARM"
+                                    f"_{self.installation.number}"
+                                ),
+                                "title": cancel_label,
+                            },
+                        ],
                     },
-                )
+                },
             )
 
     def _dismiss_arming_exception_notification(self) -> None:

--- a/custom_components/securitas/button.py
+++ b/custom_components/securitas/button.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, SecuritasDirectDevice, SecuritasHub
+from . import DOMAIN, SecuritasDirectDevice, SecuritasHub, _async_notify
 from .entity import SecuritasEntity, camera_device_info
 from .securitas_direct_new_api import (
     Installation,
@@ -98,20 +98,10 @@ class SecuritasRefreshButton(SecuritasEntity, ButtonEntity):
                 err.log_detail(),
             )
             if getattr(err, "http_status", None) == 403:
-                await self.hass.services.async_call(
-                    domain="persistent_notification",
-                    service="create",
-                    service_data={
-                        "title": "Securitas: Rate limited",
-                        "message": (
-                            "Too many requests — blocked by Securitas servers. "
-                            "Please wait a few minutes before trying again."
-                        ),
-                        "notification_id": (
-                            f"{DOMAIN}.securitas_rate_limited_"
-                            f"{self._installation.number}"
-                        ),
-                    },
+                await _async_notify(
+                    self.hass,
+                    f"rate_limited_{self._installation.number}",
+                    "rate_limited",
                 )
                 alarm_entity = self._get_alarm_entity()
                 if alarm_entity is not None:

--- a/custom_components/securitas/entity.py
+++ b/custom_components/securitas/entity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -78,19 +77,3 @@ class SecuritasEntity(Entity):
         if self.hass is not None:
             self.async_schedule_update_ha_state()
 
-    def _notify_error(self, title: str, message: str) -> None:
-        """Send persistent notification with auto-generated ID."""
-        notification_id = re.sub(r"\W+", "_", title.lower()).strip("_")
-        self.hass.async_create_task(
-            self.hass.services.async_call(
-                domain="persistent_notification",
-                service="create",
-                service_data={
-                    "title": title,
-                    "message": message,
-                    "notification_id": (
-                        f"{DOMAIN}.{notification_id}_{self._installation.number}"
-                    ),
-                },
-            )
-        )

--- a/custom_components/securitas/entity.py
+++ b/custom_components/securitas/entity.py
@@ -76,4 +76,3 @@ class SecuritasEntity(Entity):
         self._state = state
         if self.hass is not None:
             self.async_schedule_update_ha_state()
-

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.translation import async_get_translations
 
 from .api_queue import ApiQueue
 from .const import (
@@ -46,20 +47,44 @@ from .securitas_direct_new_api.http_transport import HttpTransport
 _LOGGER = logging.getLogger(__name__)
 
 
-def _notify_error(
-    hass: HomeAssistant, notification_id: str, title: str, message: str
+async def _async_notify(
+    hass: HomeAssistant,
+    notification_id: str,
+    translation_key: str,
+    placeholders: dict[str, str] | None = None,
 ) -> None:
-    """Notify user with persistent notification."""
+    """Send a translated persistent notification."""
+    translations = await async_get_translations(
+        hass, hass.config.language, "notifications", {DOMAIN}
+    )
+    base = f"component.{DOMAIN}.notifications.{translation_key}"
+    title = translations.get(f"{base}.title", "")
+    message = translations.get(f"{base}.message", "")
+    if placeholders:
+        for key, value in placeholders.items():
+            token = "{" + key + "}"
+            title = title.replace(token, str(value))
+            message = message.replace(token, str(value))
+    await hass.services.async_call(
+        domain="persistent_notification",
+        service="create",
+        service_data={
+            "title": title,
+            "message": message,
+            "notification_id": f"{DOMAIN}.{notification_id}",
+        },
+    )
+
+
+def _notify(
+    hass: HomeAssistant,
+    notification_id: str,
+    translation_key: str,
+    placeholders: dict[str, str] | None = None,
+) -> None:
+    """Schedule a translated persistent notification (sync-callable)."""
     hass.async_create_task(
-        hass.services.async_call(
-            domain="persistent_notification",
-            service="create",
-            service_data={
-                "title": title,
-                "message": message,
-                "notification_id": f"{DOMAIN}.{notification_id}",
-            },
-        )
+        _async_notify(hass, notification_id, translation_key, placeholders)
     )
 
 

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.translation import async_get_translations
 
 from .api_queue import ApiQueue
 from .const import (
@@ -29,6 +28,7 @@ from .const import (
     SIGNAL_CAMERA_STATE,
 )
 from .log_filter import SensitiveDataFilter
+from .notification_translations import get_notification_strings
 from .securitas_direct_new_api import (
     ApiDomains,
     CameraDevice,
@@ -54,12 +54,9 @@ async def _async_notify(
     placeholders: dict[str, str] | None = None,
 ) -> None:
     """Send a translated persistent notification."""
-    translations = await async_get_translations(
-        hass, hass.config.language, "notifications", {DOMAIN}
-    )
-    base = f"component.{DOMAIN}.notifications.{translation_key}"
-    title = translations.get(f"{base}.title", "")
-    message = translations.get(f"{base}.message", "")
+    entry = get_notification_strings(hass, translation_key)
+    title = entry.get("title", "")
+    message = entry.get("message", "")
     if placeholders:
         for key, value in placeholders.items():
             token = "{" + key + "}"

--- a/custom_components/securitas/notification_translations.py
+++ b/custom_components/securitas/notification_translations.py
@@ -1,0 +1,429 @@
+"""Translations for persistent notifications and mobile push action labels.
+
+Home Assistant's `strings.json` schema does not include a category for
+persistent-notification titles/messages, so these are stored inline in
+Python instead of `translations/*.json`. The structure intentionally
+mirrors the schema HA uses for translatable categories — each entry has
+`title` and `message`, and some entries have additional fields (e.g.
+`mobile_message`, `force_arm_action`, `cancel_action`) consumed by call
+sites that need them.
+
+Catalan strings use the "Verisure" brand name; all other locales use
+"Securitas"/"Securitas Direct".
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+
+NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
+    "en": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Your Securitas Direct configuration uses an old format. "
+                "Please remove the integration entry and re-add it."
+            ),
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Securitas Direct needs a 2FA verification code. Please log in again."
+            ),
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Could not log in to Securitas Direct: {error}",
+        },
+        "arm_failed": {
+            "title": "Securitas: Arming failed",
+            "message": "{error}",
+        },
+        "disarm_failed": {
+            "title": "Securitas: Disarming failed",
+            "message": "{error}",
+        },
+        "rate_limited": {
+            "title": "Securitas: Rate limited",
+            "message": (
+                "Too many requests — blocked by Securitas servers. "
+                "Please wait a few minutes before trying again."
+            ),
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarm not armed",
+            "message": (
+                "The force-arm option has expired. The alarm was **not armed**. "
+                "Please try arming again."
+            ),
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Arm blocked — open sensor(s)",
+            "message": (
+                "Arming was blocked because the following sensor(s) are open:\n"
+                "{sensor_list}\n\n"
+                "To arm anyway, tap **Force Arm** on the alarm card "
+                "or on your mobile notification."
+            ),
+            "mobile_message": (
+                "Arm blocked — open sensor(s): {sensor_list}. Arm anyway?"
+            ),
+            "force_arm_action": "Force Arm",
+            "cancel_action": "Cancel",
+        },
+    },
+    "es": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Tu configuración de Securitas Direct usa un formato antiguo. "
+                "Por favor, elimina la integración y vuelve a añadirla."
+            ),
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Securitas Direct necesita un código de verificación 2FA. "
+                "Por favor, inicia sesión de nuevo."
+            ),
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "No se pudo iniciar sesión en Securitas Direct: {error}",
+        },
+        "arm_failed": {
+            "title": "Securitas: Error al armar",
+            "message": "{error}",
+        },
+        "disarm_failed": {
+            "title": "Securitas: Error al desarmar",
+            "message": "{error}",
+        },
+        "rate_limited": {
+            "title": "Securitas: Demasiadas solicitudes",
+            "message": (
+                "Demasiadas solicitudes — bloqueado por los servidores de "
+                "Securitas. Espera unos minutos antes de volver a intentarlo."
+            ),
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarma no armada",
+            "message": (
+                "La opción de armado forzado ha expirado. La alarma **no** se "
+                "armó. Por favor, intenta armar de nuevo."
+            ),
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Armado bloqueado — sensor(es) abierto(s)",
+            "message": (
+                "El armado se bloqueó porque los siguientes sensores están "
+                "abiertos:\n{sensor_list}\n\n"
+                "Para armar de todos modos, pulsa **Armar de todos modos** en "
+                "la tarjeta de la alarma o en tu notificación móvil."
+            ),
+            "mobile_message": (
+                "Armado bloqueado — sensor(es) abierto(s): {sensor_list}. "
+                "¿Armar de todos modos?"
+            ),
+            "force_arm_action": "Armar de todos modos",
+            "cancel_action": "Cancelar",
+        },
+    },
+    "fr": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Votre configuration Securitas Direct utilise un ancien format. "
+                "Veuillez supprimer l'intégration et l'ajouter à nouveau."
+            ),
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Securitas Direct a besoin d'un code de vérification 2FA. "
+                "Veuillez vous reconnecter."
+            ),
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Impossible de se connecter à Securitas Direct : {error}",
+        },
+        "arm_failed": {
+            "title": "Securitas : Échec de l'armement",
+            "message": "{error}",
+        },
+        "disarm_failed": {
+            "title": "Securitas : Échec du désarmement",
+            "message": "{error}",
+        },
+        "rate_limited": {
+            "title": "Securitas : Trop de requêtes",
+            "message": (
+                "Trop de requêtes — bloqué par les serveurs Securitas. "
+                "Veuillez patienter quelques minutes avant de réessayer."
+            ),
+        },
+        "force_arm_expired": {
+            "title": "Securitas : Alarme non armée",
+            "message": (
+                "L'option d'armement forcé a expiré. "
+                "L'alarme **n'a pas** été armée. Veuillez réessayer."
+            ),
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas : Armement bloqué — capteur(s) ouvert(s)",
+            "message": (
+                "L'armement a été bloqué car les capteurs suivants sont "
+                "ouverts :\n{sensor_list}\n\n"
+                "Pour armer quand même, appuyez sur **Armer quand même** sur "
+                "la carte d'alarme ou sur votre notification mobile."
+            ),
+            "mobile_message": (
+                "Armement bloqué — capteur(s) ouvert(s) : {sensor_list}. "
+                "Armer quand même ?"
+            ),
+            "force_arm_action": "Armer quand même",
+            "cancel_action": "Annuler",
+        },
+    },
+    "it": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "La tua configurazione Securitas Direct utilizza un formato "
+                "obsoleto. Rimuovi l'integrazione e aggiungila di nuovo."
+            ),
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Securitas Direct richiede un codice di verifica 2FA. "
+                "Effettua di nuovo l'accesso."
+            ),
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Impossibile accedere a Securitas Direct: {error}",
+        },
+        "arm_failed": {
+            "title": "Securitas: Attivazione fallita",
+            "message": "{error}",
+        },
+        "disarm_failed": {
+            "title": "Securitas: Disattivazione fallita",
+            "message": "{error}",
+        },
+        "rate_limited": {
+            "title": "Securitas: Troppe richieste",
+            "message": (
+                "Troppe richieste — bloccato dai server Securitas. "
+                "Attendi alcuni minuti prima di riprovare."
+            ),
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Allarme non attivato",
+            "message": (
+                "L'opzione di attivazione forzata è scaduta. "
+                "L'allarme **non** è stato attivato. Riprova ad attivarlo."
+            ),
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Attivazione bloccata — sensore(i) aperto(i)",
+            "message": (
+                "L'attivazione è stata bloccata perché i seguenti sensori "
+                "sono aperti:\n{sensor_list}\n\n"
+                "Per attivare comunque, tocca **Attiva comunque** sulla card "
+                "dell'allarme o sulla tua notifica mobile."
+            ),
+            "mobile_message": (
+                "Attivazione bloccata — sensore(i) aperto(i): {sensor_list}. "
+                "Attivare comunque?"
+            ),
+            "force_arm_action": "Attiva comunque",
+            "cancel_action": "Annulla",
+        },
+    },
+    "pt": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "A sua configuração do Securitas Direct usa um formato antigo. "
+                "Por favor, remova a integração e adicione-a novamente."
+            ),
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Securitas Direct precisa de um código de verificação 2FA. "
+                "Por favor, inicie sessão novamente."
+            ),
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Não foi possível iniciar sessão no Securitas Direct: {error}",
+        },
+        "arm_failed": {
+            "title": "Securitas: Falha ao armar",
+            "message": "{error}",
+        },
+        "disarm_failed": {
+            "title": "Securitas: Falha ao desarmar",
+            "message": "{error}",
+        },
+        "rate_limited": {
+            "title": "Securitas: Demasiados pedidos",
+            "message": (
+                "Demasiados pedidos — bloqueado pelos servidores Securitas. "
+                "Aguarde alguns minutos antes de tentar novamente."
+            ),
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarme não armado",
+            "message": (
+                "A opção de armar à força expirou. "
+                "O alarme **não** foi armado. Tente armar novamente."
+            ),
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Armar bloqueado — sensor(es) aberto(s)",
+            "message": (
+                "O armar foi bloqueado porque os seguintes sensores estão "
+                "abertos:\n{sensor_list}\n\n"
+                "Para armar na mesma, toque em **Armar na mesma** no cartão "
+                "do alarme ou na sua notificação móvel."
+            ),
+            "mobile_message": (
+                "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. Armar na mesma?"
+            ),
+            "force_arm_action": "Armar na mesma",
+            "cancel_action": "Cancelar",
+        },
+    },
+    "pt-BR": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Sua configuração do Securitas Direct usa um formato antigo. "
+                "Por favor, remova a integração e adicione-a novamente."
+            ),
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": (
+                "Securitas Direct precisa de um código de verificação 2FA. "
+                "Por favor, faça login novamente."
+            ),
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Não foi possível fazer login no Securitas Direct: {error}",
+        },
+        "arm_failed": {
+            "title": "Securitas: Falha ao armar",
+            "message": "{error}",
+        },
+        "disarm_failed": {
+            "title": "Securitas: Falha ao desarmar",
+            "message": "{error}",
+        },
+        "rate_limited": {
+            "title": "Securitas: Limite de requisições",
+            "message": (
+                "Muitas requisições — bloqueado pelos servidores Securitas. "
+                "Aguarde alguns minutos antes de tentar novamente."
+            ),
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarme não armado",
+            "message": (
+                "A opção de forçar armado expirou. "
+                "O alarme **não** foi armado. Tente armar novamente."
+            ),
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Armar bloqueado — sensor(es) aberto(s)",
+            "message": (
+                "Armar foi bloqueado porque os seguintes sensores estão "
+                "abertos:\n{sensor_list}\n\n"
+                "Para armar mesmo assim, toque em **Forçar armado** no cartão "
+                "do alarme ou na sua notificação móvel."
+            ),
+            "mobile_message": (
+                "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. "
+                "Armar mesmo assim?"
+            ),
+            "force_arm_action": "Forçar armado",
+            "cancel_action": "Cancelar",
+        },
+    },
+    "ca": {
+        "migration_required": {
+            "title": "Verisure",
+            "message": (
+                "La teva configuració de Verisure utilitza un format antic. "
+                "Si us plau, elimina la integració i torna-la a afegir."
+            ),
+        },
+        "two_factor_required": {
+            "title": "Verisure",
+            "message": (
+                "Verisure necessita un codi de verificació 2FA. "
+                "Si us plau, torna a iniciar sessió."
+            ),
+        },
+        "login_failed": {
+            "title": "Verisure",
+            "message": "No s'ha pogut iniciar sessió a Verisure: {error}",
+        },
+        "arm_failed": {
+            "title": "Verisure: Error en armar",
+            "message": "{error}",
+        },
+        "disarm_failed": {
+            "title": "Verisure: Error en desarmar",
+            "message": "{error}",
+        },
+        "rate_limited": {
+            "title": "Verisure: Massa peticions",
+            "message": (
+                "Massa peticions — bloquejat pels servidors de Verisure. "
+                "Espera uns minuts abans de tornar a provar."
+            ),
+        },
+        "force_arm_expired": {
+            "title": "Verisure: Alarma no armada",
+            "message": (
+                "L'opció d'armat forçat ha expirat. "
+                "L'alarma **no** s'ha armat. Si us plau, torna a provar a armar."
+            ),
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Verisure: Armat bloquejat — sensor(s) obert(s)",
+            "message": (
+                "L'armat s'ha bloquejat perquè els següents sensors estan "
+                "oberts:\n{sensor_list}\n\n"
+                "Per armar igualment, toca **Forçar armat** a la targeta de "
+                "l'alarma o a la teva notificació mòbil."
+            ),
+            "mobile_message": (
+                "Armat bloquejat — sensor(s) obert(s): {sensor_list}. Armar igualment?"
+            ),
+            "force_arm_action": "Forçar armat",
+            "cancel_action": "Cancel·lar",
+        },
+    },
+}
+
+
+def get_notification_strings(
+    hass: HomeAssistant, translation_key: str
+) -> dict[str, str]:
+    """Return all translated fields for a notification key in the user's language.
+
+    Falls back to English when the user's language is not localized or the
+    key is missing in that locale.
+    """
+    locale = NOTIFICATION_TRANSLATIONS.get(hass.config.language)
+    if locale is None or translation_key not in locale:
+        return NOTIFICATION_TRANSLATIONS["en"].get(translation_key, {})
+    return locale[translation_key]

--- a/custom_components/securitas/strings.json
+++ b/custom_components/securitas/strings.json
@@ -123,9 +123,52 @@
             "description": "Cancel a pending force-arm and dismiss the arming-exception notification."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": "Your Securitas Direct configuration uses an old format. Please remove the integration entry and re-add it."
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": "Securitas Direct needs a 2FA verification code. Please log in again."
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Could not log in to Securitas Direct: {error}"
+        },
+        "arm_failed": {
+            "title": "Securitas: Arming failed",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Securitas: Disarming failed",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Securitas: Rate limited",
+            "message": "Too many requests — blocked by Securitas servers. Please wait a few minutes before trying again."
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarm not armed",
+            "message": "The force-arm option has expired. The alarm was **not armed**. Please try arming again."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Arm blocked — open sensor(s)",
+            "message": "Arming was blocked because the following sensor(s) are open:\n{sensor_list}\n\nTo arm anyway, tap **Force Arm** on the alarm card or on your mobile notification.",
+            "mobile_message": "Arm blocked — open sensor(s): {sensor_list}. Arm anyway?",
+            "force_arm_action": "Force Arm",
+            "cancel_action": "Cancel"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Invalid PIN code for {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "This alarm mode is not supported by your panel. Check the state mappings in the integration options (Settings → Devices & Services → Securitas → Configure)."
+        },
+        "no_supported_command": {
+            "message": "No supported command found for this panel. Check the state mappings in the integration options (Settings → Devices & Services → Securitas → Configure)."
         }
     }
 }

--- a/custom_components/securitas/strings.json
+++ b/custom_components/securitas/strings.json
@@ -123,43 +123,6 @@
             "description": "Cancel a pending force-arm and dismiss the arming-exception notification."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Securitas Direct",
-            "message": "Your Securitas Direct configuration uses an old format. Please remove the integration entry and re-add it."
-        },
-        "two_factor_required": {
-            "title": "Securitas Direct",
-            "message": "Securitas Direct needs a 2FA verification code. Please log in again."
-        },
-        "login_failed": {
-            "title": "Securitas Direct",
-            "message": "Could not log in to Securitas Direct: {error}"
-        },
-        "arm_failed": {
-            "title": "Securitas: Arming failed",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Securitas: Disarming failed",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Securitas: Rate limited",
-            "message": "Too many requests — blocked by Securitas servers. Please wait a few minutes before trying again."
-        },
-        "force_arm_expired": {
-            "title": "Securitas: Alarm not armed",
-            "message": "The force-arm option has expired. The alarm was **not armed**. Please try arming again."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Securitas: Arm blocked — open sensor(s)",
-            "message": "Arming was blocked because the following sensor(s) are open:\n{sensor_list}\n\nTo arm anyway, tap **Force Arm** on the alarm card or on your mobile notification.",
-            "mobile_message": "Arm blocked — open sensor(s): {sensor_list}. Arm anyway?",
-            "force_arm_action": "Force Arm",
-            "cancel_action": "Cancel"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Invalid PIN code for {entity_id}"

--- a/custom_components/securitas/translations/ca.json
+++ b/custom_components/securitas/translations/ca.json
@@ -123,43 +123,6 @@
             "description": "Cancel·la un armat forçat pendent i descarta la notificació d'excepció d'armat."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Verisure",
-            "message": "La teva configuració de Verisure utilitza un format antic. Si us plau, elimina la integració i torna-la a afegir."
-        },
-        "two_factor_required": {
-            "title": "Verisure",
-            "message": "Verisure necessita un codi de verificació 2FA. Si us plau, torna a iniciar sessió."
-        },
-        "login_failed": {
-            "title": "Verisure",
-            "message": "No s'ha pogut iniciar sessió a Verisure: {error}"
-        },
-        "arm_failed": {
-            "title": "Verisure: Error en armar",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Verisure: Error en desarmar",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Verisure: Massa peticions",
-            "message": "Massa peticions — bloquejat pels servidors de Verisure. Espera uns minuts abans de tornar a provar."
-        },
-        "force_arm_expired": {
-            "title": "Verisure: Alarma no armada",
-            "message": "L'opció d'armat forçat ha expirat. L'alarma **no** s'ha armat. Si us plau, torna a provar a armar."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Verisure: Armat bloquejat — sensor(s) obert(s)",
-            "message": "L'armat s'ha bloquejat perquè els següents sensors estan oberts:\n{sensor_list}\n\nPer armar igualment, toca **Forçar armat** a la targeta de l'alarma o a la teva notificació mòbil.",
-            "mobile_message": "Armat bloquejat — sensor(s) obert(s): {sensor_list}. Armar igualment?",
-            "force_arm_action": "Forçar armat",
-            "cancel_action": "Cancel·lar"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Codi PIN no vàlid per a {entity_id}"

--- a/custom_components/securitas/translations/ca.json
+++ b/custom_components/securitas/translations/ca.json
@@ -123,9 +123,52 @@
             "description": "Cancel·la un armat forçat pendent i descarta la notificació d'excepció d'armat."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Verisure",
+            "message": "La teva configuració de Verisure utilitza un format antic. Si us plau, elimina la integració i torna-la a afegir."
+        },
+        "two_factor_required": {
+            "title": "Verisure",
+            "message": "Verisure necessita un codi de verificació 2FA. Si us plau, torna a iniciar sessió."
+        },
+        "login_failed": {
+            "title": "Verisure",
+            "message": "No s'ha pogut iniciar sessió a Verisure: {error}"
+        },
+        "arm_failed": {
+            "title": "Verisure: Error en armar",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Verisure: Error en desarmar",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Verisure: Massa peticions",
+            "message": "Massa peticions — bloquejat pels servidors de Verisure. Espera uns minuts abans de tornar a provar."
+        },
+        "force_arm_expired": {
+            "title": "Verisure: Alarma no armada",
+            "message": "L'opció d'armat forçat ha expirat. L'alarma **no** s'ha armat. Si us plau, torna a provar a armar."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Verisure: Armat bloquejat — sensor(s) obert(s)",
+            "message": "L'armat s'ha bloquejat perquè els següents sensors estan oberts:\n{sensor_list}\n\nPer armar igualment, toca **Forçar armat** a la targeta de l'alarma o a la teva notificació mòbil.",
+            "mobile_message": "Armat bloquejat — sensor(s) obert(s): {sensor_list}. Armar igualment?",
+            "force_arm_action": "Forçar armat",
+            "cancel_action": "Cancel·lar"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Codi PIN no vàlid per a {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "Aquest mode d'alarma no és compatible amb el teu panell. Revisa les assignacions d'estat a les opcions de la integració (Configuració → Dispositius i serveis → Verisure → Configurar)."
+        },
+        "no_supported_command": {
+            "message": "No s'ha trobat cap ordre compatible per a aquest panell. Revisa les assignacions d'estat a les opcions de la integració (Configuració → Dispositius i serveis → Verisure → Configurar)."
         }
     }
 }

--- a/custom_components/securitas/translations/en.json
+++ b/custom_components/securitas/translations/en.json
@@ -123,9 +123,52 @@
             "description": "Cancel a pending force-arm and dismiss the arming-exception notification."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": "Your Securitas Direct configuration uses an old format. Please remove the integration entry and re-add it."
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": "Securitas Direct needs a 2FA verification code. Please log in again."
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Could not log in to Securitas Direct: {error}"
+        },
+        "arm_failed": {
+            "title": "Securitas: Arming failed",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Securitas: Disarming failed",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Securitas: Rate limited",
+            "message": "Too many requests — blocked by Securitas servers. Please wait a few minutes before trying again."
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarm not armed",
+            "message": "The force-arm option has expired. The alarm was **not armed**. Please try arming again."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Arm blocked — open sensor(s)",
+            "message": "Arming was blocked because the following sensor(s) are open:\n{sensor_list}\n\nTo arm anyway, tap **Force Arm** on the alarm card or on your mobile notification.",
+            "mobile_message": "Arm blocked — open sensor(s): {sensor_list}. Arm anyway?",
+            "force_arm_action": "Force Arm",
+            "cancel_action": "Cancel"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Invalid PIN code for {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "This alarm mode is not supported by your panel. Check the state mappings in the integration options (Settings → Devices & Services → Securitas → Configure)."
+        },
+        "no_supported_command": {
+            "message": "No supported command found for this panel. Check the state mappings in the integration options (Settings → Devices & Services → Securitas → Configure)."
         }
     }
 }

--- a/custom_components/securitas/translations/en.json
+++ b/custom_components/securitas/translations/en.json
@@ -123,43 +123,6 @@
             "description": "Cancel a pending force-arm and dismiss the arming-exception notification."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Securitas Direct",
-            "message": "Your Securitas Direct configuration uses an old format. Please remove the integration entry and re-add it."
-        },
-        "two_factor_required": {
-            "title": "Securitas Direct",
-            "message": "Securitas Direct needs a 2FA verification code. Please log in again."
-        },
-        "login_failed": {
-            "title": "Securitas Direct",
-            "message": "Could not log in to Securitas Direct: {error}"
-        },
-        "arm_failed": {
-            "title": "Securitas: Arming failed",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Securitas: Disarming failed",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Securitas: Rate limited",
-            "message": "Too many requests — blocked by Securitas servers. Please wait a few minutes before trying again."
-        },
-        "force_arm_expired": {
-            "title": "Securitas: Alarm not armed",
-            "message": "The force-arm option has expired. The alarm was **not armed**. Please try arming again."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Securitas: Arm blocked — open sensor(s)",
-            "message": "Arming was blocked because the following sensor(s) are open:\n{sensor_list}\n\nTo arm anyway, tap **Force Arm** on the alarm card or on your mobile notification.",
-            "mobile_message": "Arm blocked — open sensor(s): {sensor_list}. Arm anyway?",
-            "force_arm_action": "Force Arm",
-            "cancel_action": "Cancel"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Invalid PIN code for {entity_id}"

--- a/custom_components/securitas/translations/es.json
+++ b/custom_components/securitas/translations/es.json
@@ -123,43 +123,6 @@
             "description": "Cancelar un armado forzado pendiente y descartar la notificación de excepción de armado."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Securitas Direct",
-            "message": "Tu configuración de Securitas Direct usa un formato antiguo. Por favor, elimina la integración y vuelve a añadirla."
-        },
-        "two_factor_required": {
-            "title": "Securitas Direct",
-            "message": "Securitas Direct necesita un código de verificación 2FA. Por favor, inicia sesión de nuevo."
-        },
-        "login_failed": {
-            "title": "Securitas Direct",
-            "message": "No se pudo iniciar sesión en Securitas Direct: {error}"
-        },
-        "arm_failed": {
-            "title": "Securitas: Error al armar",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Securitas: Error al desarmar",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Securitas: Demasiadas solicitudes",
-            "message": "Demasiadas solicitudes — bloqueado por los servidores de Securitas. Espera unos minutos antes de volver a intentarlo."
-        },
-        "force_arm_expired": {
-            "title": "Securitas: Alarma no armada",
-            "message": "La opción de armado forzado ha expirado. La alarma **no** se armó. Por favor, intenta armar de nuevo."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Securitas: Armado bloqueado — sensor(es) abierto(s)",
-            "message": "El armado se bloqueó porque los siguientes sensores están abiertos:\n{sensor_list}\n\nPara armar de todos modos, pulsa **Armar de todos modos** en la tarjeta de la alarma o en tu notificación móvil.",
-            "mobile_message": "Armado bloqueado — sensor(es) abierto(s): {sensor_list}. ¿Armar de todos modos?",
-            "force_arm_action": "Armar de todos modos",
-            "cancel_action": "Cancelar"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Código PIN no válido para {entity_id}"

--- a/custom_components/securitas/translations/es.json
+++ b/custom_components/securitas/translations/es.json
@@ -123,9 +123,52 @@
             "description": "Cancelar un armado forzado pendiente y descartar la notificación de excepción de armado."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": "Tu configuración de Securitas Direct usa un formato antiguo. Por favor, elimina la integración y vuelve a añadirla."
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": "Securitas Direct necesita un código de verificación 2FA. Por favor, inicia sesión de nuevo."
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "No se pudo iniciar sesión en Securitas Direct: {error}"
+        },
+        "arm_failed": {
+            "title": "Securitas: Error al armar",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Securitas: Error al desarmar",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Securitas: Demasiadas solicitudes",
+            "message": "Demasiadas solicitudes — bloqueado por los servidores de Securitas. Espera unos minutos antes de volver a intentarlo."
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarma no armada",
+            "message": "La opción de armado forzado ha expirado. La alarma **no** se armó. Por favor, intenta armar de nuevo."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Armado bloqueado — sensor(es) abierto(s)",
+            "message": "El armado se bloqueó porque los siguientes sensores están abiertos:\n{sensor_list}\n\nPara armar de todos modos, pulsa **Armar de todos modos** en la tarjeta de la alarma o en tu notificación móvil.",
+            "mobile_message": "Armado bloqueado — sensor(es) abierto(s): {sensor_list}. ¿Armar de todos modos?",
+            "force_arm_action": "Armar de todos modos",
+            "cancel_action": "Cancelar"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Código PIN no válido para {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "Este modo de alarma no es compatible con tu panel. Revisa las asignaciones de estado en las opciones de la integración (Configuración → Dispositivos y servicios → Securitas → Configurar)."
+        },
+        "no_supported_command": {
+            "message": "No se encontró un comando compatible para este panel. Revisa las asignaciones de estado en las opciones de la integración (Configuración → Dispositivos y servicios → Securitas → Configurar)."
         }
     }
 }

--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -123,9 +123,52 @@
             "description": "Annuler un armement forcé en attente et fermer la notification d'exception d'armement."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": "Votre configuration Securitas Direct utilise un ancien format. Veuillez supprimer l'intégration et l'ajouter à nouveau."
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": "Securitas Direct a besoin d'un code de vérification 2FA. Veuillez vous reconnecter."
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Impossible de se connecter à Securitas Direct : {error}"
+        },
+        "arm_failed": {
+            "title": "Securitas : Échec de l'armement",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Securitas : Échec du désarmement",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Securitas : Trop de requêtes",
+            "message": "Trop de requêtes — bloqué par les serveurs Securitas. Veuillez patienter quelques minutes avant de réessayer."
+        },
+        "force_arm_expired": {
+            "title": "Securitas : Alarme non armée",
+            "message": "L'option d'armement forcé a expiré. L'alarme **n'a pas** été armée. Veuillez réessayer."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas : Armement bloqué — capteur(s) ouvert(s)",
+            "message": "L'armement a été bloqué car les capteurs suivants sont ouverts :\n{sensor_list}\n\nPour armer quand même, appuyez sur **Armer quand même** sur la carte d'alarme ou sur votre notification mobile.",
+            "mobile_message": "Armement bloqué — capteur(s) ouvert(s) : {sensor_list}. Armer quand même ?",
+            "force_arm_action": "Armer quand même",
+            "cancel_action": "Annuler"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Code PIN non valide pour {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "Ce mode d'alarme n'est pas pris en charge par votre panneau. Vérifiez les correspondances d'états dans les options de l'intégration (Paramètres → Appareils et services → Securitas → Configurer)."
+        },
+        "no_supported_command": {
+            "message": "Aucune commande compatible trouvée pour ce panneau. Vérifiez les correspondances d'états dans les options de l'intégration (Paramètres → Appareils et services → Securitas → Configurer)."
         }
     }
 }

--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -123,43 +123,6 @@
             "description": "Annuler un armement forcé en attente et fermer la notification d'exception d'armement."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Securitas Direct",
-            "message": "Votre configuration Securitas Direct utilise un ancien format. Veuillez supprimer l'intégration et l'ajouter à nouveau."
-        },
-        "two_factor_required": {
-            "title": "Securitas Direct",
-            "message": "Securitas Direct a besoin d'un code de vérification 2FA. Veuillez vous reconnecter."
-        },
-        "login_failed": {
-            "title": "Securitas Direct",
-            "message": "Impossible de se connecter à Securitas Direct : {error}"
-        },
-        "arm_failed": {
-            "title": "Securitas : Échec de l'armement",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Securitas : Échec du désarmement",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Securitas : Trop de requêtes",
-            "message": "Trop de requêtes — bloqué par les serveurs Securitas. Veuillez patienter quelques minutes avant de réessayer."
-        },
-        "force_arm_expired": {
-            "title": "Securitas : Alarme non armée",
-            "message": "L'option d'armement forcé a expiré. L'alarme **n'a pas** été armée. Veuillez réessayer."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Securitas : Armement bloqué — capteur(s) ouvert(s)",
-            "message": "L'armement a été bloqué car les capteurs suivants sont ouverts :\n{sensor_list}\n\nPour armer quand même, appuyez sur **Armer quand même** sur la carte d'alarme ou sur votre notification mobile.",
-            "mobile_message": "Armement bloqué — capteur(s) ouvert(s) : {sensor_list}. Armer quand même ?",
-            "force_arm_action": "Armer quand même",
-            "cancel_action": "Annuler"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Code PIN non valide pour {entity_id}"

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -123,43 +123,6 @@
             "description": "Annullare un'attivazione forzata in sospeso e chiudere la notifica di eccezione di attivazione."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Securitas Direct",
-            "message": "La tua configurazione Securitas Direct utilizza un formato obsoleto. Rimuovi l'integrazione e aggiungila di nuovo."
-        },
-        "two_factor_required": {
-            "title": "Securitas Direct",
-            "message": "Securitas Direct richiede un codice di verifica 2FA. Effettua di nuovo l'accesso."
-        },
-        "login_failed": {
-            "title": "Securitas Direct",
-            "message": "Impossibile accedere a Securitas Direct: {error}"
-        },
-        "arm_failed": {
-            "title": "Securitas: Attivazione fallita",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Securitas: Disattivazione fallita",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Securitas: Troppe richieste",
-            "message": "Troppe richieste — bloccato dai server Securitas. Attendi alcuni minuti prima di riprovare."
-        },
-        "force_arm_expired": {
-            "title": "Securitas: Allarme non attivato",
-            "message": "L'opzione di attivazione forzata è scaduta. L'allarme **non** è stato attivato. Riprova ad attivarlo."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Securitas: Attivazione bloccata — sensore(i) aperto(i)",
-            "message": "L'attivazione è stata bloccata perché i seguenti sensori sono aperti:\n{sensor_list}\n\nPer attivare comunque, tocca **Attiva comunque** sulla card dell'allarme o sulla tua notifica mobile.",
-            "mobile_message": "Attivazione bloccata — sensore(i) aperto(i): {sensor_list}. Attivare comunque?",
-            "force_arm_action": "Attiva comunque",
-            "cancel_action": "Annulla"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Codice PIN non valido per {entity_id}"

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -123,9 +123,52 @@
             "description": "Annullare un'attivazione forzata in sospeso e chiudere la notifica di eccezione di attivazione."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": "La tua configurazione Securitas Direct utilizza un formato obsoleto. Rimuovi l'integrazione e aggiungila di nuovo."
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": "Securitas Direct richiede un codice di verifica 2FA. Effettua di nuovo l'accesso."
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Impossibile accedere a Securitas Direct: {error}"
+        },
+        "arm_failed": {
+            "title": "Securitas: Attivazione fallita",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Securitas: Disattivazione fallita",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Securitas: Troppe richieste",
+            "message": "Troppe richieste — bloccato dai server Securitas. Attendi alcuni minuti prima di riprovare."
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Allarme non attivato",
+            "message": "L'opzione di attivazione forzata è scaduta. L'allarme **non** è stato attivato. Riprova ad attivarlo."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Attivazione bloccata — sensore(i) aperto(i)",
+            "message": "L'attivazione è stata bloccata perché i seguenti sensori sono aperti:\n{sensor_list}\n\nPer attivare comunque, tocca **Attiva comunque** sulla card dell'allarme o sulla tua notifica mobile.",
+            "mobile_message": "Attivazione bloccata — sensore(i) aperto(i): {sensor_list}. Attivare comunque?",
+            "force_arm_action": "Attiva comunque",
+            "cancel_action": "Annulla"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Codice PIN non valido per {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "Questa modalità di allarme non è supportata dal tuo pannello. Controlla le mappature degli stati nelle opzioni dell'integrazione (Impostazioni → Dispositivi e servizi → Securitas → Configura)."
+        },
+        "no_supported_command": {
+            "message": "Nessun comando compatibile trovato per questo pannello. Controlla le mappature degli stati nelle opzioni dell'integrazione (Impostazioni → Dispositivi e servizi → Securitas → Configura)."
         }
     }
 }

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -123,43 +123,6 @@
             "description": "Cancelar um armar forçado pendente e dispensar a notificação de exceção de armação."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Securitas Direct",
-            "message": "Sua configuração do Securitas Direct usa um formato antigo. Por favor, remova a integração e adicione-a novamente."
-        },
-        "two_factor_required": {
-            "title": "Securitas Direct",
-            "message": "Securitas Direct precisa de um código de verificação 2FA. Por favor, faça login novamente."
-        },
-        "login_failed": {
-            "title": "Securitas Direct",
-            "message": "Não foi possível fazer login no Securitas Direct: {error}"
-        },
-        "arm_failed": {
-            "title": "Securitas: Falha ao armar",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Securitas: Falha ao desarmar",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Securitas: Limite de requisições",
-            "message": "Muitas requisições — bloqueado pelos servidores Securitas. Aguarde alguns minutos antes de tentar novamente."
-        },
-        "force_arm_expired": {
-            "title": "Securitas: Alarme não armado",
-            "message": "A opção de forçar armado expirou. O alarme **não** foi armado. Tente armar novamente."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Securitas: Armar bloqueado — sensor(es) aberto(s)",
-            "message": "Armar foi bloqueado porque os seguintes sensores estão abertos:\n{sensor_list}\n\nPara armar mesmo assim, toque em **Forçar armado** no cartão do alarme ou na sua notificação móvel.",
-            "mobile_message": "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. Armar mesmo assim?",
-            "force_arm_action": "Forçar armado",
-            "cancel_action": "Cancelar"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Código PIN inválido para {entity_id}"

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -123,9 +123,52 @@
             "description": "Cancelar um armar forçado pendente e dispensar a notificação de exceção de armação."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": "Sua configuração do Securitas Direct usa um formato antigo. Por favor, remova a integração e adicione-a novamente."
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": "Securitas Direct precisa de um código de verificação 2FA. Por favor, faça login novamente."
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Não foi possível fazer login no Securitas Direct: {error}"
+        },
+        "arm_failed": {
+            "title": "Securitas: Falha ao armar",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Securitas: Falha ao desarmar",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Securitas: Limite de requisições",
+            "message": "Muitas requisições — bloqueado pelos servidores Securitas. Aguarde alguns minutos antes de tentar novamente."
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarme não armado",
+            "message": "A opção de forçar armado expirou. O alarme **não** foi armado. Tente armar novamente."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Armar bloqueado — sensor(es) aberto(s)",
+            "message": "Armar foi bloqueado porque os seguintes sensores estão abertos:\n{sensor_list}\n\nPara armar mesmo assim, toque em **Forçar armado** no cartão do alarme ou na sua notificação móvel.",
+            "mobile_message": "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. Armar mesmo assim?",
+            "force_arm_action": "Forçar armado",
+            "cancel_action": "Cancelar"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Código PIN inválido para {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "Este modo de alarme não é suportado pelo seu painel. Verifique os mapeamentos de estado nas opções da integração (Configurações → Dispositivos e Serviços → Securitas → Configurar)."
+        },
+        "no_supported_command": {
+            "message": "Nenhum comando compatível encontrado para este painel. Verifique os mapeamentos de estado nas opções da integração (Configurações → Dispositivos e Serviços → Securitas → Configurar)."
         }
     }
 }

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -123,43 +123,6 @@
             "description": "Cancelar um armar forçado pendente e dispensar a notificação de exceção de armação."
         }
     },
-    "notifications": {
-        "migration_required": {
-            "title": "Securitas Direct",
-            "message": "A sua configuração do Securitas Direct usa um formato antigo. Por favor, remova a integração e adicione-a novamente."
-        },
-        "two_factor_required": {
-            "title": "Securitas Direct",
-            "message": "Securitas Direct precisa de um código de verificação 2FA. Por favor, inicie sessão novamente."
-        },
-        "login_failed": {
-            "title": "Securitas Direct",
-            "message": "Não foi possível iniciar sessão no Securitas Direct: {error}"
-        },
-        "arm_failed": {
-            "title": "Securitas: Falha ao armar",
-            "message": "{error}"
-        },
-        "disarm_failed": {
-            "title": "Securitas: Falha ao desarmar",
-            "message": "{error}"
-        },
-        "rate_limited": {
-            "title": "Securitas: Demasiados pedidos",
-            "message": "Demasiados pedidos — bloqueado pelos servidores Securitas. Aguarde alguns minutos antes de tentar novamente."
-        },
-        "force_arm_expired": {
-            "title": "Securitas: Alarme não armado",
-            "message": "A opção de armar à força expirou. O alarme **não** foi armado. Tente armar novamente."
-        },
-        "arm_blocked_open_sensors": {
-            "title": "Securitas: Armar bloqueado — sensor(es) aberto(s)",
-            "message": "O armar foi bloqueado porque os seguintes sensores estão abertos:\n{sensor_list}\n\nPara armar na mesma, toque em **Armar na mesma** no cartão do alarme ou na sua notificação móvel.",
-            "mobile_message": "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. Armar na mesma?",
-            "force_arm_action": "Armar na mesma",
-            "cancel_action": "Cancelar"
-        }
-    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Código PIN inválido para {entity_id}"

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -123,9 +123,52 @@
             "description": "Cancelar um armar forçado pendente e dispensar a notificação de exceção de armação."
         }
     },
+    "notifications": {
+        "migration_required": {
+            "title": "Securitas Direct",
+            "message": "A sua configuração do Securitas Direct usa um formato antigo. Por favor, remova a integração e adicione-a novamente."
+        },
+        "two_factor_required": {
+            "title": "Securitas Direct",
+            "message": "Securitas Direct precisa de um código de verificação 2FA. Por favor, inicie sessão novamente."
+        },
+        "login_failed": {
+            "title": "Securitas Direct",
+            "message": "Não foi possível iniciar sessão no Securitas Direct: {error}"
+        },
+        "arm_failed": {
+            "title": "Securitas: Falha ao armar",
+            "message": "{error}"
+        },
+        "disarm_failed": {
+            "title": "Securitas: Falha ao desarmar",
+            "message": "{error}"
+        },
+        "rate_limited": {
+            "title": "Securitas: Demasiados pedidos",
+            "message": "Demasiados pedidos — bloqueado pelos servidores Securitas. Aguarde alguns minutos antes de tentar novamente."
+        },
+        "force_arm_expired": {
+            "title": "Securitas: Alarme não armado",
+            "message": "A opção de armar à força expirou. O alarme **não** foi armado. Tente armar novamente."
+        },
+        "arm_blocked_open_sensors": {
+            "title": "Securitas: Armar bloqueado — sensor(es) aberto(s)",
+            "message": "O armar foi bloqueado porque os seguintes sensores estão abertos:\n{sensor_list}\n\nPara armar na mesma, toque em **Armar na mesma** no cartão do alarme ou na sua notificação móvel.",
+            "mobile_message": "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. Armar na mesma?",
+            "force_arm_action": "Armar na mesma",
+            "cancel_action": "Cancelar"
+        }
+    },
     "exceptions": {
         "invalid_pin_code": {
             "message": "Código PIN inválido para {entity_id}"
+        },
+        "unsupported_alarm_mode": {
+            "message": "Este modo de alarme não é suportado pelo seu painel. Verifique os mapeamentos de estado nas opções da integração (Definições → Dispositivos e Serviços → Securitas → Configurar)."
+        },
+        "no_supported_command": {
+            "message": "Nenhum comando compatível encontrado para este painel. Verifique os mapeamentos de estado nas opções da integração (Definições → Dispositivos e Serviços → Securitas → Configurar)."
         }
     }
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -137,10 +137,49 @@ const TRANSLATIONS = {
     card_name: "Cart\u00e3o de Alarme Securitas",
     card_description: "Cart\u00e3o de alarme Securitas Direct: modos de armar, PIN e armamento for\u00e7ado.",
   },
+  "pt-BR": {
+    disarmed: "Desarmado", armed_away: "Armado (ausente)", armed_home: "Armado (em casa)",
+    armed_night: "Armado (noite)", armed_vacation: "Armado (f\u00e9rias)",
+    armed_custom: "Armado (personalizado)",
+    arming: "Armando\u2026", pending: "Pendente", triggered: "DISPARADO",
+    unavailable: "Indispon\u00edvel", unknown: "Desconhecido",
+    arm_away: "Armar ausente", arm_home: "Armar em casa", arm_night: "Armar noite",
+    arm_vacation: "Armar f\u00e9rias", arm_custom: "Armar personalizado", disarm: "Desarmar",
+    force_arm: "For\u00e7ar armado", cancel: "Cancelar",
+    open_sensors: "Sensor(es) aberto(s) \u2014 armar mesmo assim?",
+    enter_pin: "Digite o PIN para {action}", enter_code: "Digite o c\u00f3digo para {action}",
+    code: "C\u00f3digo", confirm: "Confirmar",
+    refresh: "Atualizar status",
+    waf_blocked: "Bloqueado pelos servidores da Securitas. Aguarde alguns minutos.",
+    refresh_failed: "A atualiza\u00e7\u00e3o expirou \u2014 os dados podem estar desatualizados.",
+    entity_not_found: "Entidade n\u00e3o encontrada: {entity}",
+    editor_entity: "Entidade", editor_select: "\u2014 Selecionar painel de alarme \u2014",
+    editor_name: "Nome (opcional)", editor_name_placeholder: "Substituir nome",
+    card_name: "Cart\u00e3o de Alarme Securitas",
+    card_description: "Cart\u00e3o de alarme Securitas Direct: modos de armar, PIN e armado for\u00e7ado.",
+  },
+  ca: {
+    disarmed: "Desarmat", armed_away: "Armat (fora)", armed_home: "Armat (casa)",
+    armed_night: "Armat (nit)", armed_vacation: "Armat (vacances)",
+    armed_custom: "Armat (personalitzat)",
+    arming: "Armant\u2026", pending: "Pendent", triggered: "ACTIVADA",
+    unavailable: "No disponible", unknown: "Desconegut",
+    arm_away: "Armar fora", arm_home: "Armar casa", arm_night: "Armar nit",
+    arm_vacation: "Armar vacances", arm_custom: "Armar personalitzat", disarm: "Desarmar",
+    force_arm: "For\u00e7a l\u2019armat", cancel: "Cancel\u00b7la",
+    open_sensors: "Sensor(s) obert(s) \u2014 armar igualment?",
+    enter_pin: "Introdu\u00efu PIN per {action}", enter_code: "Introdu\u00efu codi per {action}",
+    code: "Codi", confirm: "Confirma",
+    refresh: "Actualitza l\u2019estat",
+    waf_blocked: "Bloquejat pels servidors de Verisure. Espereu uns minuts.",
+    refresh_failed: "L\u2019actualitzaci\u00f3 ha caducat \u2014 les dades poden estar desactualitzades.",
+    entity_not_found: "Entitat no trobada: {entity}",
+    editor_entity: "Entitat", editor_select: "\u2014 Seleccioneu el panell d\u2019alarma \u2014",
+    editor_name: "Nom (opcional)", editor_name_placeholder: "Sobreescriu el nom",
+    card_name: "Targeta d\u2019Alarma Verisure",
+    card_description: "Targeta d\u2019alarma per a Verisure: modes d\u2019armat, PIN i armat for\u00e7at.",
+  },
 };
-
-// pt-BR falls back to pt
-TRANSLATIONS["pt-BR"] = TRANSLATIONS.pt;
 
 function _t(lang, key, vars) {
   const l = TRANSLATIONS[lang] || TRANSLATIONS[lang?.split("-")[0]] || TRANSLATIONS.en;

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -14,6 +14,102 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
+// ── Translations ──────────────────────────────────────────────────────────────
+
+const TRANSLATIONS = {
+  en: {
+    editor_entity: "Entity",
+    editor_name: "Name",
+    editor_name_placeholder: "Override friendly name",
+    entity_not_found: "Entity not found: {entity}",
+    ago_seconds: "{n}s ago",
+    ago_minutes: "{n} min ago",
+    ago_hours: "{n}h ago",
+    ago_days: "{n}d ago",
+    card_name: "Securitas Camera Card",
+    card_description: "Displays a Securitas Direct camera image with capture trigger and timestamp.",
+  },
+  es: {
+    editor_entity: "Entidad",
+    editor_name: "Nombre",
+    editor_name_placeholder: "Nombre personalizado",
+    entity_not_found: "Entidad no encontrada: {entity}",
+    ago_seconds: "hace {n}s",
+    ago_minutes: "hace {n} min",
+    ago_hours: "hace {n}h",
+    ago_days: "hace {n}d",
+    card_name: "Tarjeta de Cámara Securitas",
+    card_description: "Muestra la imagen de una cámara Securitas Direct con captura y marca de tiempo.",
+  },
+  fr: {
+    editor_entity: "Entité",
+    editor_name: "Nom",
+    editor_name_placeholder: "Remplacer le nom",
+    entity_not_found: "Entité introuvable : {entity}",
+    ago_seconds: "il y a {n}s",
+    ago_minutes: "il y a {n} min",
+    ago_hours: "il y a {n}h",
+    ago_days: "il y a {n}j",
+    card_name: "Carte Caméra Securitas",
+    card_description: "Affiche l’image d’une caméra Securitas Direct avec capture et horodatage.",
+  },
+  it: {
+    editor_entity: "Entità",
+    editor_name: "Nome",
+    editor_name_placeholder: "Nome personalizzato",
+    entity_not_found: "Entità non trovata: {entity}",
+    ago_seconds: "{n}s fa",
+    ago_minutes: "{n} min fa",
+    ago_hours: "{n}h fa",
+    ago_days: "{n}g fa",
+    card_name: "Scheda Camera Securitas",
+    card_description: "Mostra l’immagine di una camera Securitas Direct con cattura e timestamp.",
+  },
+  pt: {
+    editor_entity: "Entidade",
+    editor_name: "Nome",
+    editor_name_placeholder: "Nome personalizado",
+    entity_not_found: "Entidade não encontrada: {entity}",
+    ago_seconds: "há {n}s",
+    ago_minutes: "há {n} min",
+    ago_hours: "há {n}h",
+    ago_days: "há {n}d",
+    card_name: "Cartão de Câmara Securitas",
+    card_description: "Mostra a imagem de uma câmara Securitas Direct com captura e marca temporal.",
+  },
+  "pt-BR": {
+    editor_entity: "Entidade",
+    editor_name: "Nome",
+    editor_name_placeholder: "Substituir nome",
+    entity_not_found: "Entidade não encontrada: {entity}",
+    ago_seconds: "{n}s atrás",
+    ago_minutes: "{n} min atrás",
+    ago_hours: "{n}h atrás",
+    ago_days: "{n}d atrás",
+    card_name: "Cartão de Câmera Securitas",
+    card_description: "Exibe a imagem de uma câmera Securitas Direct com captura e marca de tempo.",
+  },
+  ca: {
+    editor_entity: "Entitat",
+    editor_name: "Nom",
+    editor_name_placeholder: "Sobreescriu el nom",
+    entity_not_found: "Entitat no trobada: {entity}",
+    ago_seconds: "fa {n}s",
+    ago_minutes: "fa {n} min",
+    ago_hours: "fa {n}h",
+    ago_days: "fa {n}d",
+    card_name: "Targeta de Càmera Verisure",
+    card_description: "Mostra la imatge d’una càmera Verisure amb captura i marca de temps.",
+  },
+};
+
+function _t(lang, key, vars) {
+  const l = TRANSLATIONS[lang] || TRANSLATIONS[lang?.split("-")[0]] || TRANSLATIONS.en;
+  let s = l[key] || TRANSLATIONS.en[key] || key;
+  if (vars) Object.entries(vars).forEach(([k, v]) => { s = s.replace(`{${k}}`, v); });
+  return s;
+}
+
 // ── Utilities ─────────────────────────────────────────────────────────────────
 
 function _escHtml(str) {
@@ -56,6 +152,7 @@ class SecuritasCameraCardEditor extends HTMLElement {
   }
 
   _render() {
+    const lang = this._hass?.language || "en";
     this.shadowRoot.innerHTML = `
       <style>
         .editor { padding: 16px; display: flex; flex-direction: column; gap: 8px; }
@@ -73,7 +170,7 @@ class SecuritasCameraCardEditor extends HTMLElement {
     entityForm.schema = [
       { name: "entity", selector: { entity: { domain: "camera" } } },
     ];
-    entityForm.computeLabel = () => "Entity";
+    entityForm.computeLabel = () => _t(lang, "editor_entity");
     entityForm.addEventListener("value-changed", (e) => {
       const newEntity = e.detail.value?.entity;
       if (newEntity !== undefined) {
@@ -84,9 +181,9 @@ class SecuritasCameraCardEditor extends HTMLElement {
 
     // Name field — ha-textfield with input event (no value-changed → no re-render cycle)
     const nameTf = document.createElement("ha-textfield");
-    nameTf.label = "Name";
+    nameTf.label = _t(lang, "editor_name");
     nameTf.value = this._config.name || "";
-    nameTf.placeholder = "Override friendly name";
+    nameTf.placeholder = _t(lang, "editor_name_placeholder");
     nameTf.addEventListener("input", (e) => {
       const val = e.target.value;
       if (val.trim()) {
@@ -146,13 +243,14 @@ class SecuritasCameraCard extends HTMLElement {
 
   _render() {
     const entityId = this._config.entity;
+    const lang = this._hass?.language || "en";
     const stateObj = this._hass?.states[entityId];
 
     if (!stateObj) {
       this.shadowRoot.innerHTML = `
       <ha-card>
         <div style="padding:16px;color:var(--error-color)">
-          Entity not found: ${_escHtml(entityId)}
+          ${_escHtml(_t(lang, "entity_not_found", { entity: entityId }))}
         </div>
       </ha-card>`;
       return;
@@ -169,7 +267,7 @@ class SecuritasCameraCard extends HTMLElement {
       : null;
     const name = this._config.name || deviceName || stateObj.attributes.friendly_name || entityId;
     const timestamp = stateObj.attributes.image_timestamp;
-    const { relative, absolute } = this._formatTimestamp(timestamp);
+    const { relative, absolute } = this._formatTimestamp(timestamp, lang);
     const hasCapture = !!this._captureEntityId;
     // Only use the full entity if it has a real image (non-null timestamp).
     // PIR cameras may not support full-resolution images.
@@ -270,19 +368,19 @@ class SecuritasCameraCard extends HTMLElement {
     }
   }
 
-  _formatTimestamp(timestamp) {
+  _formatTimestamp(timestamp, lang) {
     if (!timestamp) return { relative: "", absolute: "" };
     const date = new Date(timestamp);
     if (isNaN(date.getTime())) return { relative: timestamp, absolute: timestamp };
-    const absolute = date.toLocaleString();
+    const absolute = date.toLocaleString(lang);
     const diffMs = Date.now() - date.getTime();
     const diffSec = Math.round(diffMs / 1000);
-    if (diffSec < 60) return { relative: `${diffSec}s ago`, absolute };
+    if (diffSec < 60) return { relative: _t(lang, "ago_seconds", { n: diffSec }), absolute };
     const diffMin = Math.round(diffSec / 60);
-    if (diffMin < 60) return { relative: `${diffMin} min ago`, absolute };
+    if (diffMin < 60) return { relative: _t(lang, "ago_minutes", { n: diffMin }), absolute };
     const diffHr = Math.round(diffMin / 60);
-    if (diffHr < 24) return { relative: `${diffHr}h ago`, absolute };
-    return { relative: `${Math.round(diffHr / 24)}d ago`, absolute };
+    if (diffHr < 24) return { relative: _t(lang, "ago_hours", { n: diffHr }), absolute };
+    return { relative: _t(lang, "ago_days", { n: Math.round(diffHr / 24) }), absolute };
   }
 
   _openMoreInfo(entityId) {
@@ -369,8 +467,8 @@ window.customCards = window.customCards || [];
 if (!window.customCards.find(c => c.type === "securitas-camera-card")) {
   window.customCards.push({
     type: "securitas-camera-card",
-    name: "Securitas Camera Card",
-    description: "Displays a Securitas Direct camera image with capture trigger and timestamp.",
+    name: TRANSLATIONS.en.card_name,
+    description: TRANSLATIONS.en.card_description,
     preview: false,
   });
 }

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2902,20 +2902,12 @@ class TestLastProtoCode:
 # ===========================================================================
 
 
-_FAKE_NOTIFICATION_TRANSLATIONS = {
-    "component.securitas.notifications.arm_blocked_open_sensors.title": "TITLE",
-    "component.securitas.notifications.arm_blocked_open_sensors.message": (
-        "Arming blocked because:\n{sensor_list}\nTap Force Arm to override."
-    ),
-    "component.securitas.notifications.arm_blocked_open_sensors.mobile_message": (
-        "Blocked: {sensor_list}"
-    ),
-    "component.securitas.notifications.arm_blocked_open_sensors.force_arm_action": (
-        "Forçar"
-    ),
-    "component.securitas.notifications.arm_blocked_open_sensors.cancel_action": (
-        "Cancel·lar"
-    ),
+_FAKE_NOTIFICATION_ENTRY = {
+    "title": "TITLE",
+    "message": "Arming blocked because:\n{sensor_list}\nTap Force Arm to override.",
+    "mobile_message": "Blocked: {sensor_list}",
+    "force_arm_action": "Forçar",
+    "cancel_action": "Cancel·lar",
 }
 
 
@@ -2943,8 +2935,8 @@ class TestNotificationContent:
         event = self._make_event()
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 
@@ -2961,8 +2953,8 @@ class TestNotificationContent:
         event = self._make_event(zones=[])
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 
@@ -2980,13 +2972,14 @@ class TestNotificationContent:
         event = self._make_event()
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 
         mobile_call = next(
-            c for c in alarm.hass.services.async_call.call_args_list
+            c
+            for c in alarm.hass.services.async_call.call_args_list
             if c[1]["domain"] == "notify"
         )
         data = mobile_call[1]["service_data"]["data"]
@@ -2999,13 +2992,14 @@ class TestNotificationContent:
         event = self._make_event()
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 
         mobile_call = next(
-            c for c in alarm.hass.services.async_call.call_args_list
+            c
+            for c in alarm.hass.services.async_call.call_args_list
             if c[1]["domain"] == "notify"
         )
         actions = mobile_call[1]["service_data"]["data"]["actions"]
@@ -3022,8 +3016,8 @@ class TestNotificationContent:
         event = self._make_event()
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 
@@ -3042,8 +3036,8 @@ class TestNotificationContent:
         event = self._make_event(zones=["Kitchen Door", "Bedroom Window"])
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 
@@ -3064,8 +3058,8 @@ class TestNotificationContent:
         event = self._make_event(zones=[])
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 
@@ -3081,8 +3075,8 @@ class TestNotificationContent:
         event = self._make_event()
 
         with patch(
-            "custom_components.securitas.alarm_control_panel.async_get_translations",
-            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+            "custom_components.securitas.alarm_control_panel.get_notification_strings",
+            return_value=_FAKE_NOTIFICATION_ENTRY,
         ):
             await alarm._async_notify_arm_exceptions(event)
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -1235,6 +1235,21 @@ class TestForceState:
 
         assert "waf_blocked" not in alarm._attr_extra_state_attributes
 
+    def test_clearing_waf_blocked_dismisses_rate_limited_notification(self):
+        """When WAF clears, dismissing must target the same ID used to create the rate-limited notification."""
+        alarm = make_alarm()
+        alarm._attr_extra_state_attributes["waf_blocked"] = True
+
+        alarm._set_waf_blocked(False)
+
+        alarm.hass.async_create_task.assert_called_once()  # type: ignore[attr-defined]
+        call = alarm.hass.services.async_call.call_args  # type: ignore[attr-defined]
+        assert call[1]["domain"] == "persistent_notification"
+        assert call[1]["service"] == "dismiss"
+        assert call[1]["service_data"]["notification_id"] == (
+            f"securitas.rate_limited_{alarm.installation.number}"
+        )
+
 
 # ===========================================================================
 # async_will_remove_from_hass

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -10,7 +10,7 @@ from homeassistant.components.alarm_control_panel.const import (
     AlarmControlPanelState,
     CodeFormat,
 )
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.securitas.securitas_direct_new_api.models import (
@@ -145,8 +145,12 @@ class TestForceArmNotificationsConfig:
         mock_event.data = fire_args[0][1]
         handler_cb(mock_event)
 
-        # persistent_notification + notify group = 2 async_create_task calls
-        assert alarm.hass.async_create_task.call_count == 2
+        # Single async_create_task that wraps both persistent + mobile work
+        assert alarm.hass.async_create_task.call_count == 1
+        for call in alarm.hass.async_create_task.call_args_list:
+            arg = call[0][0]
+            if hasattr(arg, "close"):
+                arg.close()
 
     async def test_handler_skips_notifications_when_disabled(self):
         """No notifications when force_arm_notifications is False."""
@@ -653,21 +657,26 @@ class TestAsyncAlarmDisarm:
         assert alarm._state == AlarmControlPanelState.ARMED_AWAY
 
     async def test_disarm_error_notifies(self):
-        """Error from disarm_alarm calls _notify_error."""
+        """Error from disarm_alarm sends a translated disarm_failed notification."""
         alarm = make_alarm(code="1234")
         alarm._state = AlarmControlPanelState.ARMED_AWAY
         alarm._last_proto_code = "T"  # resolver needs armed proto to issue disarm
-        alarm._notify_error = MagicMock()
 
         alarm.client.disarm_alarm = AsyncMock(
             side_effect=SecuritasDirectError("API down")
         )
 
-        await alarm.async_alarm_disarm("1234")
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.async_alarm_disarm("1234")
 
-        alarm._notify_error.assert_called_once()
-        args = alarm._notify_error.call_args
-        assert args[0][0] == "Securitas: Error disarming"
+        mock_notify.assert_called_once_with(
+            alarm.hass,
+            f"disarm_failed_{alarm.installation.number}",
+            "disarm_failed",
+            {"error": "API down"},
+        )
 
     async def test_disarm_with_peri_armed_uses_combined_command(self):
         """When peri is configured and armed, tries DARM1DARMPERI."""
@@ -817,7 +826,7 @@ class TestSetArmState:
         assert alarm._state == AlarmControlPanelState.ARMED_AWAY
 
     async def test_unmapped_mode_raises_error(self):
-        """If mode has no configured SecuritasState, raises SecuritasDirectError."""
+        """If mode has no configured SecuritasState, notifies via arm_failed translation key."""
         config = {
             "PERI_alarm": False,
             "map_home": SecuritasState.PARTIAL_DAY.value,
@@ -828,13 +837,16 @@ class TestSetArmState:
         }
         alarm = make_alarm(config=config)
         alarm._state = AlarmControlPanelState.DISARMED
-        alarm._notify_error = MagicMock()
         alarm.client.arm_alarm = AsyncMock()
 
-        await alarm.set_arm_state(AlarmControlPanelState.ARMED_CUSTOM_BYPASS)
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.set_arm_state(AlarmControlPanelState.ARMED_CUSTOM_BYPASS)
 
         alarm.client.arm_alarm.assert_not_called()
-        alarm._notify_error.assert_called_once()
+        mock_notify.assert_called_once()
+        assert mock_notify.call_args[0][2] == "arm_failed"
 
 
 # ===========================================================================
@@ -1135,43 +1147,49 @@ class TestForceState:
         assert alarm._operation_in_progress is False
 
     async def test_disarm_403_sets_waf_blocked_skips_generic_notification(self):
-        """403 on disarm sets waf_blocked, shows rate-limited but NOT generic error."""
+        """403 on disarm sets waf_blocked, shows rate_limited but NOT disarm_failed."""
         alarm = make_alarm(code="1234")
         alarm._state = AlarmControlPanelState.ARMED_AWAY
         alarm._last_proto_code = "T"
-        alarm._notify_error = MagicMock()
 
         alarm.client.disarm_alarm = AsyncMock(
             side_effect=SecuritasDirectError("HTTP 403", http_status=403)
         )
 
-        await alarm.async_alarm_disarm("1234")
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.async_alarm_disarm("1234")
 
         assert alarm._attr_extra_state_attributes.get("waf_blocked") is True
-        # _notify_error is called once for "Rate limited" from _execute_step,
-        # but NOT for the generic "Error disarming" message
-        for call in alarm._notify_error.call_args_list:
-            assert "Error disarming" not in call[0][0]
+        # _notify is called once for "rate_limited" from _execute_step,
+        # but NOT for the generic "disarm_failed" message
+        translation_keys = [c.args[2] for c in mock_notify.call_args_list]
+        assert "disarm_failed" not in translation_keys
+        assert "rate_limited" in translation_keys
         assert alarm._state == AlarmControlPanelState.ARMED_AWAY
 
     async def test_arm_403_sets_waf_blocked_skips_generic_notification(self):
-        """403 on arm sets waf_blocked, shows rate-limited but NOT generic error."""
+        """403 on arm sets waf_blocked, shows rate_limited but NOT arm_failed."""
         alarm = make_alarm()
         alarm._state = AlarmControlPanelState.DISARMED
         alarm._last_state = AlarmControlPanelState.DISARMED
-        alarm._notify_error = MagicMock()
 
         alarm.client.arm_alarm = AsyncMock(
             side_effect=SecuritasDirectError("HTTP 403", http_status=403)
         )
 
-        await alarm.set_arm_state(AlarmControlPanelState.ARMED_AWAY)
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.set_arm_state(AlarmControlPanelState.ARMED_AWAY)
 
         assert alarm._attr_extra_state_attributes.get("waf_blocked") is True
-        # _notify_error is called once for "Rate limited" from _execute_step,
-        # but NOT for the generic "Arming failed" message
-        for call in alarm._notify_error.call_args_list:
-            assert "Arming failed" not in call[0][0]
+        # _notify is called once for "rate_limited" from _execute_step,
+        # but NOT for the generic "arm_failed" message
+        translation_keys = [c.args[2] for c in mock_notify.call_args_list]
+        assert "arm_failed" not in translation_keys
+        assert "rate_limited" in translation_keys
         assert alarm._state == AlarmControlPanelState.DISARMED
 
     async def test_successful_disarm_clears_waf_blocked(self):
@@ -1695,6 +1713,20 @@ class TestForceArmContext:
         assert alarm._force_context is not None
         assert alarm._attr_extra_state_attributes.get("force_arm_available") is True
 
+    async def test_notify_force_arm_expired_uses_translation_key(self):
+        """_notify_force_arm_expired calls _notify with the force_arm_expired translation key."""
+        alarm = make_alarm()
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            alarm._notify_force_arm_expired()
+
+        mock_notify.assert_called_once_with(
+            alarm.hass,
+            f"arming_exception_{alarm.installation.number}",
+            "force_arm_expired",
+        )
+
     async def test_force_context_cleared_on_expired_coordinator_update(self):
         """Coordinator update clears force context after scan interval expires."""
         alarm = make_alarm()
@@ -1741,7 +1773,7 @@ class TestForceArmContext:
         assert alarm._state == AlarmControlPanelState.ARMED_AWAY
 
     async def test_arming_exception_sends_persistent_notification(self):
-        """ArmingExceptionError triggers persistent notification via event handler."""
+        """ArmingExceptionError triggers async notification helper via event handler."""
         alarm = make_alarm()
         alarm.client.config["force_arm_notifications"] = True
         alarm._state = AlarmControlPanelState.ARMING
@@ -1761,11 +1793,16 @@ class TestForceArmContext:
         mock_event.data = alarm.hass.bus.async_fire.call_args[0][1]
         handler_cb(mock_event)
 
-        # Verify persistent notification was created
+        # Verify the async helper was scheduled
         alarm.hass.async_create_task.assert_called()  # type: ignore[attr-defined]
+        # Close the unawaited coroutine to silence RuntimeWarning
+        for call in alarm.hass.async_create_task.call_args_list:  # type: ignore[attr-defined]
+            arg = call[0][0]
+            if hasattr(arg, "close"):
+                arg.close()
 
     async def test_arming_exception_notifies_configured_group(self):
-        """ArmingExceptionError sends to configured notify group via event handler."""
+        """ArmingExceptionError schedules async helper which dispatches both notifications."""
         alarm = make_alarm()
         alarm.client.config["force_arm_notifications"] = True
         alarm.client.config["notify_group"] = "mobile_app_phone"
@@ -1786,8 +1823,12 @@ class TestForceArmContext:
         mock_event.data = alarm.hass.bus.async_fire.call_args[0][1]
         handler_cb(mock_event)
 
-        # Should have two async_create_task calls: persistent_notification + notify
-        assert alarm.hass.async_create_task.call_count == 2  # type: ignore[attr-defined]
+        # Single async_create_task that wraps the persistent + mobile work
+        alarm.hass.async_create_task.assert_called_once()  # type: ignore[attr-defined]
+        for call in alarm.hass.async_create_task.call_args_list:  # type: ignore[attr-defined]
+            arg = call[0][0]
+            if hasattr(arg, "close"):
+                arg.close()
 
     async def test_arming_exception_no_notify_group_only_persistent(self):
         """Without notify_group configured, only persistent notification fires via handler."""
@@ -1810,8 +1851,12 @@ class TestForceArmContext:
         mock_event.data = alarm.hass.bus.async_fire.call_args[0][1]
         handler_cb(mock_event)
 
-        # Only persistent notification
-        assert alarm.hass.async_create_task.call_count == 1  # type: ignore[attr-defined]
+        # Single async_create_task that wraps the (persistent-only) work
+        alarm.hass.async_create_task.assert_called_once()  # type: ignore[attr-defined]
+        for call in alarm.hass.async_create_task.call_args_list:  # type: ignore[attr-defined]
+            arg = call[0][0]
+            if hasattr(arg, "close"):
+                arg.close()
 
     async def test_async_force_arm_uses_stored_context(self):
         """async_force_arm consumes stored context and passes force params."""
@@ -2127,7 +2172,6 @@ class TestCompoundArmCommands:
         alarm._state = AlarmControlPanelState.ARMING
         alarm._last_state = AlarmControlPanelState.DISARMED
         alarm._resolver.mark_unsupported("ARMNIGHT1PERI1")
-        alarm._notify_error = MagicMock()
 
         call_count = 0
 
@@ -2147,32 +2191,55 @@ class TestCompoundArmCommands:
 
         alarm.client.arm_alarm = arm_side_effect
 
-        await alarm.set_arm_state(AlarmControlPanelState.ARMED_NIGHT)
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.set_arm_state(AlarmControlPanelState.ARMED_NIGHT)
 
         assert call_count == 2
         # Partial state: ARMNIGHT1 succeeded with proto "Q" (partial_night)
         # which maps to ARMED_CUSTOM_BYPASS if unmapped in _night_peri_config,
         # or ARMED_NIGHT if Q is in the status map
         alarm.async_write_ha_state.assert_called()  # type: ignore[attr-defined]
-        alarm._notify_error.assert_called_once()
+        mock_notify.assert_called_once()
+        assert mock_notify.call_args[0][2] == "arm_failed"
 
-    async def test_all_alternatives_fail_notifies(self):
-        """When compound and multi-step alternatives all fail, error is reported."""
+    async def test_all_commands_already_unsupported_raises_no_supported_command(self):
+        """When every command in a step is already marked unsupported, raise translated HomeAssistantError."""
+        from custom_components.securitas.securitas_direct_new_api.command_resolver import (
+            CommandStep,
+        )
+
+        alarm = make_alarm(config=_night_peri_config())
+        alarm._resolver.mark_unsupported("ARMNIGHT1PERI1")
+        alarm._resolver.mark_unsupported("ARMNIGHT1+PERI1")
+
+        step = CommandStep(commands=["ARMNIGHT1PERI1", "ARMNIGHT1+PERI1"])
+
+        with pytest.raises(HomeAssistantError) as excinfo:
+            await alarm._execute_step(step)
+
+        assert excinfo.value.translation_domain == "securitas"
+        assert excinfo.value.translation_key == "no_supported_command"
+
+    async def test_all_alternatives_fail_raises_unsupported_alarm_mode(self):
+        """When all 400-failing alternatives are exhausted, raise translated HomeAssistantError."""
         alarm = make_alarm(config=_night_peri_config())
         alarm._state = AlarmControlPanelState.ARMING
         alarm._last_state = AlarmControlPanelState.DISARMED
-        alarm._notify_error = MagicMock()
 
         alarm.client.arm_alarm = AsyncMock(
             side_effect=SecuritasDirectError("API error", http_status=400)
         )
 
-        await alarm.set_arm_state(AlarmControlPanelState.ARMED_NIGHT)
+        with pytest.raises(HomeAssistantError) as excinfo:
+            await alarm.set_arm_state(AlarmControlPanelState.ARMED_NIGHT)
 
+        assert excinfo.value.translation_domain == "securitas"
+        assert excinfo.value.translation_key == "unsupported_alarm_mode"
         # Tried compound ARMNIGHT1PERI1 then ARMNIGHT1 (first sub-cmd of ARMNIGHT1+PERI1)
         assert alarm.client.arm_alarm.call_count == 2
         assert "ARMNIGHT1PERI1" in alarm._resolver.unsupported
-        alarm._notify_error.assert_called_once()
         assert alarm._state == AlarmControlPanelState.DISARMED
 
     async def test_non_compound_command_sent_directly(self):
@@ -2201,7 +2268,6 @@ class TestCompoundArmCommands:
         alarm = make_alarm(config=_night_peri_config())
         alarm._state = AlarmControlPanelState.ARMING
         alarm._last_state = AlarmControlPanelState.DISARMED
-        alarm._notify_error = MagicMock()
 
         alarm.client.arm_alarm = AsyncMock(
             side_effect=SecuritasDirectError(
@@ -2412,7 +2478,6 @@ class TestDynamicDisarm:
         alarm = make_alarm(has_peri=False)
         alarm._state = AlarmControlPanelState.ARMED_AWAY
         alarm._last_proto_code = "T"  # resolver needs armed proto
-        alarm._notify_error = MagicMock()
 
         alarm.client.disarm_alarm = AsyncMock(
             side_effect=SecuritasDirectError("API down")
@@ -2445,21 +2510,22 @@ class TestDynamicDisarm:
         alarm.client.disarm_alarm.assert_called_once_with(alarm.installation, "DARM1")
 
     async def test_both_disarm_attempts_fail(self):
-        """When both DARM1DARMPERI and DARM1 fail, error is reported."""
+        """When both DARM1DARMPERI and DARM1 fail with 400, raise translated HomeAssistantError."""
         alarm = make_alarm(has_peri=True)
         alarm._last_proto_code = "B"  # partial_day_peri
         alarm._state = AlarmControlPanelState.ARMED_HOME
         alarm._last_state = AlarmControlPanelState.ARMED_HOME
-        alarm._notify_error = MagicMock()
 
         alarm.client.disarm_alarm = AsyncMock(
             side_effect=SecuritasDirectError("permanent failure", http_status=400)
         )
 
-        await alarm.async_alarm_disarm()
+        with pytest.raises(HomeAssistantError) as excinfo:
+            await alarm.async_alarm_disarm()
 
+        assert excinfo.value.translation_domain == "securitas"
+        assert excinfo.value.translation_key == "unsupported_alarm_mode"
         assert alarm.client.disarm_alarm.call_count == 2
-        alarm._notify_error.assert_called_once()
         assert alarm._state == AlarmControlPanelState.ARMED_HOME
 
     async def test_409_does_not_trigger_darm1_fallback(self):
@@ -2468,7 +2534,6 @@ class TestDynamicDisarm:
         alarm._last_proto_code = "A"  # total_peri = peri armed
         alarm._state = AlarmControlPanelState.ARMED_AWAY
         alarm._last_state = AlarmControlPanelState.ARMED_AWAY
-        alarm._notify_error = MagicMock()
 
         alarm.client.disarm_alarm = AsyncMock(
             side_effect=SecuritasDirectError(
@@ -2476,36 +2541,41 @@ class TestDynamicDisarm:
             )
         )
 
-        await alarm.async_alarm_disarm()
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.async_alarm_disarm()
 
         # Should only try DARM1DARMPERI once — NOT fall back to DARM1
         alarm.client.disarm_alarm.assert_called_once_with(
             alarm.installation, "DARM1DARMPERI"
         )
-        # Error notification should show clean message, not full args dump
-        alarm._notify_error.assert_called_once()
-        _, msg = alarm._notify_error.call_args[0]
-        assert "alarm-manager.alarm_process_error" in msg
-        assert "headers" not in msg.lower()
+        # Error placeholder carries clean API message, no full args dump
+        mock_notify.assert_called_once()
+        placeholders = mock_notify.call_args[0][3]
+        assert placeholders["error"] == "alarm-manager.alarm_process_error"
+        assert "headers" not in placeholders["error"].lower()
 
     async def test_disarm_error_notification_is_short(self):
-        """Error notification should show just the message, not the full error tuple."""
+        """Error placeholder should be just the API message, not the full error tuple."""
         alarm = make_alarm(has_peri=False)
         alarm._state = AlarmControlPanelState.ARMED_AWAY
         alarm._last_state = AlarmControlPanelState.ARMED_AWAY
         alarm._last_proto_code = "T"  # resolver needs armed proto
-        alarm._notify_error = MagicMock()
 
         _err = SecuritasDirectError("API error message", http_status=500)
         _err.response_body = {"response": "data", "auth": "secret-token"}
         alarm.client.disarm_alarm = AsyncMock(side_effect=_err)
 
-        await alarm.async_alarm_disarm()
+        with patch(
+            "custom_components.securitas.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.async_alarm_disarm()
 
-        alarm._notify_error.assert_called_once()
-        _, msg = alarm._notify_error.call_args[0]
-        assert msg == "API error message"
-        assert "secret-token" not in msg
+        mock_notify.assert_called_once()
+        placeholders = mock_notify.call_args[0][3]
+        assert placeholders["error"] == "API error message"
+        assert "secret-token" not in placeholders["error"]
 
     async def test_rearm_disarm_with_peri_armed(self):
         """Mode change from peri-armed state disarms with fallback, then arms."""
@@ -2648,16 +2718,17 @@ class TestExecuteTransition:
         assert "DARM1DARMPERI" not in alarm._resolver.unsupported
 
     async def test_all_commands_fail_raises(self):
-        """When all command alternatives fail, raises the last error."""
+        """When all 400-failing command alternatives are exhausted, raise translated HomeAssistantError."""
         alarm = make_alarm(has_peri=True)
         alarm._last_proto_code = "A"
         alarm.client.disarm_alarm = AsyncMock(
             side_effect=SecuritasDirectError("fail", http_status=400)
         )
-        with pytest.raises(SecuritasDirectError):
+        with pytest.raises(HomeAssistantError) as excinfo:
             await alarm._execute_transition(
                 AlarmState(interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF)
             )
+        assert excinfo.value.translation_key == "unsupported_alarm_mode"
 
     async def test_mode_change_disarms_then_arms(self):
         """Mode change (day -> night) disarms first, then arms new mode."""
@@ -2827,33 +2898,28 @@ class TestLastProtoCode:
 
 
 # ===========================================================================
-# _notify_error per-installation notification_id
-# ===========================================================================
-
-
-class TestNotifyError:
-    """Tests for _notify_error helper."""
-
-    def test_notification_id_includes_installation_number(self):
-        """notification_id includes installation number for multi-installation setups."""
-        alarm = make_alarm()
-        alarm._notify_error("Securitas: Arming failed", "test body")
-
-        alarm.hass.async_create_task.assert_called_once()  # type: ignore[attr-defined]
-        call_args = alarm.hass.services.async_call.call_args  # type: ignore[attr-defined]
-        service_data = call_args[1]["service_data"]
-        assert "123456" in service_data["notification_id"]
-        assert (
-            service_data["notification_id"]
-            == "securitas.securitas_arming_failed_123456"
-        )
-
-
-# ===========================================================================
 # Notification content tests
 # ===========================================================================
 
 
+_FAKE_NOTIFICATION_TRANSLATIONS = {
+    "component.securitas.notifications.arm_blocked_open_sensors.title": "TITLE",
+    "component.securitas.notifications.arm_blocked_open_sensors.message": (
+        "Arming blocked because:\n{sensor_list}\nTap Force Arm to override."
+    ),
+    "component.securitas.notifications.arm_blocked_open_sensors.mobile_message": (
+        "Blocked: {sensor_list}"
+    ),
+    "component.securitas.notifications.arm_blocked_open_sensors.force_arm_action": (
+        "Forçar"
+    ),
+    "component.securitas.notifications.arm_blocked_open_sensors.cancel_action": (
+        "Cancel·lar"
+    ),
+}
+
+
+@pytest.mark.asyncio
 class TestNotificationContent:
     """Tests for arming exception notification content (event-driven path)."""
 
@@ -2865,76 +2931,123 @@ class TestNotificationContent:
         event.data = {"zones": zones}
         return event
 
-    def test_persistent_notification_content(self):
-        """Persistent notification has correct title, message, and notification_id."""
+    def _alarm_with_async_call(self):
         alarm = make_alarm()
+        alarm.hass.config.language = "en"
+        alarm.hass.services.async_call = AsyncMock()
+        return alarm
+
+    async def test_persistent_notification_translated_content(self):
+        """Persistent notification uses translated title and interpolates sensor_list."""
+        alarm = self._alarm_with_async_call()
         event = self._make_event()
 
-        alarm._notify_arm_exceptions_from_event(event)
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
 
-        # Find the persistent_notification.create call
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
+        calls = alarm.hass.services.async_call.call_args_list
         pn_call = next(c for c in calls if c[1]["domain"] == "persistent_notification")
         sd = pn_call[1]["service_data"]
-        assert sd["title"] == "Securitas: Arm blocked — open sensor(s)"
-        assert "Kitchen Door" in sd["message"]
+        assert sd["title"] == "TITLE"
+        assert "- Kitchen Door" in sd["message"]
         assert sd["notification_id"] == "securitas.arming_exception_123456"
 
-    def test_mobile_notification_has_tag(self):
+    async def test_persistent_notification_unknown_sensor_fallback(self):
+        """When zones list is empty, sensor_list placeholder uses unknown-sensor fallback."""
+        alarm = self._alarm_with_async_call()
+        event = self._make_event(zones=[])
+
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
+
+        pn_call = next(
+            c
+            for c in alarm.hass.services.async_call.call_args_list
+            if c[1]["domain"] == "persistent_notification"
+        )
+        assert "(unknown sensor)" in pn_call[1]["service_data"]["message"]
+
+    async def test_mobile_notification_has_tag(self):
         """Mobile notification includes the per-installation tag."""
-        alarm = make_alarm()
+        alarm = self._alarm_with_async_call()
         alarm.client.config["notify_group"] = "mobile_app_phone"
         event = self._make_event()
 
-        alarm._notify_arm_exceptions_from_event(event)
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
 
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
-        mobile_call = next(c for c in calls if c[1]["domain"] == "notify")
+        mobile_call = next(
+            c for c in alarm.hass.services.async_call.call_args_list
+            if c[1]["domain"] == "notify"
+        )
         data = mobile_call[1]["service_data"]["data"]
         assert data["tag"] == "securitas.arming_exception_123456"
 
-    def test_mobile_notification_action_buttons(self):
-        """Mobile notification has Force Arm and Cancel action buttons."""
-        alarm = make_alarm()
+    async def test_mobile_notification_action_buttons_translated(self):
+        """Mobile action button titles come from translations."""
+        alarm = self._alarm_with_async_call()
         alarm.client.config["notify_group"] = "mobile_app_phone"
         event = self._make_event()
 
-        alarm._notify_arm_exceptions_from_event(event)
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
 
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
-        mobile_call = next(c for c in calls if c[1]["domain"] == "notify")
+        mobile_call = next(
+            c for c in alarm.hass.services.async_call.call_args_list
+            if c[1]["domain"] == "notify"
+        )
         actions = mobile_call[1]["service_data"]["data"]["actions"]
         assert len(actions) == 2
         assert actions[0]["action"] == "SECURITAS_FORCE_ARM_123456"
-        assert actions[0]["title"] == "Force Arm"
+        assert actions[0]["title"] == "Forçar"
         assert actions[1]["action"] == "SECURITAS_CANCEL_FORCE_ARM_123456"
-        assert actions[1]["title"] == "Cancel"
+        assert actions[1]["title"] == "Cancel·lar"
 
-    def test_mobile_notification_short_message(self):
+    async def test_mobile_notification_short_message(self):
         """Mobile message is shorter than persistent message and contains sensor alias."""
-        alarm = make_alarm()
+        alarm = self._alarm_with_async_call()
         alarm.client.config["notify_group"] = "mobile_app_phone"
         event = self._make_event()
 
-        alarm._notify_arm_exceptions_from_event(event)
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
 
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
+        calls = alarm.hass.services.async_call.call_args_list
         pn_call = next(c for c in calls if c[1]["domain"] == "persistent_notification")
         mobile_call = next(c for c in calls if c[1]["domain"] == "notify")
         persistent_msg = pn_call[1]["service_data"]["message"]
         mobile_msg = mobile_call[1]["service_data"]["message"]
         assert "Kitchen Door" in mobile_msg
-        assert len(mobile_msg) < len(persistent_msg)
+        assert len(mobile_msg) <= len(persistent_msg)
 
-    def test_notification_multiple_sensors(self):
+    async def test_notification_multiple_sensors(self):
         """Multiple sensors appear in both persistent and mobile notifications."""
-        alarm = make_alarm()
+        alarm = self._alarm_with_async_call()
         alarm.client.config["notify_group"] = "mobile_app_phone"
         event = self._make_event(zones=["Kitchen Door", "Bedroom Window"])
 
-        alarm._notify_arm_exceptions_from_event(event)
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
 
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
+        calls = alarm.hass.services.async_call.call_args_list
         pn_call = next(c for c in calls if c[1]["domain"] == "persistent_notification")
         mobile_call = next(c for c in calls if c[1]["domain"] == "notify")
         persistent_msg = pn_call[1]["service_data"]["message"]
@@ -2944,36 +3057,52 @@ class TestNotificationContent:
         assert "Kitchen Door" in mobile_msg
         assert "Bedroom Window" in mobile_msg
 
-    def test_notification_sensor_alias_fallback(self):
+    async def test_notification_sensor_alias_fallback(self):
         """Empty zones list shows 'unknown sensor' fallback in notification."""
-        alarm = make_alarm()
+        alarm = self._alarm_with_async_call()
         alarm.client.config["notify_group"] = "mobile_app_phone"
         event = self._make_event(zones=[])
 
-        alarm._notify_arm_exceptions_from_event(event)
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
 
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
+        calls = alarm.hass.services.async_call.call_args_list
         pn_call = next(c for c in calls if c[1]["domain"] == "persistent_notification")
         mobile_call = next(c for c in calls if c[1]["domain"] == "notify")
         assert "unknown" in pn_call[1]["service_data"]["message"]
         assert "open sensor" in mobile_call[1]["service_data"]["message"]
 
-    def test_no_mobile_notification_without_notify_group(self):
-        """Without notify_group, only persistent notification fires with correct content."""
+    async def test_no_mobile_notification_without_notify_group(self):
+        """Without notify_group, only persistent notification fires."""
+        alarm = self._alarm_with_async_call()
+        event = self._make_event()
+
+        with patch(
+            "custom_components.securitas.alarm_control_panel.async_get_translations",
+            AsyncMock(return_value=_FAKE_NOTIFICATION_TRANSLATIONS),
+        ):
+            await alarm._async_notify_arm_exceptions(event)
+
+        calls = alarm.hass.services.async_call.call_args_list
+        assert len(calls) == 1
+        sd = calls[0][1]["service_data"]
+        assert sd["title"] == "TITLE"
+        assert "Kitchen Door" in sd["message"]
+        assert sd["notification_id"] == "securitas.arming_exception_123456"
+
+    def test_event_handler_schedules_async_helper(self):
+        """The sync event handler schedules the async helper via async_create_task."""
         alarm = make_alarm()
         event = self._make_event()
 
         alarm._notify_arm_exceptions_from_event(event)
 
-        # Only 1 async_create_task call (persistent only)
-        assert alarm.hass.async_create_task.call_count == 1  # type: ignore[attr-defined]
-        # Verify persistent notification content is still correct
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
-        assert len(calls) == 1
-        sd = calls[0][1]["service_data"]
-        assert sd["title"] == "Securitas: Arm blocked — open sensor(s)"
-        assert "Kitchen Door" in sd["message"]
-        assert sd["notification_id"] == "securitas.arming_exception_123456"
+        alarm.hass.async_create_task.assert_called_once()
+        coro = alarm.hass.async_create_task.call_args[0][0]
+        coro.close()
 
 
 # ===========================================================================
@@ -3124,7 +3253,7 @@ class TestForceArmWorkflow:
     """End-to-end integration tests for the force-arm workflow."""
 
     async def test_full_force_arm_workflow(self):
-        """Full workflow: arm fails -> event handler sends notifications -> force arm succeeds."""
+        """Full workflow: arm fails -> event handler schedules notifications -> force arm succeeds."""
         alarm = make_alarm()
         alarm.client.config["force_arm_notifications"] = True
         alarm.client.config["notify_group"] = "mobile_app_phone"
@@ -3166,16 +3295,12 @@ class TestForceArmWorkflow:
         mock_event.data = alarm.hass.bus.async_fire.call_args[0][1]
         handler_cb(mock_event)
 
-        # Notifications should have been sent (persistent + mobile)
-        assert alarm.hass.async_create_task.call_count == 2  # type: ignore[attr-defined]
-        calls = alarm.hass.services.async_call.call_args_list  # type: ignore[attr-defined]
-        pn_create = next(
-            c
-            for c in calls
-            if c[1]["domain"] == "persistent_notification"
-            and c[1]["service"] == "create"
-        )
-        assert "Kitchen Door" in pn_create[1]["service_data"]["message"]
+        # Single async_create_task that wraps the persistent + mobile work
+        alarm.hass.async_create_task.assert_called_once()  # type: ignore[attr-defined]
+        for call in alarm.hass.async_create_task.call_args_list:  # type: ignore[attr-defined]
+            arg = call[0][0]
+            if hasattr(arg, "close"):
+                arg.close()
 
         # Reset call tracking for step 2
         alarm.hass.async_create_task.reset_mock()  # type: ignore[attr-defined]

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,7 +1,7 @@
 """Tests for button entity (SecuritasRefreshButton)."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.securitas.button import SecuritasRefreshButton, async_setup_entry
 from custom_components.securitas import DOMAIN
@@ -140,7 +140,7 @@ class TestSecuritasRefreshButtonAsyncPress:
         alarm_entity._set_refresh_failed.assert_called_with(True)
 
     async def test_sets_waf_blocked_on_403(self):
-        """async_press sets waf_blocked on 403 error."""
+        """async_press sets waf_blocked on 403 error and triggers a translated rate-limit notification."""
         button = make_button()
         err = SecuritasDirectError("blocked", http_status=403)
         button._client.refresh_alarm_status = AsyncMock(side_effect=err)
@@ -149,10 +149,18 @@ class TestSecuritasRefreshButtonAsyncPress:
             DOMAIN: {"alarm_entities": {button._installation.number: alarm_entity}}
         }
 
-        await button.async_press()
+        with patch(
+            "custom_components.securitas.button._async_notify",
+            AsyncMock(),
+        ) as mock_async_notify:
+            await button.async_press()
 
         alarm_entity._set_waf_blocked.assert_called_with(True)
-        button.hass.services.async_call.assert_awaited_once()
+        mock_async_notify.assert_awaited_once_with(
+            button.hass,
+            f"rate_limited_{button._installation.number}",
+            "rate_limited",
+        )
 
     async def test_no_crash_when_hass_is_none(self):
         """async_press does not crash when hass is None."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -37,12 +37,15 @@ from custom_components.securitas import (
     SecuritasDirectDevice,
     SecuritasHub,
     _build_config_dict,
-    _notify_error,
     add_device_information,
     async_migrate_entry,
     async_setup_entry,
     async_unload_entry,
     async_update_options,
+)
+from custom_components.securitas.hub import (
+    _async_notify,
+    _notify,
 )
 from custom_components.securitas.securitas_direct_new_api.const import (
     STD_DEFAULTS,
@@ -164,41 +167,71 @@ class TestSecuritasHubInit:
 
 
 # ===========================================================================
-# 2. TestNotifyError
+# 2. TestAsyncNotify — translated persistent notifications
 # ===========================================================================
 
 
-class TestNotifyError:
-    """Tests for _notify_error() helper."""
+class TestAsyncNotify:
+    """Tests for _async_notify() and _notify() helpers."""
 
-    def test_creates_persistent_notification(self):
-        """Should call persistent_notification.create with correct data."""
+    async def test_translates_title_and_message_via_async_get_translations(self):
+        """Looks up title/message from notifications category and posts to persistent_notification."""
         hass = MagicMock()
-        hass.async_create_task = MagicMock()
-        _notify_error(hass, "test_id", "Test Title", "Test message")
-        hass.async_create_task.assert_called_once()
-        # Verify async_call was invoked correctly
-        hass.services.async_call.assert_called_once_with(
+        hass.config.language = "en"
+        hass.services.async_call = AsyncMock()
+
+        translations = {
+            f"component.{DOMAIN}.notifications.my_key.title": "Hello",
+            f"component.{DOMAIN}.notifications.my_key.message": "World message",
+        }
+        with patch(
+            "custom_components.securitas.hub.async_get_translations",
+            AsyncMock(return_value=translations),
+        ) as mocked:
+            await _async_notify(hass, "my_id", "my_key")
+
+        mocked.assert_awaited_once_with(hass, "en", "notifications", {DOMAIN})
+        hass.services.async_call.assert_awaited_once_with(
             domain="persistent_notification",
             service="create",
             service_data={
-                "title": "Test Title",
-                "message": "Test message",
-                "notification_id": f"{DOMAIN}.test_id",
+                "title": "Hello",
+                "message": "World message",
+                "notification_id": f"{DOMAIN}.my_id",
             },
         )
 
-    def test_notification_id_includes_domain(self):
-        """notification_id should be prefixed with the integration domain."""
+    async def test_interpolates_placeholders_into_title_and_message(self):
+        """Placeholders are substituted in both title and message."""
+        hass = MagicMock()
+        hass.config.language = "es"
+        hass.services.async_call = AsyncMock()
+
+        translations = {
+            f"component.{DOMAIN}.notifications.greeting.title": "Hola {name}",
+            f"component.{DOMAIN}.notifications.greeting.message": "{count} cosas",
+        }
+        with patch(
+            "custom_components.securitas.hub.async_get_translations",
+            AsyncMock(return_value=translations),
+        ):
+            await _async_notify(
+                hass, "g1", "greeting", {"name": "Bob", "count": 3}
+            )
+
+        service_data = hass.services.async_call.call_args[1]["service_data"]
+        assert service_data["title"] == "Hola Bob"
+        assert service_data["message"] == "3 cosas"
+
+    def test_notify_sync_wrapper_schedules_async_notify(self):
+        """_notify() schedules _async_notify via hass.async_create_task."""
         hass = MagicMock()
         hass.async_create_task = MagicMock()
-        _notify_error(hass, "my_error", "Title", "Msg")
-        # async_call is called with keyword args for service_data
-        call_args = hass.services.async_call.call_args
-        service_data = call_args[1].get(
-            "service_data", call_args[0][2] if len(call_args[0]) > 2 else None
-        )
-        assert service_data["notification_id"] == f"{DOMAIN}.my_error"
+        _notify(hass, "id1", "key1", {"x": "y"})
+        hass.async_create_task.assert_called_once()
+        coro = hass.async_create_task.call_args[0][0]
+        # Coroutine is the _async_notify call — close it to avoid RuntimeWarning
+        coro.close()
 
 
 # ===========================================================================
@@ -405,7 +438,7 @@ class TestAsyncSetupEntry:
         assert "devices" in hass.data[DOMAIN][entry.entry_id]
 
     async def test_setup_login_2fa_error(self, hass, mock_hub):
-        """TwoFactorRequiredError should raise ConfigEntryAuthFailed."""
+        """TwoFactorRequiredError raises ConfigEntryAuthFailed and notifies via translation key."""
         mock_hub.login = AsyncMock(side_effect=TwoFactorRequiredError("2FA required"))
         entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
         entry.add_to_hass(hass)
@@ -413,13 +446,17 @@ class TestAsyncSetupEntry:
         with (
             _patch_hub(mock_hub),
             patch("custom_components.securitas.async_get_clientsession"),
-            patch("custom_components.securitas._notify_error"),
+            patch("custom_components.securitas._notify") as mock_notify,
             pytest.raises(ConfigEntryAuthFailed, match="2FA required"),
         ):
             await async_setup_entry(hass, entry)
 
+        mock_notify.assert_called_once_with(
+            hass, "2fa_error", "two_factor_required"
+        )
+
     async def test_setup_login_error(self, hass, mock_hub):
-        """AuthenticationError should raise ConfigEntryAuthFailed."""
+        """AuthenticationError raises ConfigEntryAuthFailed and notifies with the API error."""
         mock_hub.login = AsyncMock(side_effect=AuthenticationError("bad credentials"))
         entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
         entry.add_to_hass(hass)
@@ -427,10 +464,14 @@ class TestAsyncSetupEntry:
         with (
             _patch_hub(mock_hub),
             patch("custom_components.securitas.async_get_clientsession"),
-            patch("custom_components.securitas._notify_error"),
+            patch("custom_components.securitas._notify") as mock_notify,
             pytest.raises(ConfigEntryAuthFailed, match="Authentication failed"),
         ):
             await async_setup_entry(hass, entry)
+
+        mock_notify.assert_called_once_with(
+            hass, "login_error", "login_failed", {"error": "bad credentials"}
+        )
 
     async def test_setup_securitas_error_during_login(self, hass, mock_hub):
         """SecuritasDirectError during login should raise ConfigEntryNotReady."""
@@ -1363,7 +1404,7 @@ class TestAsyncMigrateEntry:
     """Tests for async_migrate_entry — rejects all entries below v3."""
 
     async def test_migration_v1_rejected(self, hass):
-        """v1 entry is rejected with return False (user must delete and re-add)."""
+        """v1 entry is rejected and notifies the user via translation key."""
         data = make_config_entry_data(username="user@example.com")
 
         entry = MockConfigEntry(
@@ -1374,12 +1415,15 @@ class TestAsyncMigrateEntry:
         )
         entry.add_to_hass(hass)
 
-        with patch("custom_components.securitas._notify_error"):
+        with patch("custom_components.securitas._notify") as mock_notify:
             result = await async_migrate_entry(hass, entry)
 
         assert result is False
         # Entry version remains unchanged
         assert entry.version == 1
+        mock_notify.assert_called_once_with(
+            hass, "migration_required", "migration_required"
+        )
 
     async def test_migration_v2_rejected(self, hass):
         """v2 entry is rejected with return False (user must delete and re-add)."""
@@ -1394,7 +1438,7 @@ class TestAsyncMigrateEntry:
         )
         entry.add_to_hass(hass)
 
-        with patch("custom_components.securitas._notify_error"):
+        with patch("custom_components.securitas._notify"):
             result = await async_migrate_entry(hass, entry)
 
         assert result is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -174,23 +174,19 @@ class TestSecuritasHubInit:
 class TestAsyncNotify:
     """Tests for _async_notify() and _notify() helpers."""
 
-    async def test_translates_title_and_message_via_async_get_translations(self):
-        """Looks up title/message from notifications category and posts to persistent_notification."""
+    async def test_looks_up_title_and_message_from_translations_dict(self):
+        """Resolves title/message via get_notification_strings and posts to persistent_notification."""
         hass = MagicMock()
         hass.config.language = "en"
         hass.services.async_call = AsyncMock()
 
-        translations = {
-            f"component.{DOMAIN}.notifications.my_key.title": "Hello",
-            f"component.{DOMAIN}.notifications.my_key.message": "World message",
-        }
         with patch(
-            "custom_components.securitas.hub.async_get_translations",
-            AsyncMock(return_value=translations),
+            "custom_components.securitas.hub.get_notification_strings",
+            return_value={"title": "Hello", "message": "World message"},
         ) as mocked:
             await _async_notify(hass, "my_id", "my_key")
 
-        mocked.assert_awaited_once_with(hass, "en", "notifications", {DOMAIN})
+        mocked.assert_called_once_with(hass, "my_key")
         hass.services.async_call.assert_awaited_once_with(
             domain="persistent_notification",
             service="create",
@@ -207,17 +203,11 @@ class TestAsyncNotify:
         hass.config.language = "es"
         hass.services.async_call = AsyncMock()
 
-        translations = {
-            f"component.{DOMAIN}.notifications.greeting.title": "Hola {name}",
-            f"component.{DOMAIN}.notifications.greeting.message": "{count} cosas",
-        }
         with patch(
-            "custom_components.securitas.hub.async_get_translations",
-            AsyncMock(return_value=translations),
+            "custom_components.securitas.hub.get_notification_strings",
+            return_value={"title": "Hola {name}", "message": "{count} cosas"},
         ):
-            await _async_notify(
-                hass, "g1", "greeting", {"name": "Bob", "count": 3}
-            )
+            await _async_notify(hass, "g1", "greeting", {"name": "Bob", "count": 3})
 
         service_data = hass.services.async_call.call_args[1]["service_data"]
         assert service_data["title"] == "Hola Bob"
@@ -451,9 +441,7 @@ class TestAsyncSetupEntry:
         ):
             await async_setup_entry(hass, entry)
 
-        mock_notify.assert_called_once_with(
-            hass, "2fa_error", "two_factor_required"
-        )
+        mock_notify.assert_called_once_with(hass, "2fa_error", "two_factor_required")
 
     async def test_setup_login_error(self, hass, mock_hub):
         """AuthenticationError raises ConfigEntryAuthFailed and notifies with the API error."""


### PR DESCRIPTION
## Summary

Translate all English-only user-visible Python strings (persistent notification titles/messages, mobile push messages, and arm-time exception raises that surface in HA's UI) to Home Assistant's native translation system, and add Catalan + a distinct pt-BR locale to both Lovelace cards.

## What changed

### Lovelace cards (`caf63cf`)
- `securitas-alarm-card.js`: added Catalan and a distinct `pt-BR` block (replacing the previous `pt-BR → pt` alias).
- `securitas-camera-card.js`: introduced `TRANSLATIONS` infrastructure and `_t` helper covering `en, es, fr, it, pt, pt-BR, ca`. Catalan strings use the **"Verisure"** brand name; all other locales keep "Securitas"/"Securitas Direct".

### Python notifications & exceptions (`618ade4`)
- New `_async_notify` / `_notify` helpers in `hub.py` look up titles and messages from the `notifications` translation category, interpolate placeholders, and dispatch via `persistent_notification.create`.
- Two arm-failure raises in `_execute_step` converted to `HomeAssistantError(translation_key=…)` with keys `unsupported_alarm_mode` / `no_supported_command`, mirroring the existing `invalid_pin_code` pattern.
- Eight notification call sites migrated to the new helpers:
  - `migration_required`, `two_factor_required`, `login_failed`
  - `arm_failed`, `disarm_failed`
  - `rate_limited` (alarm panel + refresh button share the key)
  - `force_arm_expired`
  - `arm_blocked_open_sensors` (persistent + mobile push driven by a single `async_get_translations` lookup, action button labels included)
- Obsolete `_notify_error` helpers removed from `hub.py`, `entity.py`, and `alarm_control_panel.py`.
- New keys mirrored across all seven locales (`en, es, fr, it, pt, pt-BR, ca`); Catalan uses **"Verisure"** branding throughout (24 brand mentions, zero "Securitas" leakage).
- Fix the 2FA typo while translating it: English source now reads "Securitas Direct needs a 2FA verification code. Please log in again." (was "need a 2FA SMS code.Please login again with your phone").

## Stats
- 18 files changed, 988 insertions(+), 344 deletions(-)
- 7 locales × 82 keys each, all placeholders match `strings.json`
- pt-BR uses Brazilian conventions: "Forçar armado", "armar mesmo assim", "Configurações" (vs pt-PT "Forçar armar", "armar na mesma", "Definições")

## Test plan

- [x] `pytest tests/` — 1049 passed (4 new tests for `_async_notify`, `unsupported_alarm_mode`, `no_supported_command`)
- [x] `ruff check custom_components/ tests/` — clean
- [x] Translation key parity verified (script in commit body)
- [x] Catalan brand check: `grep "Securitas" ca.json` returns nothing
- [ ] Native-speaker review of the seven new locale string sets — would appreciate sanity checks from speakers of es / fr / it / pt / pt-BR / ca before merge.