### PR TITLE
docs: drop relative-time deprecation phrasing — anchor to v6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Home Assistant custom integration for **Verisure** (formerly Securitas Direct in some markets), supporting Argentina, Brazil, Chile, France, Ireland, Italy, Peru, Portugal, Spain, and the United Kingdom.
 
-Renamed from `securitas` to `verisure_owa` in v5.0.0. The legacy domain shim, service aliases, event aliases, and panel URL aliases remain available during a 6-month deprecation window. See the v5 release notes for migration details.
+Renamed from `securitas` to `verisure_owa` in v5.0.0. The legacy domain shim, service aliases, event aliases, and panel URL aliases remain available until v6.0.0. See the v5 release notes for migration details.
 
 ## Features
 

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -38,7 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.warning(
         "The 'securitas' integration is deprecated. Migrating config entry %s "
         "to 'verisure_owa'. The legacy 'securitas' shim will be removed entirely "
-        "in v6.0.0 (~6 months from now).",
+        "in v6.0.0.",
         entry.entry_id,
     )
     await migrate_legacy_entry(hass, entry)
@@ -52,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Your Securitas Direct integration has been migrated to Verisure OWA. "
             "**Please restart Home Assistant** to complete the upgrade. "
             "All your devices, entities, and customizations are preserved.\n\n"
-            "**The following will be removed in v6.0.0 (~6 months from now). "
+            "**The following will be removed in v6.0.0. "
             "Update your automations and dashboards at your pace:**\n\n"
             "- Service calls: `securitas.force_arm` / `securitas.force_arm_cancel` "
             "→ use `verisure_owa.force_arm` / `verisure_owa.force_arm_cancel`\n"

--- a/docs/before-release-todo.md
+++ b/docs/before-release-todo.md
@@ -5,8 +5,8 @@ sub-panels), the `eventlog` work (xSActV2 activity timeline → events
 bus, sensor, Lovelace card), and the **v5 Verisure rebrand** (domain
 renamed from `securitas` to `verisure_owa`, full registry migration via
 a legacy-domain shim, vendored API library renamed to `verisure_owa_api`,
-brand strings updated everywhere, and ~6 months of legacy
-service/event/URL/card-tag aliases for backwards compatibility).
+brand strings updated everywhere, and legacy service/event/URL/card-tag
+aliases for backwards compatibility, removed in v6.0.0).
 Automated tests cover the unit-level behavior; the items below need a
 real HA install + real Verisure account to validate, since they depend
 on actual API responses, multi-axis state, or hardware configuration.
@@ -266,7 +266,7 @@ on actual API responses, multi-axis state, or hardware configuration.
         repo rename.
       - Migration is automatic on first v5 launch; HA restart required.
         The shim shows a persistent notification listing what changed.
-      - 6-month deprecation window with a hard cutoff in v6.0.0.
+      - Deprecation window with a hard cutoff in v6.0.0.
         Specific list of what's deprecated:
         - `securitas` integration domain (config entries auto-migrate)
         - `securitas.force_arm[_cancel]` services

--- a/info.md
+++ b/info.md
@@ -2,7 +2,7 @@
 
 A Home Assistant custom integration for **Verisure** (formerly Securitas Direct in some markets), supporting Argentina, Brazil, Chile, France, Ireland, Italy, Peru, Portugal, Spain, and the United Kingdom.
 
-Renamed from `securitas` to `verisure_owa` in v5.0.0. The legacy domain shim, service aliases, event aliases, and panel URL aliases remain available during a 6-month deprecation window. See the v5 release notes for migration details.
+Renamed from `securitas` to `verisure_owa` in v5.0.0. The legacy domain shim, service aliases, event aliases, and panel URL aliases remain available until v6.0.0. See the v5 release notes for migration details.
 
 ## Features
 


### PR DESCRIPTION
## Summary

The deprecation messaging said the legacy `securitas` shim would be removed \"in v6.0.0 (~6 months from now)\" — but \"from now\" is relative to when the user sees the notification, not to v5.0.0 release. Someone who installs v5 a year after release would see a warning promising removal in 6 months when in reality v6 may have already shipped (or be imminent).

Anchor every user-facing claim to the version, not to a duration.

## Changes

- `custom_components/securitas/__init__.py` (legacy shim): log warning and persistent-notification body drop `(~6 months from now)`.
- `README.md` + `info.md`: \"during a 6-month deprecation window\" → \"until v6.0.0\".
- `docs/before-release-todo.md`: drop `~6 months of legacy` from the branch summary and `6-month deprecation window` from the v5.0.0 release-notes checklist.

## Test plan

- [x] No string-match regressions: `pytest tests/test_init.py tests/test_alarm_panel.py` passes.
- [x] Repo-wide grep for `6 month`, `6-month`, `months from now`, `six month` returns no matches.