### PR TITLE
Security review batch + config-flow capability fixes

### DIFF
--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -118,6 +118,55 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
+def _publish_flow_capabilities(
+    hass: HomeAssistant,
+    installation_number: str,
+    has_peri: bool,
+    has_annex: bool,
+) -> None:
+    """Cache detected capability flags so the options flow can read them
+    while async_setup_entry is still running.
+
+    Both the config flow's _select_installation step and async_setup_entry's
+    populate_capabilities_from_data call this so the options dialog opened
+    immediately after CREATE_ENTRY (or during a slow restart) doesn't see
+    has_peri=False just because the alarm coordinator dict isn't yet under
+    entry.entry_id in hass.data.
+    """
+    hass.data.setdefault(DOMAIN, {}).setdefault("flow_capabilities", {})[
+        installation_number
+    ] = {"has_peri": has_peri, "has_annex": has_annex}
+
+
+def _resolve_flow_capabilities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> tuple[bool, bool]:
+    """Return (has_peri, has_annex) for *entry* using the most authoritative
+    available source.
+
+    Order:
+      1. The alarm coordinator if it has populated capabilities.
+      2. The published capability cache (set by the config flow and by
+         async_setup_entry as soon as detection runs) — covers the race
+         window where the entry isn't yet stored in hass.data.
+      3. (False, False) if neither source has data — current default.
+    """
+    domain_data = hass.data.get(DOMAIN, {})
+    entry_data = domain_data.get(entry.entry_id, {})
+    coord = entry_data.get("alarm_coordinator")
+    if coord is not None and getattr(coord, "capabilities_populated", False):
+        return coord.has_peri, coord.has_annex
+
+    installation_number = entry.data.get(CONF_INSTALLATION)
+    if installation_number:
+        cached = domain_data.get("flow_capabilities", {}).get(installation_number)
+        if cached:
+            return cached["has_peri"], cached["has_annex"]
+
+    return False, False
+
+
 def add_device_information[T: dict](config: T) -> T:
     """Add device information to the configuration."""
     if CONF_DEVICE_ID not in config:
@@ -534,6 +583,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     first_installation.number
                 )
                 alarm_coord.populate_capabilities_from_data(services, capabilities)
+                # Publish detected capabilities for the options-flow race
+                # window (before entry data is stored under entry.entry_id).
+                _publish_flow_capabilities(
+                    hass,
+                    first_installation.number,
+                    alarm_coord.has_peri,
+                    alarm_coord.has_annex,
+                )
 
             # Sentinel coordinator — needs a sentinel service and its zone
             for service in services:

--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -271,13 +271,16 @@ async def _get_or_create_session(
                 )
                 raise
             except VerisureOwaError as err:
-                detail = err.log_detail()
+                # Log the full detail — the SensitiveDataFilter scrubs known
+                # secrets — but never embed the raw response body in the
+                # user-facing ConfigEntryNotReady text, which doesn't go
+                # through the filter.
                 _LOGGER.error(
                     "Unable to connect to Verisure: %s",
-                    detail,
+                    err.log_detail(),
                 )
                 raise ConfigEntryNotReady(
-                    f"Unable to connect to Verisure: {detail}"
+                    f"Unable to connect to Verisure: {err.message}"
                 ) from None
             sessions[username] = {"hub": client, "ref_count": 1}
 

--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -56,6 +56,7 @@ from .verisure_owa_api import (
     OperationStatus,
     PROTO_DISARMED,
     PROTO_TO_STATE,
+    STATE_LABELS,
     VerisureOwaError,
     VerisureOwaState,
     STATE_TO_COMMAND,
@@ -204,6 +205,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._has_peri = coordinator.has_peri
         self._has_annex = coordinator.has_annex
         self._last_proto_code: str | None = None
+        # Tracks the proto code most-recently logged as unmapped so we don't
+        # spam the same warning on every coordinator poll while the panel
+        # sits in that state.
+        self._last_unmapped_logged: str | None = None
         self._resolver = CommandResolver(has_peri=self._has_peri)
 
         # Build outgoing map: HA state -> API command string
@@ -343,10 +348,48 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._state = self._status_map[proto_code]
         else:
             self._state = AlarmControlPanelState.ARMED_CUSTOM_BYPASS
-            _LOGGER.info(
-                "Unmapped alarm status code '%s' from Verisure. "
-                "Check your Alarm State Mappings in the integration options",
+            self._log_unmapped_proto_code(proto_code)
+
+    def _log_unmapped_proto_code(self, proto_code: str) -> None:
+        """Warn that the panel reported a state HA can't represent.
+
+        Distinguishes two cases so the user (or a maintainer reading logs)
+        knows whether to fix their config or file a bug:
+
+        - Code is in PROTO_TO_STATE but no HA button maps to that state
+          (the user just needs to bind a button in options).
+        - Code isn't in PROTO_TO_STATE at all — the integration doesn't
+          know this state, please report.
+
+        Deduped per entity: we only re-log when the unmapped code changes,
+        so a panel sitting in the unmapped state doesn't spam every poll.
+        """
+        if self._last_unmapped_logged == proto_code:
+            return
+        self._last_unmapped_logged = proto_code
+        sec_state = PROTO_TO_STATE.get(proto_code)
+        if sec_state is not None:
+            label = STATE_LABELS.get(sec_state, sec_state.value)
+            _LOGGER.warning(
+                "[%s installation=%s] Unmapped alarm state: Verisure reports "
+                "'%s' (proto code '%s'). None of the buttons on the main "
+                "control panel are mapped to it. Map a button in Settings → "
+                "Devices & Services → Verisure OWA → Configure → Alarm State "
+                "Mappings, or HA will keep showing this as 'armed_custom_bypass'.",
+                self.entity_id,
+                self.installation.number,
+                label,
                 proto_code,
+            )
+        else:
+            _LOGGER.warning(
+                "[%s installation=%s] Unmapped alarm state: Verisure proto "
+                "code '%s' is not recognised by this integration. Please "
+                "report at %s.",
+                self.entity_id,
+                self.installation.number,
+                proto_code,
+                _PROJECT_URL,
             )
 
     def _store_operation_status_metadata(self, status: OperationStatus | None) -> bool:
@@ -394,11 +437,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._state = self._status_map[status.protom_response]
         else:
             self._state = AlarmControlPanelState.ARMED_CUSTOM_BYPASS
-            _LOGGER.info(
-                "Unmapped alarm status code '%s' from Verisure. "
-                "Check your Alarm State Mappings in the integration options",
-                status.protom_response,
-            )
+            self._log_unmapped_proto_code(status.protom_response)
 
     def _check_code_for_arm_if_required(self, code: str | None) -> bool:
         """Check the code only if arming requires a code and a PIN is configured."""

--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -205,9 +205,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._has_peri = coordinator.has_peri
         self._has_annex = coordinator.has_annex
         self._last_proto_code: str | None = None
-        # Tracks the proto code most-recently logged as unmapped so we don't
-        # spam the same warning on every coordinator poll while the panel
-        # sits in that state.
+        # Last proto code we warned about; dedupes the per-poll spam.
         self._last_unmapped_logged: str | None = None
         self._resolver = CommandResolver(has_peri=self._has_peri)
 

--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -7,6 +7,7 @@ from typing import Any
 import uuid
 
 import homeassistant.components.alarm_control_panel as alarm
+import voluptuous as vol
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,  # type: ignore[attr-defined]
     CodeFormat,  # type: ignore[attr-defined]
@@ -15,6 +16,7 @@ from homeassistant.components.alarm_control_panel.const import AlarmControlPanel
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CODE, CONF_SCAN_INTERVAL
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
@@ -159,7 +161,7 @@ async def async_setup_entry(
     platform = async_get_current_platform()
     platform.async_register_entity_service(
         "force_arm",
-        {},
+        {vol.Optional(CONF_CODE): cv.string},
         "async_force_arm",
     )
     platform.async_register_entity_service(
@@ -972,12 +974,22 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._dismiss_arming_exception_notification()
         self.async_write_ha_state()
 
-    async def async_force_arm(self) -> None:
+    async def async_force_arm(self, code: str | None = None) -> None:
         """Force-arm using stored exception context.
 
         Called by the verisure_owa.force_arm service. Re-arms in the same mode
         that previously failed, passing the stored referenceId and suid to
         override non-blocking exceptions.
+
+        The presence of self._force_context is itself proof that a PIN-
+        authenticated arm reached the server within the last scan_interval
+        — set_arm_state can only populate the context after _async_arm
+        passes _check_code_for_arm_if_required.  So we don't re-prompt for
+        the PIN on this second-half completion (which would also break the
+        mobile-notification tap flow, since notifications can't carry a PIN).
+
+        If a service caller passes ``code`` explicitly (defence-in-depth for
+        paranoid automations) we still validate it against the configured PIN.
         """
         if self._force_context is None:
             _LOGGER.warning(
@@ -985,6 +997,8 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 self.installation.number,
             )
             return
+        if code is not None:
+            self._check_code(code)
         mode = self._force_context["mode"]
         ref_id = self._force_context["reference_id"]
         suid = self._force_context["suid"]

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -80,6 +80,37 @@ _LOGGER = logging.getLogger(__name__)
 
 _NOTIFY_EXCLUDE = {"notify", "send_message", "persistent_notification"}
 
+PANEL_OPTION_KEYS = (
+    CONF_ENABLE_PERIMETER_PANEL,
+    CONF_ENABLE_INTERIOR_PANEL,
+    CONF_ENABLE_ANNEX_PANEL,
+)
+
+
+def _build_panel_extra_fields(
+    *,
+    has_peri: bool,
+    has_annex: bool,
+    peri_default: bool = False,
+    annex_default: bool = False,
+    interior_default: bool = False,
+) -> dict[Any, Any]:
+    """Build the capability-gated panel-toggle entries for a settings schema.
+
+    The interior toggle appears whenever any sibling axis is supported; this
+    matches the post-setup options behaviour so users on any peri- or annex-
+    capable installation can carve a separate interior sub-panel even after
+    flipping the sibling off.
+    """
+    fields: dict[Any, Any] = {}
+    if has_peri:
+        fields[vol.Optional(CONF_ENABLE_PERIMETER_PANEL, default=peri_default)] = bool
+    if has_annex:
+        fields[vol.Optional(CONF_ENABLE_ANNEX_PANEL, default=annex_default)] = bool
+    if has_peri or has_annex:
+        fields[vol.Optional(CONF_ENABLE_INTERIOR_PANEL, default=interior_default)] = bool
+    return fields
+
 
 def _get_notify_options(hass: HomeAssistant) -> list[dict[str, str]]:
     """Build notify service dropdown options."""
@@ -170,9 +201,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._available_installations: list[Installation] = []
         self._selected_installation: Installation | None = None
         self._options_data: dict[str, Any] = {}
-        # Sub-panel toggles selected on the initial flow's options step go
-        # into entry.options on CREATE_ENTRY (kept separate so they don't
-        # pollute entry.data, which is the OptionsFlow's fallback source).
+        # Kept separate from _options_data so toggles end up on entry.options,
+        # not entry.data — matches where the post-setup OptionsFlow writes them.
         self._panel_options: dict[str, Any] = {}
         self._has_peri: bool = False
         self._has_annex: bool = False
@@ -651,36 +681,17 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # Flatten the advanced section back to top-level keys
             advanced = user_input.pop(CONF_ADVANCED, {})
             user_input.update(advanced)
-            # Split the panel-enable toggles out of the data-bound options
-            # so they end up in entry.options (where the post-setup flow
-            # writes them) rather than entry.data.
-            for key in (
-                CONF_ENABLE_PERIMETER_PANEL,
-                CONF_ENABLE_INTERIOR_PANEL,
-                CONF_ENABLE_ANNEX_PANEL,
-            ):
+            # Toggles belong on entry.options, not entry.data.
+            for key in PANEL_OPTION_KEYS:
                 if key in user_input:
                     self._panel_options[key] = user_input.pop(key)
             self._options_data = user_input
             return await self.async_step_mappings()
 
         notify_options = _get_notify_options(self.hass)
-        # Capability-gated sub-panel toggles — same surface as the
-        # post-setup OptionsFlow, so users can opt in during initial setup
-        # without having to re-open Configure afterwards.
-        extra_fields: dict[Any, Any] = {}
-        if self._has_peri:
-            extra_fields[
-                vol.Optional(CONF_ENABLE_PERIMETER_PANEL, default=False)
-            ] = bool
-        if self._has_annex:
-            extra_fields[
-                vol.Optional(CONF_ENABLE_ANNEX_PANEL, default=False)
-            ] = bool
-        if self._has_peri or self._has_annex:
-            extra_fields[
-                vol.Optional(CONF_ENABLE_INTERIOR_PANEL, default=False)
-            ] = bool
+        extra_fields = _build_panel_extra_fields(
+            has_peri=self._has_peri, has_annex=self._has_annex
+        )
 
         schema = _build_settings_schema(
             {
@@ -798,33 +809,14 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
         has_peri, has_annex = _resolve_flow_capabilities(
             self.hass, self.config_entry
         )
-        peri_currently_enabled = self.config_entry.options.get(
-            CONF_ENABLE_PERIMETER_PANEL, False
+        opts = self.config_entry.options
+        extra_fields = _build_panel_extra_fields(
+            has_peri=has_peri,
+            has_annex=has_annex,
+            peri_default=opts.get(CONF_ENABLE_PERIMETER_PANEL, False),
+            annex_default=opts.get(CONF_ENABLE_ANNEX_PANEL, False),
+            interior_default=opts.get(CONF_ENABLE_INTERIOR_PANEL, False),
         )
-        annex_currently_enabled = self.config_entry.options.get(
-            CONF_ENABLE_ANNEX_PANEL, False
-        )
-
-        extra_fields: dict[Any, Any] = {}
-        if has_peri:
-            extra_fields[
-                vol.Optional(
-                    CONF_ENABLE_PERIMETER_PANEL, default=peri_currently_enabled
-                )
-            ] = bool
-        if has_annex:
-            extra_fields[
-                vol.Optional(CONF_ENABLE_ANNEX_PANEL, default=annex_currently_enabled)
-            ] = bool
-        if has_peri or has_annex:
-            extra_fields[
-                vol.Optional(
-                    CONF_ENABLE_INTERIOR_PANEL,
-                    default=self.config_entry.options.get(
-                        CONF_ENABLE_INTERIOR_PANEL, False
-                    ),
-                )
-            ] = bool
 
         schema = _build_settings_schema(
             {

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -48,6 +48,8 @@ from . import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     VerisureHub,
+    _publish_flow_capabilities,
+    _resolve_flow_capabilities,
     generate_uuid,
 )
 from .const import (
@@ -70,7 +72,7 @@ from .verisure_owa_api import (
     VerisureOwaError,
     TwoFactorRequiredError,
 )
-from .verisure_owa_api.capabilities import detect_peri
+from .verisure_owa_api.capabilities import detect_annex, detect_peri
 
 VERSION = 4
 
@@ -592,8 +594,15 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         capabilities = self.hub.client.get_supported_commands(installation.number)
         self._has_peri = detect_peri(installation, services, capabilities)
+        has_annex = detect_annex(capabilities)
         _LOGGER.debug(
             "Perimeter detected for %s: %s", installation.number, self._has_peri
+        )
+        # Publish the detection result so the options flow can render the
+        # right toggles even if the user opens it before async_setup_entry
+        # has finished storing the alarm coordinator under entry.entry_id.
+        _publish_flow_capabilities(
+            self.hass, installation.number, self._has_peri, has_annex
         )
 
         return await self.async_step_options()
@@ -745,14 +754,13 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
 
         notify_options = _get_notify_options(self.hass)
 
-        # Capability-gated sub-panel toggles — read from the running coordinator.
-        coordinator = (
-            self.hass.data.get(DOMAIN, {})
-            .get(self.config_entry.entry_id, {})
-            .get("alarm_coordinator")
+        # Capability-gated sub-panel toggles — resolve via the helper so the
+        # options dialog opened during async_setup_entry's get_services await
+        # (when the coordinator dict isn't yet under entry.entry_id) still
+        # picks up the published capabilities from the config flow.
+        has_peri, has_annex = _resolve_flow_capabilities(
+            self.hass, self.config_entry
         )
-        has_peri = bool(coordinator and coordinator.has_peri)
-        has_annex = bool(coordinator and coordinator.has_annex)
         peri_currently_enabled = self.config_entry.options.get(
             CONF_ENABLE_PERIMETER_PANEL, False
         )
@@ -812,13 +820,10 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
             data = {**self._general_data, **user_input}
             return self.async_create_entry(title="", data=data)
 
-        # Read has_peri from the running coordinator (live detection).
-        # Falls back to False if the coordinator is unavailable.
-        coordinator_data = self.hass.data.get(DOMAIN, {}).get(
-            self.config_entry.entry_id, {}
-        )
-        coordinator = coordinator_data.get("alarm_coordinator")
-        has_peri = coordinator.has_peri if coordinator is not None else False
+        # Resolve via the helper so we read coordinator → published cache →
+        # False, matching the init step. Avoids the race where the user
+        # opens the dialog before async_setup_entry has stored the coord.
+        has_peri, _ = _resolve_flow_capabilities(self.hass, self.config_entry)
 
         # Determine defaults for mapping dropdowns
         defaults = PERI_DEFAULTS if has_peri else STD_DEFAULTS

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -170,7 +170,12 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._available_installations: list[Installation] = []
         self._selected_installation: Installation | None = None
         self._options_data: dict[str, Any] = {}
+        # Sub-panel toggles selected on the initial flow's options step go
+        # into entry.options on CREATE_ENTRY (kept separate so they don't
+        # pollute entry.data, which is the OptionsFlow's fallback source).
+        self._panel_options: dict[str, Any] = {}
         self._has_peri: bool = False
+        self._has_annex: bool = False
         self._reauth_entry: config_entries.ConfigEntry | None = None
 
     async def _create_entry_for_installation(
@@ -196,7 +201,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         entry_data = dict(self.config)
         entry_data.pop(CONF_PASSWORD, None)
         entry_data[CONF_REFRESH_TOKEN] = refresh_token
-        return self.async_create_entry(title=installation.alias, data=entry_data)
+        return self.async_create_entry(
+            title=installation.alias,
+            data=entry_data,
+            options=dict(self._panel_options) if self._panel_options else None,
+        )
 
     def _create_client(
         self,
@@ -594,7 +603,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         capabilities = self.hub.client.get_supported_commands(installation.number)
         self._has_peri = detect_peri(installation, services, capabilities)
-        has_annex = detect_annex(capabilities)
+        self._has_annex = detect_annex(capabilities)
         _LOGGER.debug(
             "Perimeter detected for %s: %s", installation.number, self._has_peri
         )
@@ -602,7 +611,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # right toggles even if the user opens it before async_setup_entry
         # has finished storing the alarm coordinator under entry.entry_id.
         _publish_flow_capabilities(
-            self.hass, installation.number, self._has_peri, has_annex
+            self.hass, installation.number, self._has_peri, self._has_annex
         )
 
         return await self.async_step_options()
@@ -636,22 +645,50 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_options(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
-        """Step 3: PIN, scan interval, notification settings."""
+        """Step 3: PIN, scan interval, notifications, sub-panel toggles."""
         if user_input is not None:
             user_input.setdefault(CONF_CODE, DEFAULT_CODE)
             # Flatten the advanced section back to top-level keys
             advanced = user_input.pop(CONF_ADVANCED, {})
             user_input.update(advanced)
+            # Split the panel-enable toggles out of the data-bound options
+            # so they end up in entry.options (where the post-setup flow
+            # writes them) rather than entry.data.
+            for key in (
+                CONF_ENABLE_PERIMETER_PANEL,
+                CONF_ENABLE_INTERIOR_PANEL,
+                CONF_ENABLE_ANNEX_PANEL,
+            ):
+                if key in user_input:
+                    self._panel_options[key] = user_input.pop(key)
             self._options_data = user_input
             return await self.async_step_mappings()
 
         notify_options = _get_notify_options(self.hass)
+        # Capability-gated sub-panel toggles — same surface as the
+        # post-setup OptionsFlow, so users can opt in during initial setup
+        # without having to re-open Configure afterwards.
+        extra_fields: dict[Any, Any] = {}
+        if self._has_peri:
+            extra_fields[
+                vol.Optional(CONF_ENABLE_PERIMETER_PANEL, default=False)
+            ] = bool
+        if self._has_annex:
+            extra_fields[
+                vol.Optional(CONF_ENABLE_ANNEX_PANEL, default=False)
+            ] = bool
+        if self._has_peri or self._has_annex:
+            extra_fields[
+                vol.Optional(CONF_ENABLE_INTERIOR_PANEL, default=False)
+            ] = bool
+
         schema = _build_settings_schema(
             {
                 CONF_CODE: DEFAULT_CODE,
                 CONF_CODE_ARM_REQUIRED: DEFAULT_CODE_ARM_REQUIRED,
             },
             notify_options,
+            extra_fields=extra_fields,
         )
         install_name = (
             self._selected_installation.alias if self._selected_installation else ""

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -108,7 +108,9 @@ def _build_panel_extra_fields(
     if has_annex:
         fields[vol.Optional(CONF_ENABLE_ANNEX_PANEL, default=annex_default)] = bool
     if has_peri or has_annex:
-        fields[vol.Optional(CONF_ENABLE_INTERIOR_PANEL, default=interior_default)] = bool
+        fields[vol.Optional(CONF_ENABLE_INTERIOR_PANEL, default=interior_default)] = (
+            bool
+        )
     return fields
 
 
@@ -806,9 +808,7 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
         # options dialog opened during async_setup_entry's get_services await
         # (when the coordinator dict isn't yet under entry.entry_id) still
         # picks up the published capabilities from the config flow.
-        has_peri, has_annex = _resolve_flow_capabilities(
-            self.hass, self.config_entry
-        )
+        has_peri, has_annex = _resolve_flow_capabilities(self.hass, self.config_entry)
         opts = self.config_entry.options
         extra_fields = _build_panel_extra_fields(
             has_peri=has_peri,

--- a/custom_components/verisure_owa/coordinators.py
+++ b/custom_components/verisure_owa/coordinators.py
@@ -161,6 +161,17 @@ class AlarmCoordinator(DataUpdateCoordinator[AlarmStatusData]):
         return self._has_annex
 
     @property
+    def capabilities_populated(self) -> bool:
+        """Return True once has_peri / has_annex have been derived from a
+        real fetch — not the initial False default.
+
+        The options flow uses this to decide whether the coordinator's
+        capability flags are authoritative or whether to fall back to the
+        published capability cache.
+        """
+        return self._capabilities_populated
+
+    @property
     def capabilities(self) -> frozenset[str]:
         """Return the supported command capability set."""
         return self._capabilities

--- a/custom_components/verisure_owa/hub.py
+++ b/custom_components/verisure_owa/hub.py
@@ -482,10 +482,6 @@ class VerisureHub:
         """Get the authentication token."""
         return self.client.authentication_token
 
-    def set_authentication_token(self, value: str) -> None:
-        """Set the authentication token."""
-        self.client.authentication_token = value
-
     def get_refresh_token(self) -> str:
         """Get the long-lived refresh token, or empty string if absent."""
         return self.client.refresh_token_value

--- a/custom_components/verisure_owa/hub.py
+++ b/custom_components/verisure_owa/hub.py
@@ -150,6 +150,12 @@ class VerisureHub:
         self.lang: str = api_domains.get_language(self.country)
         self.hass: HomeAssistant = hass
         self._services_cache: dict[str, list[Service]] = {}
+        # Mirrors `installation.alarm_partitions` (a side-effect of
+        # client.get_services) keyed by installation number so cache hits
+        # in get_services can re-apply the partitions to a fresh
+        # Installation instance — required by detect_peri's Italian
+        # SDVECU signal.
+        self._partitions_cache: dict[str, list[dict[str, Any]]] = {}
         self.log_filter: SensitiveDataFilter | None = hass.data.get(DOMAIN, {}).get(
             "log_filter"
         )
@@ -227,11 +233,22 @@ class VerisureHub:
     async def get_services(
         self, instalation: Installation, priority: int | None = None
     ) -> list[Service]:
-        """Get the list of services from the installation (cached)."""
+        """Get the list of services from the installation (cached).
+
+        ``client.get_services`` mutates ``installation.alarm_partitions`` as
+        a side effect — Italian SDVECU panels need that field for capability
+        detection (it's the only signal that fires for them).  Cache the
+        partitions alongside the services and re-apply them on cache hits
+        so downstream detect_peri sees them no matter which Installation
+        instance the caller passed in.
+        """
         if priority is None:
             priority = ApiQueue.BACKGROUND
         key = instalation.number
         if key in self._services_cache:
+            cached_partitions = self._partitions_cache.get(key)
+            if cached_partitions is not None:
+                instalation.alarm_partitions = list(cached_partitions)
             return self._services_cache[key]
         services = await self._api_queue.submit(
             self.client.get_services,
@@ -239,6 +256,9 @@ class VerisureHub:
             priority=priority,
         )
         self._services_cache[key] = services
+        # Snapshot the partitions populated by client.get_services so the
+        # next caller with a fresh Installation can recover them.
+        self._partitions_cache[key] = list(instalation.alarm_partitions)
         return services
 
     async def get_camera_devices(

--- a/custom_components/verisure_owa/services.yaml
+++ b/custom_components/verisure_owa/services.yaml
@@ -3,6 +3,12 @@ force_arm:
     entity:
       integration: verisure_owa
       domain: alarm_control_panel
+  fields:
+    code:
+      example: "1234"
+      selector:
+        text:
+          type: password
 
 force_arm_cancel:
   target:

--- a/custom_components/verisure_owa/strings.json
+++ b/custom_components/verisure_owa/strings.json
@@ -57,7 +57,10 @@
                     "code": "PIN Code (leave empty for no PIN)",
                     "code_arm_required": "Also require PIN code (if any) to arm alarm",
                     "notify_group": "Notify service for arming exceptions (e.g. mobile_app_phone)",
-                    "force_arm_notifications": "Built-in force-arm notifications (disable to use your own automations)"
+                    "force_arm_notifications": "Built-in force-arm notifications (disable to use your own automations)",
+                    "enable_interior_panel": "Enable Interior-only control panel",
+                    "enable_perimeter_panel": "Enable Perimeter-only control panel",
+                    "enable_annex_panel": "Enable Annex-only control panel"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/strings.json
+++ b/custom_components/verisure_owa/strings.json
@@ -120,7 +120,13 @@
     "services": {
         "force_arm": {
             "name": "Force arm",
-            "description": "Force-arm the alarm, overriding non-blocking exceptions (e.g. open windows) from a previous failed arm attempt."
+            "description": "Force-arm the alarm, overriding non-blocking exceptions (e.g. open windows) from a previous failed arm attempt.",
+            "fields": {
+                "code": {
+                    "name": "PIN code",
+                    "description": "Optional. If supplied, validated against the configured PIN before completing the force-arm. Most callers don't need this — the prior arm attempt that produced the force-arm context already validated the PIN."
+                }
+            }
         },
         "force_arm_cancel": {
             "name": "Cancel force arm",

--- a/custom_components/verisure_owa/translations/ca.json
+++ b/custom_components/verisure_owa/translations/ca.json
@@ -57,7 +57,10 @@
                     "code": "Codi PIN (deixeu-lo buit per no usar cap PIN)",
                     "code_arm_required": "Requerir també el codi PIN (si n'hi ha) per armar l'alarma",
                     "notify_group": "Servei de notificació per a excepcions en armar (p. ex. mobile_app_phone)",
-                    "force_arm_notifications": "Notificacions integrades d'armat forçat (desactiveu-les per usar les vostres automatitzacions)"
+                    "force_arm_notifications": "Notificacions integrades d'armat forçat (desactiveu-les per usar les vostres automatitzacions)",
+                    "enable_interior_panel": "Activar el panell de control només Interior",
+                    "enable_perimeter_panel": "Activar el panell de control només Perímetre",
+                    "enable_annex_panel": "Activar el panell de control només Annex"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/translations/en.json
+++ b/custom_components/verisure_owa/translations/en.json
@@ -57,7 +57,10 @@
                     "code": "PIN Code (leave empty for no PIN)",
                     "code_arm_required": "Also require PIN code (if any) to arm alarm",
                     "notify_group": "Notify service for arming exceptions (e.g. mobile_app_phone)",
-                    "force_arm_notifications": "Built-in force-arm notifications (disable to use your own automations)"
+                    "force_arm_notifications": "Built-in force-arm notifications (disable to use your own automations)",
+                    "enable_interior_panel": "Enable Interior-only control panel",
+                    "enable_perimeter_panel": "Enable Perimeter-only control panel",
+                    "enable_annex_panel": "Enable Annex-only control panel"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/translations/es.json
+++ b/custom_components/verisure_owa/translations/es.json
@@ -57,7 +57,10 @@
                     "code": "Código PIN (dejar vacío si no hay PIN)",
                     "code_arm_required": "Requerir también código PIN (si lo hay) para armar alarma",
                     "notify_group": "Servicio de notificación para excepciones de armado (p. ej. mobile_app_phone)",
-                    "force_arm_notifications": "Notificaciones integradas de forzar armado (desactivar para usar sus propias automatizaciones)"
+                    "force_arm_notifications": "Notificaciones integradas de forzar armado (desactivar para usar sus propias automatizaciones)",
+                    "enable_interior_panel": "Activar panel de control solo Interior",
+                    "enable_perimeter_panel": "Activar panel de control solo Perimetral",
+                    "enable_annex_panel": "Activar panel de control solo Anexo"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/translations/fr.json
+++ b/custom_components/verisure_owa/translations/fr.json
@@ -57,7 +57,10 @@
                     "code": "Code PIN (laisser vide pour ne pas utiliser de PIN)",
                     "code_arm_required": "Exiger également le code PIN (s'il y en a un) pour armer l'alarme",
                     "notify_group": "Service de notification pour les exceptions d'armement (ex. mobile_app_phone)",
-                    "force_arm_notifications": "Notifications intégrées de forçage d'armement (désactiver pour utiliser vos propres automatisations)"
+                    "force_arm_notifications": "Notifications intégrées de forçage d'armement (désactiver pour utiliser vos propres automatisations)",
+                    "enable_interior_panel": "Activer le panneau de contrôle Intérieur uniquement",
+                    "enable_perimeter_panel": "Activer le panneau de contrôle Périmètre uniquement",
+                    "enable_annex_panel": "Activer le panneau de contrôle Annexe uniquement"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/translations/it.json
+++ b/custom_components/verisure_owa/translations/it.json
@@ -57,7 +57,10 @@
                     "code": "Codice PIN (lasciare vuoto per non usare un PIN)",
                     "code_arm_required": "Richiedere anche il codice PIN (se presente) per attivare l'allarme",
                     "notify_group": "Servizio di notifica per eccezioni di attivazione (es. mobile_app_phone)",
-                    "force_arm_notifications": "Notifiche integrate di attivazione forzata (disattivare per usare le proprie automazioni)"
+                    "force_arm_notifications": "Notifiche integrate di attivazione forzata (disattivare per usare le proprie automazioni)",
+                    "enable_interior_panel": "Attiva pannello di controllo solo Interno",
+                    "enable_perimeter_panel": "Attiva pannello di controllo solo Perimetrale",
+                    "enable_annex_panel": "Attiva pannello di controllo solo Annesso"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/translations/pt-BR.json
+++ b/custom_components/verisure_owa/translations/pt-BR.json
@@ -57,7 +57,10 @@
                     "code": "Código PIN (deixar vazio para não usar PIN)",
                     "code_arm_required": "Exigir também o código PIN (se houver) para armar o alarme",
                     "notify_group": "Serviço de notificação para exceções de armar (ex. mobile_app_phone)",
-                    "force_arm_notifications": "Notificações integradas de armar forçado (desativar para usar suas próprias automatizações)"
+                    "force_arm_notifications": "Notificações integradas de armar forçado (desativar para usar suas próprias automatizações)",
+                    "enable_interior_panel": "Ativar painel de controle apenas Interior",
+                    "enable_perimeter_panel": "Ativar painel de controle apenas Perímetro",
+                    "enable_annex_panel": "Ativar painel de controle apenas Anexo"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/translations/pt.json
+++ b/custom_components/verisure_owa/translations/pt.json
@@ -57,7 +57,10 @@
                     "code": "Código PIN (deixar vazio para não usar PIN)",
                     "code_arm_required": "Exigir também o código PIN (se existir) para armar o alarme",
                     "notify_group": "Serviço de notificação para exceções de armar (ex. mobile_app_phone)",
-                    "force_arm_notifications": "Notificações integradas de armar forçado (desativar para usar as suas próprias automatizações)"
+                    "force_arm_notifications": "Notificações integradas de armar forçado (desativar para usar as suas próprias automatizações)",
+                    "enable_interior_panel": "Ativar painel de controlo apenas Interior",
+                    "enable_perimeter_panel": "Ativar painel de controlo apenas Perímetro",
+                    "enable_annex_panel": "Ativar painel de controlo apenas Anexo"
                 },
                 "sections": {
                     "advanced": {

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -351,6 +351,10 @@ class VerisureOwaClient:
         if not token_str:
             return None
         try:
+            # Tokens come from a trusted HTTPS endpoint, so we don't verify
+            # signatures here. The Verisure API signs with EdDSA, not HS256 —
+            # passing a constraining `algorithms=` would be misleading and
+            # would break if signature verification were ever turned on.
             decoded = jwt.decode(token_str, options={"verify_signature": False})
         except jwt.exceptions.DecodeError:
             _LOGGER.warning("Failed to decode authentication token")
@@ -749,8 +753,11 @@ class VerisureOwaClient:
 
         try:
             response = await self._execute_raw(content, "mkValidateDevice")
-            self.authentication_otp_challenge_value = None
         except VerisureOwaError as err:
+            # Always invalidate the (hash, code) pair on failure so a wrong
+            # OTP cannot be replayed in the next request's headers; the user
+            # must request a fresh OTP via send_otp.
+            self.authentication_otp_challenge_value = None
             if err.response_body is not None:
                 try:
                     error_data = err.response_body["errors"][0]["data"]
@@ -759,6 +766,8 @@ class VerisureOwaClient:
                 except (KeyError, IndexError, TypeError):
                     pass
             raise
+        else:
+            self.authentication_otp_challenge_value = None
 
         if "errors" in response and response["errors"][0]["message"] == "Unauthorized":
             return self._extract_otp_data(response["errors"][0]["data"])
@@ -1796,7 +1805,9 @@ class VerisureOwaClient:
             _LOGGER.warning("API returned no capabilities for %s", installation.number)
             return []
 
-        # Decode capabilities JWT and store in self._capabilities
+        # Decode capabilities JWT and store in self._capabilities. As with
+        # the auth token, tokens come from a trusted HTTPS endpoint and are
+        # signed with EdDSA, so we don't verify signatures here.
         try:
             token = jwt.decode(capabilities, options={"verify_signature": False})
         except jwt.exceptions.DecodeError as err:

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -766,8 +766,7 @@ class VerisureOwaClient:
                 except (KeyError, IndexError, TypeError):
                     pass
             raise
-        else:
-            self.authentication_otp_challenge_value = None
+        self.authentication_otp_challenge_value = None
 
         if "errors" in response and response["errors"][0]["message"] == "Unauthorized":
             return self._extract_otp_data(response["errors"][0]["data"])

--- a/custom_components/verisure_owa/verisure_owa_api/http_transport.py
+++ b/custom_components/verisure_owa/verisure_owa_api/http_transport.py
@@ -135,7 +135,9 @@ class HttpTransport:
                 # could send Retry-After: 86400 and freeze the coordinator
                 # for a day. A 60s ceiling lets the rate limiter recover
                 # gracefully without blocking the event loop indefinitely.
-                delay = min(delay, _RETRY_AFTER_MAX_SECONDS)
+                # Negative values from a hostile server would crash
+                # asyncio.sleep; floor to 0 (retry immediately).
+                delay = max(0, min(delay, _RETRY_AFTER_MAX_SECONDS))
                 _LOGGER.warning("HTTP 403, retrying in %ds", delay)
                 await asyncio.sleep(delay)
                 continue

--- a/custom_components/verisure_owa/verisure_owa_api/http_transport.py
+++ b/custom_components/verisure_owa/verisure_owa_api/http_transport.py
@@ -20,6 +20,10 @@ from .exceptions import VerisureOwaError, WAFBlockedError
 
 _LOGGER = logging.getLogger(__name__)
 
+# Upper bound on a server-supplied Retry-After delay. Without this, a hostile
+# or misconfigured server can block the worker for arbitrarily long.
+_RETRY_AFTER_MAX_SECONDS = 60
+
 # Keys whose values should be replaced with a placeholder in debug logs
 _LOG_TRUNCATE_KEYS = {"hours", "image", "reg"}
 
@@ -127,6 +131,11 @@ class HttpTransport:
                     delay = int(retry_after) if retry_after else 2
                 except (ValueError, TypeError):
                     delay = 2
+                # Clamp to a sensible upper bound — a hostile or buggy server
+                # could send Retry-After: 86400 and freeze the coordinator
+                # for a day. A 60s ceiling lets the rate limiter recover
+                # gracefully without blocking the event loop indefinitely.
+                delay = min(delay, _RETRY_AFTER_MAX_SECONDS)
                 _LOGGER.warning("HTTP 403, retrying in %ds", delay)
                 await asyncio.sleep(delay)
                 continue

--- a/custom_components/verisure_owa/www/verisure-owa-alarm-card.js
+++ b/custom_components/verisure_owa/www/verisure-owa-alarm-card.js
@@ -406,6 +406,11 @@ class VerisureOwaAlarmCard extends HTMLElement {
 
   disconnectedCallback() {
     if (this._gestureCleanup) { this._gestureCleanup(); this._gestureCleanup = null; }
+    // Zero in-flight PIN entry so it doesn't linger in memory if the card is
+    // detached mid-entry (e.g. dashboard tab switch).
+    this._pin = "";
+    this._uiState = "normal";
+    this._pendingAction = null;
   }
 
   setConfig(config) {
@@ -626,7 +631,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
         <div class="pin-section">
           <div class="pin-label">${_t(lang, "enter_pin", { action: actionLabel })}</div>
           <input id="pin-keyboard-input" class="pin-input" type="password"
-                 inputmode="numeric" autocomplete="off" value="${this._pin}"
+                 inputmode="numeric" autocomplete="off"
                  placeholder="\u2022\u2022\u2022\u2022" />
           <div class="keypad">
             ${[1,2,3,4,5,6,7,8,9].map(n =>
@@ -645,7 +650,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
       <div class="pin-section">
         <div class="pin-label">${_t(lang, "enter_code", { action: actionLabel })}</div>
         <input class="code-input" type="password" autocomplete="off"
-               placeholder="${_t(lang, "code")}" value="${this._esc(this._pin)}" id="code-input" />
+               placeholder="${_t(lang, "code")}" id="code-input" />
         <div class="text-pin-btns">
           <button class="btn btn-cancel-force" data-action="cancel-pin">${_t(lang, "cancel")}</button>
           <button class="btn btn-arm" data-action="confirm-pin">${_t(lang, "confirm")}</button>
@@ -680,6 +685,8 @@ class VerisureOwaAlarmCard extends HTMLElement {
       });
     });
     if (pinInput) {
+      // Restore in-flight PIN imperatively — never via the HTML value attribute.
+      pinInput.value = this._pin;
       requestAnimationFrame(() => pinInput.focus());
       pinInput.addEventListener("input", e => {
         this._pin = e.target.value.replace(/\D/g, "");
@@ -694,6 +701,8 @@ class VerisureOwaAlarmCard extends HTMLElement {
     // Text code input
     const codeInput = this.shadowRoot.getElementById("code-input");
     if (codeInput) {
+      // Restore in-flight code imperatively — never via the HTML value attribute.
+      codeInput.value = this._pin;
       requestAnimationFrame(() => codeInput.focus());
       codeInput.addEventListener("input", e => { this._pin = e.target.value; });
       codeInput.addEventListener("keydown", e => {
@@ -1420,7 +1429,10 @@ class VerisureOwaAlarmBadge extends HTMLElement {
 
   disconnectedCallback() {
     if (this._gestureCleanup) { this._gestureCleanup(); this._gestureCleanup = null; }
-    if (this._pinOverlay) { this._pinOverlay.remove(); this._pinOverlay = null; this._pinState = null; this._pin = ""; }
+    if (this._pinOverlay) { this._pinOverlay.remove(); this._pinOverlay = null; }
+    // Always zero PIN state on disconnect, even without an active overlay.
+    this._pinState = null;
+    this._pin = "";
   }
 
   setConfig(config) {
@@ -1703,7 +1715,10 @@ class VerisureOwaAlarmChip extends HTMLElement {
 
   disconnectedCallback() {
     if (this._gestureCleanup) { this._gestureCleanup(); this._gestureCleanup = null; }
-    if (this._pinOverlay) { this._pinOverlay.remove(); this._pinOverlay = null; this._pinState = null; this._pin = ""; }
+    if (this._pinOverlay) { this._pinOverlay.remove(); this._pinOverlay = null; }
+    // Always zero PIN state on disconnect, even without an active overlay.
+    this._pinState = null;
+    this._pin = "";
   }
 
   setConfig(config) {

--- a/docs/before-release-todo.md
+++ b/docs/before-release-todo.md
@@ -226,6 +226,34 @@ on actual API responses, multi-axis state, or hardware configuration.
       is 4, `data.token` is gone, and `data.password` is removed (with
       `data.refresh_token` populated).
 
+### Security hardening
+
+- [ ] **`force_arm` service is gated by force context, not by a fresh
+      PIN prompt.** The service registration accepts an optional `code`
+      that's validated as defence-in-depth, but the legitimate flow
+      relies on `_force_context` (set only after a PIN-authenticated
+      arm reached the server, expires after one `scan_interval`).
+      Setup: configure a PIN in options and enable **Code required to
+      arm**. Arm against an open sensor and enter the PIN at the
+      dashboard prompt — the arm will fail with an exception and the
+      Force Arm persistent notification fires. Then verify:
+      - **Mobile notification tap completes the force-arm.** Tap
+        Force Arm on the mobile notification (which can't carry a
+        PIN). The arm proceeds — the context's existence is treated
+        as proof of the PIN auth from the prior step.
+      - **Service call without code, with active context, arms.**
+        Re-trigger the exception. In Developer Tools → Services call
+        `verisure_owa.force_arm` with no `code`. Arms.
+      - **Service call with wrong code raises.** Re-trigger.
+        `verisure_owa.force_arm` with `code: "9999"` →
+        `ServiceValidationError`, no client call, context preserved.
+      - **Service call with correct code arms.** Re-trigger. Same
+        service call with the configured PIN → arms.
+      - **Service call without context is a no-op.** Cancel the
+        force-arm (or wait `scan_interval` seconds for the context
+        to expire). `verisure_owa.force_arm` with no code logs
+        "no force context available" and does nothing.
+
 ## Post-merge follow-ups
 
 - [ ] **Map the four perimeter+annex proto codes.** Issue #441 supplied

--- a/docs/before-release-todo.md
+++ b/docs/before-release-todo.md
@@ -254,6 +254,45 @@ on actual API responses, multi-axis state, or hardware configuration.
         to expire). `verisure_owa.force_arm` with no code logs
         "no force context available" and does nothing.
 
+- [ ] **User-facing setup error doesn't leak raw response body.**
+      Synthetic test: edit `/etc/hosts` (or use firewall) to point
+      `customers.verisure.es` (or whichever country host the entry
+      uses) at `127.0.0.1`, restart the container. The integration
+      setup will fail. In Settings → Devices & Services, the entry's
+      error message should be short ("Unable to connect to Verisure:
+      …") with no raw JSON dump. Logs still contain the full filtered
+      detail (the redaction filter scrubs known secrets). Restore
+      `/etc/hosts` and reload.
+
+- [ ] **Unmapped proto-code log is actionable.** Trigger an alarm
+      state that isn't bound to any HA button on a multi-installation
+      setup (e.g. arm Total when no button maps to Total). Confirm
+      the warning:
+      - is at WARNING level, not INFO,
+      - identifies the entity_id and installation number so you can
+        tell which panel triggered it on a multi-install setup,
+      - names the state ("Total") and the proto code ("T"),
+      - says "None of the buttons on the main control panel are
+        mapped to it",
+      - fires once per state (does not spam every 30s coordinator
+        poll while the panel sits in the unmapped state).
+
+#### Done
+
+- [x] **PIN never appears in the alarm card's serialised shadow DOM.**
+      With the PIN entry open, `document.querySelector(
+      "verisure-owa-alarm-card").shadowRoot.getElementById(
+      "pin-keyboard-input").outerHTML` shows no `value=` attribute,
+      while `.value` on the same element holds what was typed. The
+      PIN survives unrelated re-renders and is zeroed on
+      `disconnectedCallback`.
+
+- [x] **Wrong OTP doesn't poison the next attempt.** On a 2FA
+      account, entering a wrong OTP, then retrying with the correct
+      OTP, completes setup. The wrong (hash, code) pair was
+      invalidated on the error path so the second request used a
+      fresh challenge.
+
 ## Post-merge follow-ups
 
 - [ ] **Map the four perimeter+annex proto codes.** Issue #441 supplied

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,7 +267,6 @@ def make_securitas_hub_mock(**overrides) -> MagicMock:
     hub.get_services = AsyncMock(return_value=[])
     hub.logout = AsyncMock(return_value=True)
     hub.get_authentication_token = MagicMock(return_value=FAKE_JWT)
-    hub.set_authentication_token = MagicMock()
     hub.get_refresh_token = MagicMock(return_value=FAKE_REFRESH_TOKEN)
     for key, val in overrides.items():
         setattr(hub, key, val)

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2106,9 +2106,7 @@ class TestUnmappedProtoCodeLogging:
             "scan_interval": 120,
         }
 
-    def test_recognised_unmapped_code_logs_state_name_and_installation(
-        self, caplog
-    ):
+    def test_recognised_unmapped_code_logs_state_name_and_installation(self, caplog):
         """Code in PROTO_TO_STATE but not bound to any HA button → WARNING
         naming the state, the installation number, and the entity_id."""
         import logging
@@ -2156,7 +2154,11 @@ class TestUnmappedProtoCodeLogging:
         assert "Z" in msg
         assert "123456" in msg
         # Phrasing must clearly mark this as integration-unknown, not user-config.
-        assert "unknown" in msg.lower() or "not recognised" in msg.lower() or "not recognized" in msg.lower()
+        assert (
+            "unknown" in msg.lower()
+            or "not recognised" in msg.lower()
+            or "not recognized" in msg.lower()
+        )
 
     def test_repeat_unmapped_code_does_not_spam_log(self, caplog):
         """Two polls with the same unmapped code → only one warning."""
@@ -2177,7 +2179,8 @@ class TestUnmappedProtoCodeLogging:
             alarm.update_status_alarm(status)
 
         warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelno >= logging.WARNING and "Unmapped" in r.message
         ]
         assert len(warnings) == 1

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2089,6 +2089,100 @@ class TestForceArmContext:
 # ===========================================================================
 
 
+class TestUnmappedProtoCodeLogging:
+    """When a proto code falls through to ARMED_CUSTOM_BYPASS the log line
+    must identify the installation, distinguish recognised-but-unmapped
+    from unknown-code, and not spam every poll."""
+
+    @staticmethod
+    def _config_without_total():
+        # STD_DEFAULTS map_away → TOTAL; replace it so 'T' is unmapped.
+        return {
+            "map_home": STD_DEFAULTS["map_home"],
+            "map_away": VerisureOwaState.PARTIAL_DAY.value,
+            "map_night": STD_DEFAULTS["map_night"],
+            "map_custom": STD_DEFAULTS["map_custom"],
+            "map_vacation": STD_DEFAULTS["map_vacation"],
+            "scan_interval": 120,
+        }
+
+    def test_recognised_unmapped_code_logs_state_name_and_installation(
+        self, caplog
+    ):
+        """Code in PROTO_TO_STATE but not bound to any HA button → WARNING
+        naming the state, the installation number, and the entity_id."""
+        import logging
+
+        alarm = make_alarm(config=self._config_without_total())
+        alarm.entity_id = "alarm_control_panel.home"
+
+        status = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="T",
+            protom_response_data="",
+        )
+        with caplog.at_level(logging.WARNING, logger="custom_components.verisure_owa"):
+            alarm.update_status_alarm(status)
+
+        msg = caplog.text
+        assert "Total" in msg, msg  # human label
+        assert "T" in msg
+        assert "123456" in msg
+        assert "alarm_control_panel.home" in msg
+
+    def test_unknown_code_logs_unrecognised_message(self, caplog):
+        """Code not in PROTO_TO_STATE → WARNING saying the integration
+        doesn't recognise it."""
+        import logging
+
+        alarm = make_alarm(config=self._config_without_total())
+        alarm.entity_id = "alarm_control_panel.home"
+
+        status = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="Z",
+            protom_response_data="",
+        )
+        with caplog.at_level(logging.WARNING, logger="custom_components.verisure_owa"):
+            alarm.update_status_alarm(status)
+
+        msg = caplog.text
+        assert "Z" in msg
+        assert "123456" in msg
+        # Phrasing must clearly mark this as integration-unknown, not user-config.
+        assert "unknown" in msg.lower() or "not recognised" in msg.lower() or "not recognized" in msg.lower()
+
+    def test_repeat_unmapped_code_does_not_spam_log(self, caplog):
+        """Two polls with the same unmapped code → only one warning."""
+        import logging
+
+        alarm = make_alarm(config=self._config_without_total())
+
+        status = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="T",
+            protom_response_data="",
+        )
+        with caplog.at_level(logging.WARNING, logger="custom_components.verisure_owa"):
+            alarm.update_status_alarm(status)
+            alarm.update_status_alarm(status)
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno >= logging.WARNING and "Unmapped" in r.message
+        ]
+        assert len(warnings) == 1
+
+
 class TestForceArmCodeGate:
     """force_arm trusts the force context as proof of recent PIN auth.
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2089,6 +2089,99 @@ class TestForceArmContext:
 # ===========================================================================
 
 
+class TestForceArmCodeGate:
+    """force_arm trusts the force context as proof of recent PIN auth.
+
+    The context is set only after _check_code_for_arm_if_required passes
+    in _async_arm, so its existence is itself proof.  We additionally
+    accept an optional code argument and validate it for defence-in-depth
+    callers.
+    """
+
+    @staticmethod
+    def _make_alarm_with_code(code_required: bool):
+        """make_alarm with a configured PIN, optionally requiring code on arm."""
+        defaults = STD_DEFAULTS
+        config = {
+            "map_home": defaults["map_home"],
+            "map_away": defaults["map_away"],
+            "map_night": defaults["map_night"],
+            "map_custom": defaults["map_custom"],
+            "map_vacation": defaults["map_vacation"],
+            "scan_interval": 120,
+            "code": "1234",
+            "code_arm_required": code_required,
+        }
+        return make_alarm(config=config)
+
+    @staticmethod
+    def _seed_force_context(alarm):
+        alarm._state = AlarmControlPanelState.DISARMED
+        alarm._force_context = {
+            "reference_id": "ref-789",
+            "suid": "suid-789",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Window"}],
+            "created_at": datetime.now(),
+        }
+        alarm._attr_extra_state_attributes["force_arm_available"] = True
+        alarm.client.arm_alarm = AsyncMock(
+            return_value=OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                installation_number="123456",
+                protom_response="T",
+                protom_response_data="",
+            )
+        )
+
+    async def test_force_arm_with_context_proceeds_without_code(self):
+        """Force context exists → arm without re-prompting for the PIN.
+
+        The context is set only after a PIN-authenticated arm reached
+        the server, so re-prompting on the second-half completion would
+        be redundant and would break the mobile-notification flow.
+        """
+        alarm = self._make_alarm_with_code(code_required=True)
+        self._seed_force_context(alarm)
+
+        await alarm.async_force_arm()
+
+        alarm.client.arm_alarm.assert_awaited_once()
+
+    async def test_force_arm_no_context_no_op(self):
+        """No force context → no client call, regardless of code_arm_required."""
+        alarm = self._make_alarm_with_code(code_required=True)
+        alarm.client.arm_alarm = AsyncMock()
+        # No _seed_force_context — context is None.
+
+        await alarm.async_force_arm()
+
+        alarm.client.arm_alarm.assert_not_awaited()
+
+    async def test_force_arm_with_explicit_wrong_code_raises(self):
+        """Defence-in-depth: explicit wrong code rejected even with context."""
+        alarm = self._make_alarm_with_code(code_required=True)
+        self._seed_force_context(alarm)
+
+        with pytest.raises(ServiceValidationError):
+            await alarm.async_force_arm(code="9999")
+
+        alarm.client.arm_alarm.assert_not_awaited()
+        # Force context must remain so the user can retry with the right code.
+        assert alarm._force_context is not None
+
+    async def test_force_arm_with_explicit_correct_code_proceeds(self):
+        """Defence-in-depth: explicit correct code accepted."""
+        alarm = self._make_alarm_with_code(code_required=True)
+        self._seed_force_context(alarm)
+
+        await alarm.async_force_arm(code="1234")
+
+        alarm.client.arm_alarm.assert_awaited_once()
+
+
 class TestForceArmCancel:
     """Tests for the securitas.force_arm_cancel entity service."""
 

--- a/tests/test_client_auth.py
+++ b/tests/test_client_auth.py
@@ -272,6 +272,24 @@ class TestLogin:
         assert client._authentication_token_exp > datetime.now()
         assert client._authentication_token_exp < datetime.now() + timedelta(minutes=20)
 
+    async def test_login_decodes_non_hs256_token(self, client, transport):
+        """Token decoding must succeed regardless of the JWT signing algorithm.
+
+        The Verisure API actually signs tokens with EdDSA, not HS256. We don't
+        verify signatures (the token comes from a trusted HTTPS endpoint), so
+        the decode path must accept any algorithm.
+        """
+        exp = datetime.now(tz=timezone.utc) + timedelta(minutes=15)
+        non_hs256_token = jwt.encode(
+            {"exp": exp, "sub": "test"}, "k", algorithm="HS512"
+        )
+        transport.execute.return_value = login_response(hash_token=non_hs256_token)
+
+        await client.login()
+
+        assert client.authentication_token == non_hs256_token
+        assert client._authentication_token_exp > datetime.now()
+
     async def test_login_2fa_raises_two_factor_required(self, client, transport):
         """Login with needDeviceAuthorization raises TwoFactorRequiredError."""
         transport.execute.return_value = login_response(need_2fa=True)
@@ -806,6 +824,60 @@ class TestAuthRequestContracts:
         assert v["deviceName"] == "SM-S901U"
         assert v["deviceOsVersion"] == "12"
         assert v["deviceVersion"] == "10.102.0"
+
+    async def test_username_with_special_chars_does_not_break_auth_header(
+        self, transport
+    ):
+        """Username with " or \\ must round-trip cleanly through the auth header.
+
+        Regression: the request id concatenates the username into a string,
+        which is then placed in a dict value and serialised with json.dumps.
+        json.dumps escapes embedded quotes/backslashes, so the auth header
+        remains valid JSON.
+        """
+        client = VerisureOwaClient(
+            transport=transport,
+            country="ES",
+            language="es",
+            username='qu"ote\\back@example.com',
+            password="x",
+            device_id="d",
+            uuid="u",
+            id_device_indigitall="i",
+        )
+        client.authentication_token = FAKE_JWT
+        client.login_timestamp = 1
+        transport.execute.return_value = {"data": {"xSGetExceptions": {}}}
+
+        # Trigger any non-auth GraphQL call so headers are built and sent.
+        await client._execute_raw(
+            {"operationName": "GetExceptions", "variables": {}, "query": "q"},
+            "GetExceptions",
+        )
+
+        headers = transport.execute.call_args[0][1]
+        # The auth header must be valid JSON and round-trip the username.
+        decoded = json.loads(headers["auth"])
+        assert decoded["user"] == 'qu"ote\\back@example.com'
+        assert client.username in decoded["id"]
+
+    async def test_validate_device_clears_otp_challenge_on_error(
+        self, client, transport
+    ):
+        """A failed validate_device must invalidate the (hash, code) pair.
+
+        Without this, a wrong OTP leaves the same challenge in memory and the
+        next request would reuse it in headers — letting a guessed code stay
+        valid until the server expires the hash.
+        """
+        transport.execute.side_effect = VerisureOwaError("validation failed")
+
+        with pytest.raises(VerisureOwaError):
+            await client.validate_device(
+                otp_succeed=True, auth_otp_hash="stale-hash", sms_code="000000"
+            )
+
+        assert client.authentication_otp_challenge_value is None
 
     # ── 4. send OTP payload ─────────────────────────────────────────────
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1016,9 +1016,7 @@ async def test_initial_flow_persists_panel_toggles_to_entry_options(hass):
         CONF_ENABLE_INTERIOR_PANEL: True,
     }
 
-    result = await _complete_full_flow(
-        hass, mock_hub, options=options_with_toggles
-    )
+    result = await _complete_full_flow(hass, mock_hub, options=options_with_toggles)
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["options"][CONF_ENABLE_PERIMETER_PANEL] is True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -938,6 +938,132 @@ async def test_options_get_falls_back_to_data(hass):
 
 
 # ===================================================================
+# TestFlowCapabilitiesPublishResolve
+#
+# Race fix: when async_setup_entry hasn't yet stored the alarm
+# coordinator under entry.entry_id (still inside its `await get_services`),
+# the options flow can't read coordinator.has_peri.  The config flow's
+# _select_installation already detected the capability values, so we
+# publish them to hass.data[DOMAIN]["flow_capabilities"][installation]
+# and the options flow falls back to that.
+# ===================================================================
+
+
+async def test_resolve_flow_capabilities_uses_coordinator_when_populated(hass):
+    """When the coordinator has populated capabilities, prefer it."""
+    from custom_components.verisure_owa import _resolve_flow_capabilities
+
+    coord = MagicMock()
+    coord.capabilities_populated = True
+    coord.has_peri = True
+    coord.has_annex = False
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {CONF_INSTALLATION: "111"}
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"alarm_coordinator": coord}
+    # Stale opposite values in the cache must NOT win over a populated coord.
+    hass.data[DOMAIN]["flow_capabilities"] = {
+        "111": {"has_peri": False, "has_annex": True}
+    }
+
+    has_peri, has_annex = _resolve_flow_capabilities(hass, entry)
+
+    assert (has_peri, has_annex) == (True, False)
+
+
+async def test_resolve_flow_capabilities_falls_back_to_cache_when_coord_missing(hass):
+    """When entry.entry_id isn't yet in hass.data, fall back to the cache."""
+    from custom_components.verisure_owa import _resolve_flow_capabilities
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {CONF_INSTALLATION: "111"}
+    # Note: no entry-id-keyed dict in hass.data — this is the race window.
+    hass.data.setdefault(DOMAIN, {})["flow_capabilities"] = {
+        "111": {"has_peri": True, "has_annex": False}
+    }
+
+    has_peri, has_annex = _resolve_flow_capabilities(hass, entry)
+
+    assert (has_peri, has_annex) == (True, False)
+
+
+async def test_resolve_flow_capabilities_falls_back_when_coord_unpopulated(hass):
+    """A coordinator that hasn't run yet has has_peri=False as the
+    default — that's not authoritative.  Fall back to the cache."""
+    from custom_components.verisure_owa import _resolve_flow_capabilities
+
+    coord = MagicMock()
+    coord.capabilities_populated = False
+    coord.has_peri = False
+    coord.has_annex = False
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {CONF_INSTALLATION: "111"}
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"alarm_coordinator": coord}
+    hass.data[DOMAIN]["flow_capabilities"] = {
+        "111": {"has_peri": True, "has_annex": True}
+    }
+
+    has_peri, has_annex = _resolve_flow_capabilities(hass, entry)
+
+    assert (has_peri, has_annex) == (True, True)
+
+
+async def test_resolve_flow_capabilities_returns_false_when_nothing_known(hass):
+    """No coordinator and no cache → (False, False) — current behaviour."""
+    from custom_components.verisure_owa import _resolve_flow_capabilities
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {CONF_INSTALLATION: "111"}
+    hass.data.setdefault(DOMAIN, {})
+
+    has_peri, has_annex = _resolve_flow_capabilities(hass, entry)
+
+    assert (has_peri, has_annex) == (False, False)
+
+
+def _form_has_field(result, field_name: str) -> bool:
+    """Return True if the rendered form schema contains a key with this name."""
+    schema = result["data_schema"].schema
+    for key in schema:
+        # vol.Required / vol.Optional wrap the key — unwrap with `.schema`.
+        name = getattr(key, "schema", key)
+        if name == field_name:
+            return True
+    return False
+
+
+async def test_options_init_renders_peri_toggle_via_published_cache(hass):
+    """Race fix: options init shows the perimeter toggle even if the
+    coordinator dict isn't in hass.data yet, by reading the published
+    capability cache."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**make_config_entry_data(has_peri=True), CONF_INSTALLATION: "111"},
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    # Simulate the race: published cache exists, but no alarm_coordinator
+    # under entry.entry_id yet.
+    hass.data.setdefault(DOMAIN, {})["flow_capabilities"] = {
+        "111": {"has_peri": True, "has_annex": False}
+    }
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert _form_has_field(result, CONF_ENABLE_PERIMETER_PANEL)
+
+
+# ===================================================================
 # TestInstallationSelection (~6 tests)
 # ===================================================================
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -569,8 +569,8 @@ async def test_otp_challenge_advances_to_options(hass):
 # ===================================================================
 
 
-async def test_finish_setup_logs_in_gets_token_advances_to_options(hass):
-    """finish_setup should login, get token, and advance to options."""
+async def test_finish_setup_logs_in_advances_to_options(hass):
+    """finish_setup should login (when no token yet) and advance to options."""
     mock_hub = _hub_factory()
 
     with _patches(mock_hub):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -938,6 +938,98 @@ async def test_options_get_falls_back_to_data(hass):
 
 
 # ===================================================================
+# TestInitialFlowPanelToggles
+#
+# When peri/annex is detected during the initial config flow, the
+# user should be able to enable the corresponding sub-panels right
+# there — without having to dig through Configure after CREATE_ENTRY.
+# ===================================================================
+
+
+def _hub_with_peri_capability():
+    """Mock hub that returns capabilities including PERI."""
+    mock_hub = _hub_factory()
+    mock_hub.client.get_supported_commands = MagicMock(return_value=frozenset({"PERI"}))
+    return mock_hub
+
+
+def _initial_options_form_keys(result) -> set[str]:
+    """Return the unwrapped key names of the rendered initial options form."""
+    keys: set[str] = set()
+    for key in result["data_schema"].schema:
+        name = getattr(key, "schema", key)
+        keys.add(name)
+    return keys
+
+
+async def test_initial_options_step_shows_perimeter_toggle_when_peri_detected(
+    hass,
+):
+    """The initial flow's options page must render the panel-enable toggles
+    when the underlying installation has the corresponding capability — same
+    surface as the post-setup Configure dialog.
+    """
+    mock_hub = _hub_with_peri_capability()
+
+    with _patches(mock_hub):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_CREDENTIALS
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "options"
+    keys = _initial_options_form_keys(result)
+    assert CONF_ENABLE_PERIMETER_PANEL in keys
+    assert CONF_ENABLE_INTERIOR_PANEL in keys
+
+
+async def test_initial_options_step_omits_toggles_when_no_capability(hass):
+    """Without peri/annex detected, the initial flow's options page must
+    NOT render the panel-enable toggles (matches Configure dialog behaviour).
+    """
+    mock_hub = _hub_factory()  # no PERI in capabilities
+
+    with _patches(mock_hub):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_CREDENTIALS
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "options"
+    keys = _initial_options_form_keys(result)
+    assert CONF_ENABLE_PERIMETER_PANEL not in keys
+    assert CONF_ENABLE_INTERIOR_PANEL not in keys
+    assert CONF_ENABLE_ANNEX_PANEL not in keys
+
+
+async def test_initial_flow_persists_panel_toggles_to_entry_options(hass):
+    """When user enables the panel toggles during initial setup, the
+    created entry's options dict must carry them — so the post-setup
+    OptionsFlow opens with them already enabled rather than defaulting
+    back to off.
+    """
+    mock_hub = _hub_with_peri_capability()
+
+    options_with_toggles = {
+        **USER_INPUT_OPTIONS,
+        CONF_ENABLE_PERIMETER_PANEL: True,
+        CONF_ENABLE_INTERIOR_PANEL: True,
+    }
+
+    result = await _complete_full_flow(
+        hass, mock_hub, options=options_with_toggles
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["options"][CONF_ENABLE_PERIMETER_PANEL] is True
+    assert result["options"][CONF_ENABLE_INTERIOR_PANEL] is True
+    # And they should NOT pollute entry.data, where the OptionsFlow
+    # doesn't expect to find them.
+    assert CONF_ENABLE_PERIMETER_PANEL not in result["data"]
+    assert CONF_ENABLE_INTERIOR_PANEL not in result["data"]
+
+
+# ===================================================================
 # TestFlowCapabilitiesPublishResolve
 #
 # Race fix: when async_setup_entry hasn't yet stored the alarm

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -178,6 +178,28 @@ class TestHttpTransport:
         with pytest.raises(VerisureOwaError):
             await transport.execute(content={}, headers={})
 
+    async def test_retry_after_clamped_to_60s(self, transport, session):
+        """A server returning a huge Retry-After must not block the worker.
+
+        Regression: an unbounded Retry-After (e.g. 86400) would freeze the
+        coordinator for that long. Clamp to 60s.
+        """
+        fail = _make_response(
+            status=403,
+            text="<html>rate limited</html>",
+            headers={"Retry-After": "86400"},
+        )
+        ok = _make_response(text='{"retried": true}')
+        _mock_post(session, [fail, ok])
+
+        with patch(
+            "custom_components.verisure_owa.verisure_owa_api.http_transport.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep:
+            await transport.execute(content={}, headers={})
+
+        mock_sleep.assert_awaited_once_with(60)
+
     async def test_403_without_retry_after_defaults_to_2s(self, transport, session):
         """403 without Retry-After header defaults to 2s delay."""
         fail = _make_response(status=403, text="<html>blocked</html>", headers={})

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -200,6 +200,28 @@ class TestHttpTransport:
 
         mock_sleep.assert_awaited_once_with(60)
 
+    async def test_retry_after_negative_is_floored_to_zero(self, transport, session):
+        """A hostile/broken server returning Retry-After: -1 must not crash.
+
+        asyncio.sleep with a negative value raises ValueError; clamp to 0
+        so a malformed header just retries immediately.
+        """
+        fail = _make_response(
+            status=403,
+            text="<html>rate limited</html>",
+            headers={"Retry-After": "-1"},
+        )
+        ok = _make_response(text='{"retried": true}')
+        _mock_post(session, [fail, ok])
+
+        with patch(
+            "custom_components.verisure_owa.verisure_owa_api.http_transport.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep:
+            await transport.execute(content={}, headers={})
+
+        mock_sleep.assert_awaited_once_with(0)
+
     async def test_403_without_retry_after_defaults_to_2s(self, transport, session):
         """403 without Retry-After header defaults to 2s delay."""
         fail = _make_response(status=403, text="<html>blocked</html>", headers={})

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -711,3 +711,38 @@ class TestFullImageCapture:
 
         key = f"{installation.number}_{device.zone_id}"
         assert key not in hub._full_images
+
+
+class TestGetServicesPartitionsCache:
+    """get_services must preserve the alarm_partitions side-effect across
+    cache hits — Italian SDVECU peri detection reads it.
+    """
+
+    async def test_get_services_restores_partitions_on_cache_hit(self):
+        """Second call with a fresh Installation must end up with partitions
+        populated, even though the cache hit short-circuits the network call.
+        """
+        hub = make_hub()
+        partitions = [{"id": "02", "enterStates": ["01"], "leaveStates": ["01"]}]
+
+        async def fake_client_get_services(install):
+            install.alarm_partitions = partitions
+            return ["service-list-marker"]
+
+        hub.client.get_services = AsyncMock(side_effect=fake_client_get_services)
+
+        # First call populates the cache and the passed installation.
+        first = make_installation(number="2654190")
+        services = await hub.get_services(first)
+        assert services == ["service-list-marker"]
+        assert first.alarm_partitions == partitions
+
+        # Second call with a NEW Installation instance — alarm_partitions
+        # starts empty.  Cache hit must still surface the partitions.
+        second = make_installation(number="2654190")
+        assert second.alarm_partitions == []  # fresh default
+        services = await hub.get_services(second)
+        assert services == ["service-list-marker"]
+        assert second.alarm_partitions == partitions
+        # Underlying client.get_services must NOT have been called again.
+        assert hub.client.get_services.await_count == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -492,6 +492,33 @@ class TestAsyncSetupEntry:
         ):
             await async_setup_entry(hass, entry)
 
+    async def test_setup_login_error_does_not_leak_response_body(
+        self, hass, mock_hub
+    ):
+        """User-facing ConfigEntryNotReady must not embed raw response body.
+
+        log_detail() may include the raw API response (which can contain
+        tokens) for unknown errors. That detail belongs in the (filtered)
+        log, not in the user-facing exception text.
+        """
+        err = VerisureOwaError("connection failed")
+        err.response_body = {
+            "data": {"hash": "leaked-auth-token-value"},
+        }
+        mock_hub.login = AsyncMock(side_effect=err)
+        entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
+        entry.add_to_hass(hass)
+
+        with (
+            _patch_hub(mock_hub),
+            patch("custom_components.verisure_owa.async_get_clientsession"),
+            pytest.raises(ConfigEntryNotReady) as exc_info,
+        ):
+            await async_setup_entry(hass, entry)
+
+        # Token must not appear in the user-facing message
+        assert "leaked-auth-token-value" not in str(exc_info.value)
+
     async def test_setup_securitas_error_during_list_installations(
         self, hass, mock_hub
     ):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -492,9 +492,7 @@ class TestAsyncSetupEntry:
         ):
             await async_setup_entry(hass, entry)
 
-    async def test_setup_login_error_does_not_leak_response_body(
-        self, hass, mock_hub
-    ):
+    async def test_setup_login_error_does_not_leak_response_body(self, hass, mock_hub):
         """User-facing ConfigEntryNotReady must not embed raw response body.
 
         log_detail() may include the raw API response (which can contain

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -374,14 +374,12 @@ class TestVerisureHub:
         result = await hub.logout()
         assert result is True
 
-    def test_get_set_authentication_token(self):
-        """get/set_authentication_token should read/write session.authentication_token."""
+    def test_get_authentication_token(self):
+        """get_authentication_token should read session.authentication_token."""
         hub = self._make_hub()
         hub.client = MagicMock()
         hub.client.authentication_token = "original-token"
         assert hub.get_authentication_token() == "original-token"
-        hub.set_authentication_token("new-token")
-        assert hub.client.authentication_token == "new-token"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Stacks on top of #458 (password persistence). When #458 merges this rebases cleanly; until then the diff here includes #458's commits.

Fourteen own commits in three groups:

1. **Security review batch** (8 commits) addressing the items the user's pre-migration review listed for the post-rebrand codebase. Each item was triaged against the actual code state — five turned out to be already-fixed by the rebrand or non-issues (with regression tests added to lock that in); the remainder land here as focused commits.
2. **Two config-flow capability bugs** surfaced during smoke-testing on a real Italian (SDVECU) installation: the post-setup options dialog was hiding the perimeter/annex toggles in two different ways, and the initial flow had no way to enable them at all.
3. **Smaller items** found while testing: an unactionable "Unmapped alarm status code" log; smoke-test additions to `before-release-todo.md`; a final refactor that de-duplicates the panel-toggle schema builder between the two flows.

All 1370 tests pass; ruff clean.

## Security batch

| Commit | What |
|---|---|
| `6c033a9` | Drop production-dead `VerisureHub.set_authentication_token` and shrink the now-half-test |
| `ee4ffc0` | `force_arm` service: optional `code` arg validates as defence-in-depth, but the legitimate flow trusts the (PIN-authenticated, scan-interval-bounded) force context — re-prompting on the second-half completion would break the mobile-notification tap |
| `a00a3f0` | Keep PIN out of the alarm card's serialised shadow DOM (no more `value="${this._pin}"`); zero `_pin` in `disconnectedCallback` for card / badge / chip elements |
| `29b42cc` | Invalidate `authentication_otp_challenge_value` on the `validate_device` error path so a wrong OTP can't be replayed in the next request's headers; document why `jwt.decode` skips signature verification (tokens are EdDSA, not HS256, and come from a trusted HTTPS endpoint) |
| `7a63e77` | Clamp `Retry-After` to 60s — a hostile or buggy server returning `86400` would otherwise freeze the worker for a day |
| `db3600d` | `ConfigEntryNotReady` user-facing text uses `err.message`, not `err.log_detail()` — the latter embeds raw response body and the UI doesn't go through `SensitiveDataFilter` |

**Pre-migration findings verified non-issues** (regression tests added):

- Username with `"` or `\` "breaks the JSON header" — `json.dumps` already escapes those embedded in dict values; locked in by `test_username_with_special_chars_does_not_break_auth_header`.
- Misleading `algorithms=["HS256"]` kwarg with `verify_signature=False` — actually no behavioural impact (PyJWT ignores it under `verify_signature=False`), but dropped for honesty; locked in by `test_login_decodes_non_hs256_token`.
- Cleartext password compare in session-reuse cache — obviated by #458 removing the comparison entirely.
- Plaintext password persistence — fully addressed by #458.
- `CONF_TOKEN` write — already removed by #458; only the `set_authentication_token` follow-up remained.

## Config-flow capability bugs

The user kept reporting that the perimeter/annex sub-panel toggles were missing on Italian (SDVECU) installations. Three distinct bugs, fixed in turn:

| Commit | What |
|---|---|
| `12b5b69` | A genuine race: `OptionsFlow.async_step_init` reads the alarm coordinator from `hass.data[DOMAIN][entry.entry_id]`, but `async_setup_entry` awaits `client.get_services` for ~50ms before storing that dict. Publish detected `(has_peri, has_annex)` to a small cache from both detection sites; resolve via a helper that prefers a populated coordinator and falls back to the cache. New `capabilities_populated` property on the coordinator distinguishes "False because not detected yet" from "False because the panel really has no peri". |
| `cd83e1d` | The actual bug behind the user's repro: `VerisureHub.get_services` cached the services list but **dropped the `installation.alarm_partitions` side-effect** that `client.get_services` performs. On a cache hit (which is exactly what `async_setup_entry` does, after `_select_installation` populated the cache), the new `Installation` from `list_installations` kept its empty default partitions, and `detect_peri`'s Italian SDVECU signal — the only one that fires for SDVECU panels — returned False permanently. Snapshot partitions alongside services and re-apply on cache hits. |
| `cdb4c63` | UX gap once the above two were fixed: the toggles existed in the post-setup Configure dialog but **not** in the initial setup flow's options page. Render the same capability-gated toggles there too; selections flow into `entry.options` (not `entry.data`), matching where `OptionsFlow` writes them. |
| `3ca280d` | The toggles in the initial flow rendered their raw keys (`enable_perimeter_panel` etc.) — the labels lived only under `options.step.init.data` in `strings.json` + the seven translation files. Mirrored to `config.step.options.data`. |
| `68b5cb2` | The capability-gated `extra_fields` builder now appears in two places — extracted `_build_panel_extra_fields` helper, promoted `PANEL_OPTION_KEYS` to a module-level constant. Net -10 lines. |

## Smaller items

| Commit | What |
|---|---|
| `143ddda` | The `INFO` log "Unmapped alarm status code 'T' from Verisure" had no entity / installation context, no indication of what the code means, and fired on every coordinator poll. Replaced with a `WARNING` that names the state ("Total"), the installation number and entity_id, distinguishes "code not mapped to any HA button" from "code not recognised by the integration at all", and dedupes per `_last_unmapped_logged` so a panel parked in an unmapped state logs once. |
| `55004ee`, `594f59b` | Add the security-batch smoke tests (S3 / S10 / unmapped-code log) under a new "Security hardening" subsection of `before-release-todo.md`; mark S4 / S5 done. |

## Test plan

Manual items added to `docs/before-release-todo.md` under **Security hardening**:

- [x] **S3** — `force_arm` service is gated by force context, not a fresh PIN prompt. Mobile-notification tap completes the force-arm; service call without context is a no-op; explicit wrong/correct codes accepted/rejected as documented.
- [x] **S4** — PIN never appears in `outerHTML` of the alarm card's shadow root; runtime `.value` holds the typed digits; PIN survives unrelated re-renders; zeroed on detach.
- [x] **S5** — Wrong OTP doesn't poison the next attempt on a 2FA account.
- [ ] **S10** — User-facing setup error doesn't leak raw response body (synthetic `/etc/hosts` test).
- [ ] **Unmapped proto-code log** — fires once per state with installation/entity context.
- [x] **Italian SDVECU peri detection** — perimeter/annex toggles now appear in *both* the initial setup flow's first page **and** the post-setup Configure dialog. Selections during initial setup persist as `entry.options`.

## Notes

- This stacks on #458; merge that first to get a clean diff here. Until then the diff shows both PRs.
- Each commit is independently revertable — security batch commits don't depend on each other; config-flow commits build on each other but the dependencies are documented in the messages.
- 1370 tests pass; ruff clean.