### PR TITLE
fix: v5 follow-up — shim loader + Italian perimeter detection

### DIFF
--- a/custom_components/securitas/config_flow.py
+++ b/custom_components/securitas/config_flow.py
@@ -1,0 +1,18 @@
+"""Placeholder flow handler for the legacy 'securitas' shim.
+
+HA's loader requires a registered ConfigFlow for any persisted entry
+(homeassistant/config_entries.py:752-764). Never invoked — `config_flow: false`
+hides it from the UI and the shim removes the entry on migration.
+Removed in v6.0.0 with the rest of the shim.
+"""
+
+from homeassistant import config_entries
+
+from . import DOMAIN
+
+
+class LegacySecuritasFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Never invoked; registered only so HA's loader resolves a versioned handler."""
+
+    VERSION = 3
+    MINOR_VERSION = 1

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -1761,6 +1761,9 @@ class VerisureOwaClient:
             )
             return []
 
+        config_repo = installation_data.get("configRepoUser") or {}
+        installation.alarm_partitions = config_repo.get("alarmPartitions") or []
+
         raw_data = installation_data.get("services")
         if raw_data is None:
             _LOGGER.warning("API returned no services for %s", installation.number)

--- a/tests/test_client_misc.py
+++ b/tests/test_client_misc.py
@@ -487,6 +487,44 @@ class TestGetServices:
         assert expiry > datetime.now()
         assert isinstance(cap_set, frozenset)
 
+    async def test_populates_alarm_partitions_from_config_repo_user(
+        self, client_no_caps, transport
+    ):
+        """get_services copies configRepoUser.alarmPartitions onto the installation.
+
+        Required for SDVECU panels (Italy) where perimeter availability is
+        signaled only by alarmPartitions[id="02"].enterStates — neither a PERI
+        service nor a PERI JWT capability is present. detect_peri's signal 4
+        reads installation.alarm_partitions, which stays empty without this.
+        """
+        partitions = [
+            {"id": "01", "enterStates": ["01", "02"], "leaveStates": ["01", "02"]},
+            {"id": "02", "enterStates": ["01"], "leaveStates": ["01"]},
+            {"id": "03", "enterStates": [], "leaveStates": []},
+        ]
+        transport.execute.return_value = services_response(
+            services=[],
+            config_repo_user={"alarmPartitions": partitions},
+        )
+
+        inst = _make_installation()
+        await client_no_caps.get_services(inst)
+
+        assert inst.alarm_partitions == partitions
+
+    async def test_alarm_partitions_default_empty_when_config_repo_user_missing(
+        self, client_no_caps, transport
+    ):
+        """Spanish/UK responses omit configRepoUser; alarm_partitions stays empty."""
+        transport.execute.return_value = services_response(
+            services=[], config_repo_user=None
+        )
+
+        inst = _make_installation()
+        await client_no_caps.get_services(inst)
+
+        assert inst.alarm_partitions == []
+
     async def test_returns_empty_list_when_no_installation_data(
         self, client_no_caps, transport
     ):

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -115,3 +115,22 @@ async def test_shim_notification_lists_deprecated_surfaces(hass: HomeAssistant):
     assert "verisure_owa_arming_exception" in body
     assert "/verisure_owa_panel" in body
     assert "custom:verisure-owa-alarm-card" in body
+
+
+async def test_shim_migrates_via_ha_loader(
+    hass: HomeAssistant, enable_custom_integrations: None
+):
+    """Regression: migration runs via HA's full loader path (requires config_flow.py)."""
+    legacy = MockConfigEntry(
+        domain="securitas",
+        data={"username": "u@x", "password": "p", "country": "ES"},
+        title="Home",
+        unique_id="u@x:100001",
+        version=3,
+    )
+    legacy.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(legacy.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries("verisure_owa")) == 1


### PR DESCRIPTION
## Summary

Two unrelated bugs surfaced after PR #453 (v5 rebrand) merged. Both are real shipping bugs; bundling here for a single review pass.

### 1. Legacy shim never migrated existing entries on v4→v5 upgrade

`custom_components/securitas/` shipped without a `config_flow.py`. HA's loader unconditionally imports `config_flow.py` and looks up a registered handler when setting up any persisted entry whose domain owns the integration (`homeassistant/config_entries.py:752-764`, `async_migrate`). Without one, the legacy entry hits `SETUP_ERROR` / `MIGRATION_ERROR` *before* `async_setup_entry` runs — so the migration to `verisure_owa` is silently skipped.

Added a minimal `LegacySecuritasFlowHandler(VERSION=3, MINOR_VERSION=1)` stub. `config_flow: false` in the manifest stays as-is; users can't add a new `securitas` entry from the UI, and the stub class is never invoked.

The existing `test_shim` tests called `async_setup_entry` directly and so missed this. Added a regression test that goes through `hass.config_entries.async_setup` to exercise the real loader path.

### 2. Italian (SDVECU) installations reported `has_peri=False`

`detect_peri` has 4 signals; only signal 4 (`installation.alarm_partitions[id="02"].enterStates` non-empty) fires for SDVECU panels. The `Installation` model declared `alarm_partitions` and `SERVICES_QUERY` already requested `configRepoUser.alarmPartitions` — but `get_services()` never copied it from the response onto the installation. The docstring claimed it did. Signal 4 always saw `[]`, so the perimeter alarm panel never appeared on Italian installations.

Fixed by reading `configRepoUser.alarmPartitions` and assigning it onto the passed `Installation`. Verified live: my Italian instance went from `has_peri=False` to `has_peri=True` after restart.

## Test plan

- [x] `tests/test_shim.py::test_shim_migrates_via_ha_loader` — fails without the stub, passes with it
- [x] `tests/test_client_misc.py::test_populates_alarm_partitions_from_config_repo_user` — fails without the parsing fix
- [x] `tests/test_client_misc.py::test_alarm_partitions_default_empty_when_config_repo_user_missing` — confirms Spanish/UK responses (no `configRepoUser`) still produce `[]`
- [x] Full suite: 1318 passed locally
- [x] Live verification: Spanish + Italian instances start cleanly; both legacy `securitas` entries migrate; `capability detection for ***4190: has_peri=True` in the logs after restart