### PR TITLE
fix: refuse arm/disarm when current proto code is unknown (#441)

### DIFF
--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -46,6 +46,7 @@ from .events import (
     inject_ha_event,
 )
 from .notification_translations import get_notification_strings
+from .verisure_owa_api.__version__ import __url__ as _PROJECT_URL
 from .verisure_owa_api.models import ActivityCategory, ActivityException
 from .verisure_owa_api import (
     ArmingExceptionError,
@@ -56,6 +57,7 @@ from .verisure_owa_api import (
     VerisureOwaError,
     VerisureOwaState,
     STATE_TO_COMMAND,
+    is_proto_letter,
 )
 from .verisure_owa_api.command_resolver import (
     AlarmState,
@@ -328,10 +330,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             return
         # status.status is the proto code like "D", "T", etc.
         proto_code = status.status
-        # Only update _last_proto_code when it is a known proto code.
-        # Use PROTO_TO_ALARM_STATE (12 entries — includes annex codes X/R/S/O)
-        # not const.PROTO_TO_STATE (8 entries — pre-annex).
-        if proto_code in PROTO_TO_ALARM_STATE:
+        # Store any well-formed proto code (single uppercase letter), even ones
+        # we don't yet model — this keeps _last_proto_code truthful so the next
+        # arm/disarm refuses cleanly instead of acting on a stale cached state.
+        if is_proto_letter(proto_code):
             self._last_proto_code = proto_code
         if proto_code == PROTO_DISARMED:
             self._state = AlarmControlPanelState.DISARMED
@@ -352,11 +354,11 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         caller should derive ``_state`` from it.  Returns False to short-circuit
         (no status, no message attribute, or empty protom_response).
 
-        Also updates ``_last_proto_code`` when protom_response is a known proto
-        code.  Periodic polling uses xSStatus which returns values like
-        "ARMED_TOTAL" instead of proto codes; those must not overwrite the
-        last proto code or the resolver's state-based command selection will
-        break.
+        Also updates ``_last_proto_code`` when protom_response has the proto-code
+        shape (single uppercase letter).  Periodic polling uses xSStatus which
+        returns values like "ARMED_TOTAL" instead of proto codes; those must not
+        overwrite the last proto code or the resolver's state-based command
+        selection will break.
         """
         if status is None or not hasattr(status, "message"):
             return False
@@ -375,7 +377,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 status.protom_response_data,
             )
             return False
-        if status.protom_response in PROTO_TO_ALARM_STATE:
+        if is_proto_letter(status.protom_response):
             self._last_proto_code = status.protom_response
         return True
 
@@ -456,19 +458,33 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         panel's actual state matches the target.  If not (e.g. because
         ``_last_proto_code`` was stale), updates the proto code from the
         real response and retries with the corrected current state.
+
+        Refuses to act when the panel's current state is unknown (no poll
+        seen yet, or a proto code we don't model).  Acting on an unknown
+        current state would silently no-op the disarm path (issue #441) or
+        send incorrect transitions on the arm path.
         """
+        if self._last_proto_code is None:
+            raise VerisureOwaError(
+                "Alarm state not yet known. "
+                "Please wait for the first status poll and try again."
+            )
+        if self._last_proto_code not in PROTO_TO_ALARM_STATE:
+            raise VerisureOwaError(
+                f"Alarm is in unknown state '{self._last_proto_code}'. "
+                f"Please open an issue at {_PROJECT_URL}/issues "
+                "including this state code."
+            )
+
         result: OperationStatus | None = None
 
         for attempt in range(2):
-            current = PROTO_TO_ALARM_STATE.get(
-                self._last_proto_code or "D",
-                AlarmState(interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF),
-            )
+            current = PROTO_TO_ALARM_STATE[self._last_proto_code]
             steps = self._resolver.resolve(current, target)
 
             if not steps:
                 # Resolver says we're already in the target state.
-                return OperationStatus(protom_response=self._last_proto_code or "D")
+                return OperationStatus(protom_response=self._last_proto_code)
 
             for step in steps:
                 result = await self._execute_step(step, **force_params)
@@ -1084,12 +1100,13 @@ class _AxisSubPanelMixin:
     def _update_from_coordinator(self, data: AlarmStatusData) -> None:  # type: ignore[override]
         """Project the coordinator's joint state onto this panel's axis.
 
-        Unknown proto codes preserve the previous _state. coordinator.alarm_state
-        defaults to all-OFF for unrecognised codes, which would otherwise make
-        the sub-panel silently report DISARMED while the system is actually armed.
-
-        Uses PROTO_TO_ALARM_STATE (12 entries — includes annex codes X/R/S/O)
-        not const.PROTO_TO_STATE (8 entries — pre-annex).
+        Stores any well-formed proto code (single uppercase letter) so that the
+        refuse-on-unknown-state gate in _execute_transition fires for codes we
+        don't yet model.  For codes we do model, also project the coordinator's
+        joint state onto this axis; unknown codes preserve the previous _state
+        because coordinator.alarm_state defaults to all-OFF for them, which
+        would otherwise make the sub-panel silently report DISARMED while the
+        system is actually armed.
         """
         # Refresh resolver capabilities — they may have been populated late.
         self._resolver.update_capabilities(  # type: ignore[attr-defined]
@@ -1099,9 +1116,11 @@ class _AxisSubPanelMixin:
         if not status.status:
             return
         proto_code = status.status
-        if proto_code not in PROTO_TO_ALARM_STATE:
+        if not is_proto_letter(proto_code):
             return
         self._last_proto_code = proto_code  # type: ignore[attr-defined]
+        if proto_code not in PROTO_TO_ALARM_STATE:
+            return
         joint = self.coordinator.alarm_state  # type: ignore[attr-defined]
         self._state = self._extract_state(joint)  # type: ignore[attr-defined]
 

--- a/custom_components/verisure_owa/verisure_owa_api/__init__.py
+++ b/custom_components/verisure_owa/verisure_owa_api/__init__.py
@@ -37,6 +37,7 @@ from .models import (  # noqa: F401
     SmartLockMode,
     SmartLockModeStatus,
     ThumbnailResponse,
+    is_proto_letter,
     parse_proto_code,
 )
 from .domains import ApiDomains  # noqa: F401

--- a/custom_components/verisure_owa/verisure_owa_api/models.py
+++ b/custom_components/verisure_owa/verisure_owa_api/models.py
@@ -117,6 +117,16 @@ def parse_proto_code(code: str) -> ProtoCode:
         raise UnexpectedStateError(code) from exc
 
 
+def is_proto_letter(value: object) -> bool:
+    """Return True iff value has the proto-code wire shape (single uppercase letter).
+
+    Looser than ``ProtoCode(value)`` — admits well-formed codes we don't yet
+    model so callers can distinguish "alarm in a state we don't recognise"
+    (refuse cleanly) from "API noise like 'ARMED_TOTAL'" (drop on the floor).
+    """
+    return isinstance(value, str) and len(value) == 1 and "A" <= value <= "Z"
+
+
 # ── Mapping tables ────────────────────────────────────────────────────────────
 
 PROTO_TO_STATE: dict[ProtoCode, AlarmState] = {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,6 +219,8 @@ Home Assistant has five alarm buttons (Home, Away, Night, Vacation, Custom Bypas
 
 If the alarm is put into a state that is not mapped to any HA button (e.g. the perimeter is armed via a physical panel but perimeter support is not enabled in the integration), the entity reports `ARMED_CUSTOM_BYPASS` and logs the unmapped proto code at `info` level. This is not an error — it simply means the alarm is in a valid Verisure OWA state that the user has not assigned to an HA button. To resolve it, enable perimeter support or map the relevant state in the integration options.
 
+**Unknown proto codes refuse arm/disarm** (issue [#441](https://github.com/guerrerotook/securitas-direct-new-api/issues/441)). `_last_proto_code` admits any single uppercase ASCII letter — including codes we don't yet model (e.g. the unmapped perimeter+annex combinations). When an arm/disarm is requested while `_last_proto_code` is unmodeled, `_execute_transition()` refuses with a translated notification naming the actual code. Acting on an unknown current state would silently no-op the disarm path (the bug behind #441 — resolver computed `current==target` off a stale `D` and skipped `DARM1`) or send incorrect transitions on the arm path. The refusal clears automatically on the next poll once the alarm returns to a state we model.
+
 ### Exceptions (`exceptions.py`)
 
 ```

--- a/docs/before-release-todo.md
+++ b/docs/before-release-todo.md
@@ -229,7 +229,10 @@ on actual API responses, multi-axis state, or hardware configuration.
       then we add four more rows to PROTO_TO_STATE in
       `verisure_owa_api/const.py`. Until then the alarm panel falls
       back to ARMED_CUSTOM_BYPASS for these states with an info-level
-      "unmapped proto code" log line.
+      "unmapped proto code" log line. Arm/disarm against an unmapped
+      code is now refused cleanly with a notification naming the actual
+      code (vs. v5.0.0's silent disarm no-op) — see the refuse-on-
+      unknown-proto behaviour in `architecture.md`.
 
 - [ ] **Compound transition optimization (optional).** Verisure web app
       uses single-API-call compound commands when transitioning between

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -450,6 +450,59 @@ class TestUpdateStatusAlarm:
         assert alarm._attr_extra_state_attributes["message"] == "Panel ok"
         assert alarm._attr_extra_state_attributes["response_data"] == "some-data"
 
+    def test_unknown_single_letter_updates_last_proto_code(self):
+        """Unknown but well-formed proto code (single uppercase letter) is stored.
+
+        Forward-compat: if Verisure adds new state codes we don't yet model,
+        we keep `_last_proto_code` truthful so the next arm/disarm can refuse
+        cleanly instead of acting on a stale cached state.
+        """
+        alarm = make_alarm()
+        assert alarm._last_proto_code == "D"  # from initial_status
+
+        status = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="Z",  # not in PROTO_TO_ALARM_STATE; forward-compat for new codes
+            protom_response_data="",
+        )
+        alarm.update_status_alarm(status)
+        assert alarm._last_proto_code == "Z"
+
+    def test_multi_char_protom_response_does_not_update_last_proto_code(self):
+        """xSStatus polling values like 'ARMED_TOTAL' must not pollute _last_proto_code."""
+        alarm = make_alarm()
+        alarm._last_proto_code = "T"  # known prior state
+
+        status = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="ARMED_TOTAL",
+            protom_response_data="",
+        )
+        alarm.update_status_alarm(status)
+        assert alarm._last_proto_code == "T"
+
+    def test_lowercase_protom_response_does_not_update_last_proto_code(self):
+        """Lowercase letters are not valid proto codes — drop on the floor."""
+        alarm = make_alarm()
+        alarm._last_proto_code = "T"
+
+        status = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="t",
+            protom_response_data="",
+        )
+        alarm.update_status_alarm(status)
+        assert alarm._last_proto_code == "T"
+
 
 # ===========================================================================
 # update_status_alarm  (PERI config)
@@ -1414,6 +1467,33 @@ class TestHandleCoordinatorUpdate:
         alarm = make_alarm()
         alarm.coordinator.data = AlarmStatusData(
             status=SStatus(status="T"), protom_response="T"
+        )
+
+        alarm._handle_coordinator_update()
+
+        assert alarm._last_proto_code == "T"
+
+    def test_coordinator_update_unknown_letter_updates_last_proto_code(self):
+        """Unknown but well-formed proto code from coordinator is stored.
+
+        Forward-compat: when Verisure returns a code we don't yet model,
+        store it so a later arm/disarm refuses cleanly with the actual code.
+        """
+        alarm = make_alarm()
+        alarm.coordinator.data = AlarmStatusData(
+            status=SStatus(status="Z"), protom_response="Z"
+        )
+
+        alarm._handle_coordinator_update()
+
+        assert alarm._last_proto_code == "Z"
+
+    def test_coordinator_update_multi_char_does_not_update_last_proto_code(self):
+        """Multi-char status string from coordinator must not pollute _last_proto_code."""
+        alarm = make_alarm()
+        alarm._last_proto_code = "T"
+        alarm.coordinator.data = AlarmStatusData(
+            status=SStatus(status="ARMED_TOTAL"), protom_response="ARMED_TOTAL"
         )
 
         alarm._handle_coordinator_update()
@@ -2889,6 +2969,137 @@ class TestExecuteTransition:
         )
         assert result.protom_response == "T"
         alarm.client.arm_alarm.assert_called_once()
+
+
+# ===========================================================================
+# Refuse arm/disarm when current state is unknown
+# ===========================================================================
+
+
+class TestExecuteTransitionRefusesUnknownState:
+    """When _last_proto_code is None or an unrecognised proto, refuse to act.
+
+    Acting on a stale or unknown current state is the v5.0.0 disarm-fails-when-
+    annex-armed bug (#441): the resolver computed a no-op transition off a stale
+    'D' and silently skipped DARM1.  We now refuse outright and surface the
+    actual code so the user can report it.
+    """
+
+    async def test_disarm_refused_when_last_proto_code_none(self):
+        """No status poll yet → refuse, do not call disarm_alarm."""
+        alarm = make_alarm()
+        alarm._last_proto_code = None
+        alarm.client.disarm_alarm = AsyncMock()
+
+        with pytest.raises(VerisureOwaError):
+            await alarm._execute_transition(
+                AlarmState(interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF)
+            )
+
+        alarm.client.disarm_alarm.assert_not_called()
+
+    async def test_arm_refused_when_last_proto_code_none(self):
+        """No status poll yet → refuse, do not call arm_alarm."""
+        alarm = make_alarm()
+        alarm._last_proto_code = None
+        alarm.client.arm_alarm = AsyncMock()
+
+        with pytest.raises(VerisureOwaError):
+            await alarm._execute_transition(
+                AlarmState(interior=InteriorMode.TOTAL, perimeter=PerimeterMode.OFF)
+            )
+
+        alarm.client.arm_alarm.assert_not_called()
+
+    async def test_disarm_refused_when_last_proto_code_unknown_letter(self):
+        """Unknown letter (e.g. 'O' on v5.0.0) → refuse rather than silent no-op."""
+        alarm = make_alarm()
+        alarm._last_proto_code = "Z"  # unrecognised
+        alarm.client.disarm_alarm = AsyncMock()
+
+        with pytest.raises(VerisureOwaError):
+            await alarm._execute_transition(
+                AlarmState(interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF)
+            )
+
+        alarm.client.disarm_alarm.assert_not_called()
+
+    async def test_arm_refused_when_last_proto_code_unknown_letter(self):
+        """Unknown letter → refuse arm too, even though resolver could compute a delta."""
+        alarm = make_alarm()
+        alarm._last_proto_code = "Z"
+        alarm.client.arm_alarm = AsyncMock()
+
+        with pytest.raises(VerisureOwaError):
+            await alarm._execute_transition(
+                AlarmState(interior=InteriorMode.TOTAL, perimeter=PerimeterMode.OFF)
+            )
+
+        alarm.client.arm_alarm.assert_not_called()
+
+    async def test_unknown_state_error_contains_code(self):
+        """Refusal message names the unrecognised code so users can report it."""
+        alarm = make_alarm()
+        alarm._last_proto_code = "Z"
+
+        with pytest.raises(VerisureOwaError) as excinfo:
+            await alarm._execute_transition(
+                AlarmState(interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF)
+            )
+
+        assert "'Z'" in excinfo.value.message
+
+    async def test_unknown_state_error_points_to_issue_tracker(self):
+        """Refusal message points users to the upstream issue tracker."""
+        alarm = make_alarm()
+        alarm._last_proto_code = "Z"
+
+        with pytest.raises(VerisureOwaError) as excinfo:
+            await alarm._execute_transition(
+                AlarmState(interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF)
+            )
+
+        assert (
+            "github.com/guerrerotook/securitas-direct-new-api/issues"
+            in excinfo.value.message
+        )
+
+    async def test_disarm_via_public_api_fires_disarm_failed_notification(self):
+        """async_alarm_disarm with unknown current state surfaces translated notification."""
+        alarm = make_alarm()
+        alarm._state = AlarmControlPanelState.ARMED_CUSTOM_BYPASS
+        alarm._last_proto_code = "Z"
+        alarm.client.disarm_alarm = AsyncMock()
+
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.async_alarm_disarm()
+
+        alarm.client.disarm_alarm.assert_not_called()
+        mock_notify.assert_called_once()
+        args, _ = mock_notify.call_args
+        # _notify(hass, notification_id, translation_key, params)
+        assert args[2] == "disarm_failed"
+        assert "'Z'" in args[3]["error"]
+
+    async def test_arm_via_public_api_fires_arm_failed_notification(self):
+        """set_arm_state with unknown current state surfaces translated notification."""
+        alarm = make_alarm()
+        alarm._state = AlarmControlPanelState.ARMED_CUSTOM_BYPASS
+        alarm._last_proto_code = "Z"
+        alarm.client.arm_alarm = AsyncMock()
+
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._notify"
+        ) as mock_notify:
+            await alarm.set_arm_state(AlarmControlPanelState.ARMED_AWAY)
+
+        alarm.client.arm_alarm.assert_not_called()
+        mock_notify.assert_called_once()
+        args, _ = mock_notify.call_args
+        assert args[2] == "arm_failed"
+        assert "'Z'" in args[3]["error"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Closes the silent disarm no-op behind issue #441.

When the API returns a proto code we don't yet model (e.g. the annex codes `X`/`R`/`S`/`O` on v5.0.0, or the still-unmapped 8 perimeter+annex combinations), `_last_proto_code` was never updated — it stayed at whatever was last recognised, typically `"D"` (disarmed). The next disarm therefore saw `current == target == OFF/OFF`, the resolver returned `[]`, and `DARM1` was never sent. Arm coincidentally worked because stale `D` differed from the arm target, so a transition was computed.

## What changed

- `is_proto_letter()` in `verisure_owa_api/models.py` admits any single uppercase ASCII letter — including codes we don't yet model. Replaces `in PROTO_TO_ALARM_STATE` at the four sites that store `_last_proto_code`, so the actual code is captured instead of silently dropped. Multi-char strings (`"ARMED_TOTAL"` from xSStatus polling), lowercase, empty are still rejected.
- New refusal gate at the top of `_execute_transition()`: when `_last_proto_code` is `None` or admitted-but-unmodeled, raise `VerisureOwaError` with the actual code and the issue-tracker URL. The existing `_handle_arm_disarm_error` path turns this into the translated `arm_failed` / `disarm_failed` notification and reverts state.
- Drop the `or "D"` defaults — those were the lie that masked the bug.
- Side-benefit: the still-unmapped 8 perimeter+annex combinations (per `before-release-todo.md`) now fail loud instead of silent.

## Test plan

- [x] 13 new unit tests cover the filter (admit unknown letters, reject noise) and the refusal gate (None / unknown letter; tested via `_execute_transition` directly and via `async_alarm_disarm` / `set_arm_state` to confirm the translated notification fires).
- [x] Full suite: `pytest` — 1328 passed.
- [x] `ruff check .` and `ruff format --check .` clean.
- [x] `pylint custom_components/verisure_owa/` — 10.00/10 on touched files.
- [ ] Manual: arm annex via mobile app while main is disarmed; attempt main-house arm/disarm from HA. Expected: arm + disarm both work (R/S/O are now modeled) or both refuse with a translated notification (perimeter+annex combinations, still unmapped). v5.0.0 silent-disarm-fails should not reproduce.