### PR TITLE
Improvements: dead code, perf, reliability, structural refactors

### DIFF
--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -69,7 +69,9 @@ from .const import (  # noqa: F401 — re-exported for backwards compatibility
     SENTINEL_SERVICE_NAMES,
     SIGNAL_CAMERA_STATE,
 )
-from .coordinators import (  # noqa: F401 — CameraCoordinator re-exported for backwards compatibility
+
+# CameraCoordinator re-exported for backwards compatibility
+from .coordinators import (  # noqa: F401
     ActivityCoordinator,
     AlarmCoordinator,
     CameraCoordinator,

--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -170,7 +170,7 @@ def _resolve_flow_capabilities(
 def add_device_information[T: dict](config: T) -> T:
     """Add device information to the configuration."""
     if CONF_DEVICE_ID not in config:
-        config[CONF_DEVICE_ID] = generate_device_id(config[CONF_COUNTRY])
+        config[CONF_DEVICE_ID] = generate_device_id()
 
     if CONF_UNIQUE_ID not in config:
         config[CONF_UNIQUE_ID] = generate_uuid()

--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -708,6 +708,7 @@ async def _discover_cameras(
             hub.api_queue,
             installation,
             cameras=cameras,
+            full_image_fetcher=hub.fetch_full_image,
             config_entry=entry,
         )
         entry_data["camera_coordinator"] = camera_coord
@@ -802,6 +803,12 @@ def _schedule_lock_config_retry(
 
     unsub = async_call_later(hass, delay, _retry)
     lock_entity.add_config_retry_unsub(unsub)
+    # Mirror the handle at entry-scope so async_unload_entry can cancel any
+    # in-flight retries even if the per-entity teardown races with the timer.
+    if hub.config_entry is not None:
+        entry_data = hass.data.get(DOMAIN, {}).get(hub.config_entry.entry_id)
+        if entry_data is not None:
+            entry_data.setdefault("lock_config_retry_unsubs", []).append(unsub)
 
 
 async def _discover_locks(
@@ -964,6 +971,12 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     activity_listener_unsub = entry_data.get("activity_listener_unsub")
     if activity_listener_unsub is not None:
         activity_listener_unsub()
+
+    # Cancel any pending lock-config retry timers before tearing down platforms,
+    # so a timer firing mid-unload can't schedule a follow-up retry against a
+    # half-disposed hub.
+    for unsub in entry_data.get("lock_config_retry_unsubs", []):
+        unsub()
 
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS

--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -9,12 +9,12 @@ from datetime import timedelta
 import logging
 from pathlib import Path
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from uuid import uuid4
 
 import voluptuous as vol
 
-from homeassistant.components import frontend
+from homeassistant.components import frontend  # noqa: F401 — re-exported so tests can patch
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -69,12 +69,22 @@ from .const import (  # noqa: F401 — re-exported for backwards compatibility
     SENTINEL_SERVICE_NAMES,
     SIGNAL_CAMERA_STATE,
 )
-from .coordinators import (
+from .coordinators import (  # noqa: F401 — CameraCoordinator re-exported for backwards compatibility
     ActivityCoordinator,
     AlarmCoordinator,
     CameraCoordinator,
     LockCoordinator,
     SentinelCoordinator,
+)
+from .card_resources import (  # noqa: F401 — re-exported for backwards compatibility
+    _register_card_resource,
+    _unregister_card_resource,
+)
+from .discovery import (  # noqa: F401 — re-exported for backwards compatibility
+    _async_discover_devices,
+    _discover_cameras,
+    _discover_locks,
+    _schedule_lock_config_retry,
 )
 from .events import attach_activity_listener
 from .hub import (  # noqa: F401 — re-exported for backwards compatibility
@@ -93,9 +103,6 @@ from .verisure_owa_api import (
     generate_device_id,
     generate_uuid,
 )
-
-if TYPE_CHECKING:
-    from .lock import VerisureLock
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -665,304 +672,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     raise ConfigEntryNotReady(
         "Config entry missing device IDs. Delete and re-add the integration."
     )
-
-
-async def _discover_cameras(
-    hass: HomeAssistant,
-    hub: VerisureHub,
-    installation: Installation,
-    entry_data: dict[str, Any],
-    entry: ConfigEntry,
-) -> None:
-    """Discover camera devices for an installation and add entities."""
-    from .button import VerisureCaptureButton
-    from .camera import VerisureCamera, VerisureCameraFull
-
-    _LOGGER.debug(
-        "[camera_discovery] Fetching camera devices for installation %s (%s)",
-        installation.number,
-        installation.alias,
-    )
-    try:
-        cameras = await hub.get_camera_devices(installation)
-    except Exception:  # pylint: disable=broad-exception-caught  # background discovery must not crash
-        _LOGGER.warning(
-            "[camera_discovery] Failed to get camera devices for %s",
-            installation.number,
-            exc_info=True,
-        )
-        cameras = []
-
-    _LOGGER.debug(
-        "[camera_discovery] Installation %s: found %d camera(s): %s",
-        installation.number,
-        len(cameras),
-        [c.zone_id for c in cameras],
-    )
-
-    if cameras:
-        # Create and store camera coordinator
-        camera_coord = CameraCoordinator(
-            hass,
-            hub.client,
-            hub.api_queue,
-            installation,
-            cameras=cameras,
-            full_image_fetcher=hub.fetch_full_image,
-            config_entry=entry,
-        )
-        entry_data["camera_coordinator"] = camera_coord
-        entry.async_create_background_task(
-            hass,
-            camera_coord.async_refresh(),
-            "verisure_owa_camera_refresh",
-        )
-
-        camera_add = entry_data.get("camera_add_entities")
-        button_add = entry_data.get("button_add_entities")
-        _LOGGER.debug(
-            "[camera_discovery] Installation %s: camera_add=%s button_add=%s",
-            installation.number,
-            camera_add is not None,
-            button_add is not None,
-        )
-        if camera_add:
-            camera_add(
-                [
-                    VerisureCamera(camera_coord, hub, installation, cam)
-                    for cam in cameras
-                ]
-                + [
-                    VerisureCameraFull(camera_coord, hub, installation, cam)
-                    for cam in cameras
-                ],
-                False,
-            )
-        if button_add:
-            button_add(
-                [VerisureCaptureButton(hub, installation, cam) for cam in cameras],
-                True,
-            )
-
-
-_LOCK_CONFIG_RETRY_DELAYS = (60, 120, 300)  # seconds between retries
-
-
-def _schedule_lock_config_retry(
-    hass: HomeAssistant,
-    hub: VerisureHub,
-    installation: Installation,
-    lock_entity: VerisureLock,
-    attempt: int = 0,
-) -> None:
-    """Schedule a background retry to fetch lock config."""
-    from homeassistant.helpers.event import async_call_later
-
-    if attempt >= len(_LOCK_CONFIG_RETRY_DELAYS):
-        _LOGGER.info(
-            "Lock config retry exhausted for %s device %s",
-            installation.number,
-            lock_entity.device_id,
-        )
-        return
-
-    delay = _LOCK_CONFIG_RETRY_DELAYS[attempt]
-
-    async def _retry(_now: Any) -> None:
-        # Guard: entity may have been removed while the timer was pending.
-        if lock_entity.hass is None:
-            return
-
-        try:
-            config = await hub.get_lock_config(
-                installation,
-                lock_entity.device_id,
-                priority=hub.api_queue.BACKGROUND,
-            )
-        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
-            config = None
-
-        if config is not None:
-            _LOGGER.info(
-                "Lock config retry succeeded for %s device %s (attempt %d)",
-                installation.number,
-                lock_entity.device_id,
-                attempt + 1,
-            )
-            lock_entity.update_lock_config(config)
-        else:
-            _LOGGER.debug(
-                "Lock config retry %d failed for %s device %s, scheduling next retry",
-                attempt + 1,
-                installation.number,
-                lock_entity.device_id,
-            )
-            _schedule_lock_config_retry(
-                hass, hub, installation, lock_entity, attempt + 1
-            )
-
-    unsub = async_call_later(hass, delay, _retry)
-    lock_entity.add_config_retry_unsub(unsub)
-    # Mirror the handle at entry-scope so async_unload_entry can cancel any
-    # in-flight retries even if the per-entity teardown races with the timer.
-    if hub.config_entry is not None:
-        entry_data = hass.data.get(DOMAIN, {}).get(hub.config_entry.entry_id)
-        if entry_data is not None:
-            entry_data.setdefault("lock_config_retry_unsubs", []).append(unsub)
-
-
-async def _discover_locks(
-    hass: HomeAssistant,
-    hub: VerisureHub,
-    installation: Installation,
-    entry_data: dict[str, Any],
-) -> None:
-    """Discover lock devices for an installation and add entities."""
-    from .lock import (
-        DOORLOCK_SERVICE,
-        LOCK_STATUS_UNKNOWN,
-        VerisureLock,
-    )
-    from .verisure_owa_api import SmartLock, SmartLockMode
-    from .verisure_owa_api.client import SMARTLOCK_DEVICE_ID
-
-    try:
-        services = await hub.get_services(installation)
-    except Exception:  # pylint: disable=broad-exception-caught  # background discovery must not crash
-        _LOGGER.warning("Failed to get services for %s", installation.number)
-        return
-
-    has_doorlock = any(s.request == DOORLOCK_SERVICE for s in services)
-    if not has_doorlock:
-        return
-
-    try:
-        lock_modes: list[SmartLockMode] = await hub.get_lock_modes(installation)
-    except Exception:  # pylint: disable=broad-exception-caught  # background discovery must not crash
-        _LOGGER.warning("Failed to get lock modes for %s", installation.number)
-        lock_modes = []
-
-    if not lock_modes:
-        lock_modes = [
-            SmartLockMode(
-                res=None,
-                lock_status=LOCK_STATUS_UNKNOWN,
-                device_id=SMARTLOCK_DEVICE_ID,
-            )
-        ]
-
-    lock_coordinator = entry_data.get("lock_coordinator")
-    lock_add = entry_data.get("lock_add_entities")
-    if lock_add and lock_coordinator is not None:
-        locks = []
-        for mode in lock_modes:
-            device_id = mode.device_id or SMARTLOCK_DEVICE_ID
-            lock_config: SmartLock | None = None
-            try:
-                lock_config = await hub.get_lock_config(installation, device_id)
-            except Exception:  # pylint: disable=broad-exception-caught
-                _LOGGER.debug(
-                    "Could not fetch lock config for %s device %s",
-                    installation.number,
-                    device_id,
-                )
-            locks.append(
-                VerisureLock(
-                    coordinator=lock_coordinator,
-                    installation=installation,
-                    client=hub,
-                    device_id=device_id,
-                    initial_status=mode.lock_status,
-                    lock_config=lock_config,
-                )
-            )
-        lock_add(locks, False)
-
-        # Schedule deferred config retry for locks without config.
-        for lk in locks:
-            if lk.lock_config is None:
-                _schedule_lock_config_retry(hass, hub, installation, lk)
-
-
-async def _async_discover_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Discover cameras and locks in the background after setup."""
-    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if entry_data is None:
-        return
-
-    client: VerisureHub = entry_data["hub"]
-    devices: list[VerisureDevice] = entry_data["devices"]
-
-    for device in devices:
-        installation = device.installation
-        await _discover_cameras(hass, client, installation, entry_data, entry)
-        await _discover_locks(hass, client, installation, entry_data)
-
-
-async def _register_card_resource(
-    hass: HomeAssistant,
-    base_url: str,
-    card_url: str,
-    storage_key: str,
-) -> None:
-    """Register a card JS file as a Lovelace resource.
-
-    Falls back to add_extra_js_url if Lovelace resources are unavailable.
-    ``storage_key`` is used to track the resource ID in hass.data[DOMAIN].
-    """
-    try:
-        lovelace_data = hass.data.get("lovelace")
-        if lovelace_data and hasattr(lovelace_data, "resources"):
-            resources = lovelace_data.resources
-            if hasattr(resources, "async_create_item"):
-                if not resources.loaded:
-                    await resources.async_load()
-                    resources.loaded = True
-                for item in resources.async_items():
-                    url = item.get("url", "")
-                    if url == card_url:
-                        return  # Already current version
-                    if url.startswith(base_url):
-                        await resources.async_update_item(item["id"], {"url": card_url})
-                        hass.data.setdefault(DOMAIN, {})[storage_key] = item["id"]
-                        return
-                item = await resources.async_create_item(
-                    {"res_type": "module", "url": card_url}
-                )
-                hass.data.setdefault(DOMAIN, {})[storage_key] = item["id"]
-                return
-    except Exception:  # pylint: disable=broad-exception-caught
-        _LOGGER.debug(
-            "[setup] Could not register %s as Lovelace resource, falling back to add_extra_js_url",
-            base_url,
-        )
-    try:
-        frontend.add_extra_js_url(hass, card_url)
-    except (KeyError, Exception):  # pylint: disable=broad-exception-caught
-        _LOGGER.debug("[setup] Could not register %s via add_extra_js_url", base_url)
-
-
-async def _unregister_card_resource(
-    hass: HomeAssistant,
-    card_url: str,
-    storage_key: str,
-) -> None:
-    """Remove a card Lovelace resource on unload."""
-    resource_id = hass.data.get(DOMAIN, {}).get(storage_key)
-    if not resource_id:
-        try:
-            frontend.remove_extra_js_url(hass, card_url)
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-        return
-    try:
-        lovelace_data = hass.data.get("lovelace")
-        if lovelace_data and hasattr(lovelace_data, "resources"):
-            resources = lovelace_data.resources
-            if hasattr(resources, "async_delete_item"):
-                await resources.async_delete_item(resource_id)
-    except Exception:  # pylint: disable=broad-exception-caught
-        _LOGGER.debug("[teardown] Could not remove Lovelace resource %s", resource_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -407,17 +407,17 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             return False
         self._message = status.message
         self._attr_extra_state_attributes["message"] = status.message
-        self._attr_extra_state_attributes["response_data"] = status.protom_response_data
+        self._attr_extra_state_attributes["response_data"] = status.protom_response_date
         if not status.protom_response:
             _LOGGER.debug(
                 "[%s] Received empty protomResponse"
                 " (operation_status: %s, message: %s, status: %s,"
-                " protomResponseData: %s), ignoring",
+                " protomResponseDate: %s), ignoring",
                 self.entity_id,
                 status.operation_status,
                 status.message,
                 status.status,
-                status.protom_response_data,
+                status.protom_response_date,
             )
             return False
         if is_proto_letter(status.protom_response):

--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -17,7 +17,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CODE, CONF_SCAN_INTERVAL
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     async_get_current_platform,
@@ -41,7 +40,7 @@ from .const import (
     CONF_ENABLE_PERIMETER_PANEL,
 )
 from .coordinators import AlarmCoordinator, AlarmStatusData
-from .entity import securitas_device_info
+from .entity import VerisureEntity
 from .events import (
     ARMING_EXCEPTION_EVENT_TYPE,
     LEGACY_ARMING_EXCEPTION_EVENT_TYPE,
@@ -173,7 +172,9 @@ async def async_setup_entry(
 
 
 class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
-    CoordinatorEntity[AlarmCoordinator], alarm.AlarmControlPanelEntity
+    VerisureEntity,
+    CoordinatorEntity[AlarmCoordinator],
+    alarm.AlarmControlPanelEntity,
 ):
     """Representation of a Verisure alarm status."""
 
@@ -187,14 +188,8 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         coordinator: AlarmCoordinator,
     ) -> None:
         """Initialize the Verisure alarm panel."""
-        super().__init__(coordinator)
-        self._installation = installation
-        self._client = client
-        self._attr_device_info: DeviceInfo = (  # type: ignore[override]
-            securitas_device_info(installation)
-        )
-        self._state: str | None = None
-        self._last_state: str | None = None
+        CoordinatorEntity.__init__(self, coordinator)
+        VerisureEntity.__init__(self, installation, client)
         self._device: str = installation.address
         self._attr_name = installation.alias
         self._attr_unique_id: str | None = f"v5_verisure_owa.{installation.number}"
@@ -257,25 +252,6 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._arming_event_unsub_new = None
         self._arming_event_unsub_legacy = None
         self._last_handled_event_id: str | None = None
-
-    # -- Properties formerly from VerisureEntity --------------------------
-
-    @property
-    def installation(self) -> Installation:
-        """Return the installation."""
-        return self._installation
-
-    @property
-    def client(self) -> VerisureHub:
-        """Return the client hub."""
-        return self._client
-
-    def _force_state(self, state: AlarmControlPanelState) -> None:
-        """Force entity state and schedule HA update."""
-        self._last_state = self._state
-        self._state = state
-        if self.hass is not None:
-            self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Register event listeners when added to HA."""

--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -188,7 +188,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         coordinator: AlarmCoordinator,
     ) -> None:
         """Initialize the Verisure alarm panel."""
-        CoordinatorEntity.__init__(self, coordinator)
+        CoordinatorEntity.__init__(self, coordinator)  # type: ignore[arg-type]
         VerisureEntity.__init__(self, installation, client)
         self._device: str = installation.address
         self._attr_name = installation.alias

--- a/custom_components/verisure_owa/alarm_control_panel.py
+++ b/custom_components/verisure_owa/alarm_control_panel.py
@@ -318,8 +318,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._last_proto_code = proto_code
         if proto_code == PROTO_DISARMED:
             self._state = AlarmControlPanelState.DISARMED
+            self._last_unmapped_logged = None
         elif proto_code in self._status_map:
             self._state = self._status_map[proto_code]
+            self._last_unmapped_logged = None
         else:
             self._state = AlarmControlPanelState.ARMED_CUSTOM_BYPASS
             self._log_unmapped_proto_code(proto_code)
@@ -407,8 +409,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         assert status is not None  # narrowed by _store_operation_status_metadata
         if status.protom_response == PROTO_DISARMED:
             self._state = AlarmControlPanelState.DISARMED
+            self._last_unmapped_logged = None
         elif status.protom_response in self._status_map:
             self._state = self._status_map[status.protom_response]
+            self._last_unmapped_logged = None
         else:
             self._state = AlarmControlPanelState.ARMED_CUSTOM_BYPASS
             self._log_unmapped_proto_code(status.protom_response)

--- a/custom_components/verisure_owa/api_queue.py
+++ b/custom_components/verisure_owa/api_queue.py
@@ -38,10 +38,7 @@ class ApiQueue:
         self,
         interval: float = DEFAULT_INTERVAL,
     ) -> None:
-        self._intervals = {
-            self.FOREGROUND: interval,
-            self.BACKGROUND: interval,
-        }
+        self._interval: float = interval
         self._lock = asyncio.Lock()
         self._last_api_time: float = 0
         self._pending_foreground: int = 0
@@ -86,7 +83,7 @@ class ApiQueue:
 
                 # Compute throttle delay outside the lock so we don't block
                 # other callers (especially foreground) during the sleep.
-                interval = self._intervals[priority]
+                interval = self._interval
                 elapsed = time.monotonic() - self._last_api_time
                 if elapsed < interval:
                     delay = interval - elapsed

--- a/custom_components/verisure_owa/camera.py
+++ b/custom_components/verisure_owa/camera.py
@@ -86,7 +86,10 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
         self._camera_device = camera_device
         self._zone_id = camera_device.zone_id
         suffix = "_full" if self._mode == "full" else ""
-        self._attr_unique_id = f"v5_verisure_owa.{installation.number}_camera{suffix}_{camera_device.zone_id}"
+        self._attr_unique_id = (
+            f"v5_verisure_owa.{installation.number}"
+            f"_camera{suffix}_{camera_device.zone_id}"
+        )
         if self._mode == "full":
             self._attr_name = "Full Image"
         self._attr_device_info = camera_device_info(installation, camera_device)

--- a/custom_components/verisure_owa/camera.py
+++ b/custom_components/verisure_owa/camera.py
@@ -1,5 +1,6 @@
 """Verisure OWA camera platform."""
 
+import asyncio
 import base64
 import logging
 from pathlib import Path
@@ -20,7 +21,29 @@ from .verisure_owa_api.models import CameraDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-_PLACEHOLDER_IMAGE = (Path(__file__).parent / "placeholder.jpg").read_bytes()
+_PLACEHOLDER_IMAGE_PATH = Path(__file__).parent / "placeholder.jpg"
+# Cache for the placeholder JPEG bytes — populated on first access via the
+# event loop's executor to avoid sync file I/O during integration startup.
+_PLACEHOLDER_IMAGE: bytes | None = None
+_placeholder_lock: asyncio.Lock | None = None
+
+
+async def _get_placeholder_image(hass: HomeAssistant) -> bytes:
+    """Return the placeholder JPEG, reading the file once via the executor."""
+    global _PLACEHOLDER_IMAGE, _placeholder_lock  # pylint: disable=global-statement  # noqa: PLW0603
+    cached = _PLACEHOLDER_IMAGE
+    if cached is not None:
+        return cached
+    if _placeholder_lock is None:
+        _placeholder_lock = asyncio.Lock()
+    async with _placeholder_lock:
+        if _PLACEHOLDER_IMAGE is None:
+            loaded: bytes = await hass.async_add_executor_job(
+                _PLACEHOLDER_IMAGE_PATH.read_bytes
+            )
+            _PLACEHOLDER_IMAGE = loaded
+            return loaded
+        return _PLACEHOLDER_IMAGE
 
 
 async def async_setup_entry(
@@ -65,16 +88,16 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
     ) -> bytes | None:
         """Return the last captured image, or a placeholder if none exists."""
         if self.coordinator.data is None:
-            return _PLACEHOLDER_IMAGE
+            return await _get_placeholder_image(self.hass)
         thumb = self.coordinator.data.thumbnails.get(self._zone_id)
         if thumb is None or not thumb.image:
-            return _PLACEHOLDER_IMAGE
+            return await _get_placeholder_image(self.hass)
         try:
             image_bytes = base64.b64decode(thumb.image)
         except (ValueError, TypeError):
-            return _PLACEHOLDER_IMAGE
+            return await _get_placeholder_image(self.hass)
         if not image_bytes.startswith(b"\xff\xd8"):
-            return _PLACEHOLDER_IMAGE
+            return await _get_placeholder_image(self.hass)
         return image_bytes
 
     @property
@@ -145,9 +168,11 @@ class VerisureCameraFull(CoordinatorEntity[CameraCoordinator], Camera):
     ) -> bytes | None:
         """Return the last full-resolution image, or a placeholder if none exists."""
         if self.coordinator.data is None:
-            return _PLACEHOLDER_IMAGE
+            return await _get_placeholder_image(self.hass)
         image = self.coordinator.data.full_images.get(self._zone_id)
-        return image if image is not None else _PLACEHOLDER_IMAGE
+        if image is not None:
+            return image
+        return await _get_placeholder_image(self.hass)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:  # type: ignore[override]

--- a/custom_components/verisure_owa/camera.py
+++ b/custom_components/verisure_owa/camera.py
@@ -59,10 +59,19 @@ async def async_setup_entry(
 
 
 class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
-    """A Verisure OWA camera entity showing the last captured image."""
+    """A Verisure OWA camera entity.
+
+    Subclass-controlled mode: `_mode = "thumbnail"` reads
+    `coordinator.data.thumbnails` and exposes the `capturing` state attribute
+    plus a SIGNAL_CAMERA_STATE listener; `_mode = "full"` reads
+    `coordinator.data.full_images` instead.
+    """
 
     _attr_should_poll = False
     _attr_has_entity_name = True
+    _mode: str = "thumbnail"
+    _unique_id_kind: str = "camera"
+    _camera_name: str | None = None
 
     def __init__(
         self,
@@ -79,16 +88,24 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
         self._camera_device = camera_device
         self._zone_id = camera_device.zone_id
         self._attr_unique_id = (
-            f"v5_verisure_owa.{installation.number}_camera_{camera_device.zone_id}"
+            f"v5_verisure_owa.{installation.number}"
+            f"_{self._unique_id_kind}_{camera_device.zone_id}"
         )
+        if self._camera_name is not None:
+            self._attr_name = self._camera_name
         self._attr_device_info = camera_device_info(installation, camera_device)
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
-        """Return the last captured image, or a placeholder if none exists."""
+        """Return the relevant image for this mode, or a placeholder."""
         if self.coordinator.data is None:
             return await _get_placeholder_image(self.hass)
+        if self._mode == "full":
+            image = self.coordinator.data.full_images.get(self._zone_id)
+            if image is None:
+                return await _get_placeholder_image(self.hass)
+            return image
         thumb = self.coordinator.data.thumbnails.get(self._zone_id)
         if thumb is None or not thumb.image:
             return await _get_placeholder_image(self.hass)
@@ -108,10 +125,12 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
             thumb = self.coordinator.data.thumbnails.get(self._zone_id)
             if thumb is not None:
                 timestamp = thumb.timestamp
-        capturing = self._client.is_capturing(
-            self._installation.number, self._camera_device.zone_id
-        )
-        return {"image_timestamp": timestamp, "capturing": capturing}
+        attrs: dict[str, Any] = {"image_timestamp": timestamp}
+        if self._mode == "thumbnail":
+            attrs["capturing"] = self._client.is_capturing(
+                self._installation.number, self._camera_device.zone_id
+            )
+        return attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -120,11 +139,14 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
-        """Subscribe to camera state signal and set up coordinator listener."""
+        """Subscribe to camera state signal (thumbnail mode only)."""
         await super().async_added_to_hass()
-        self.async_on_remove(
-            async_dispatcher_connect(self.hass, SIGNAL_CAMERA_STATE, self._handle_state)
-        )
+        if self._mode == "thumbnail":
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass, SIGNAL_CAMERA_STATE, self._handle_state
+                )
+            )
 
     @callback
     def _handle_state(self, installation_number: str, zone_id: str) -> None:
@@ -137,55 +159,9 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
         self.async_write_ha_state()
 
 
-class VerisureCameraFull(CoordinatorEntity[CameraCoordinator], Camera):
-    """A Verisure OWA camera entity showing the last full-resolution image."""
+class VerisureCameraFull(VerisureCamera):
+    """Full-resolution variant of VerisureCamera."""
 
-    _attr_should_poll = False
-    _attr_has_entity_name = True
-
-    def __init__(
-        self,
-        coordinator: CameraCoordinator,
-        hub: VerisureHub,
-        installation: Installation,
-        camera_device: CameraDevice,
-    ) -> None:
-        """Initialize the full-resolution camera entity."""
-        super().__init__(coordinator)
-        Camera.__init__(self)
-        self._client = hub
-        self._installation = installation
-        self._camera_device = camera_device
-        self._zone_id = camera_device.zone_id
-        self._attr_unique_id = (
-            f"v5_verisure_owa.{installation.number}_camera_full_{camera_device.zone_id}"
-        )
-        self._attr_name = "Full Image"
-        self._attr_device_info = camera_device_info(installation, camera_device)
-
-    async def async_camera_image(
-        self, width: int | None = None, height: int | None = None
-    ) -> bytes | None:
-        """Return the last full-resolution image, or a placeholder if none exists."""
-        if self.coordinator.data is None:
-            return await _get_placeholder_image(self.hass)
-        image = self.coordinator.data.full_images.get(self._zone_id)
-        if image is not None:
-            return image
-        return await _get_placeholder_image(self.hass)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:  # type: ignore[override]
-        """Return extra state attributes."""
-        timestamp: str | None = None
-        if self.coordinator.data is not None:
-            thumb = self.coordinator.data.thumbnails.get(self._zone_id)
-            if thumb is not None:
-                timestamp = thumb.timestamp
-        return {"image_timestamp": timestamp}
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator — rotate token so frontend re-fetches."""
-        self.async_update_token()
-        self.async_write_ha_state()
+    _mode = "full"
+    _unique_id_kind = "camera_full"
+    _camera_name = "Full Image"

--- a/custom_components/verisure_owa/camera.py
+++ b/custom_components/verisure_owa/camera.py
@@ -70,8 +70,6 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
     _attr_should_poll = False
     _attr_has_entity_name = True
     _mode: str = "thumbnail"
-    _unique_id_kind: str = "camera"
-    _camera_name: str | None = None
 
     def __init__(
         self,
@@ -87,12 +85,10 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
         self._installation = installation
         self._camera_device = camera_device
         self._zone_id = camera_device.zone_id
-        self._attr_unique_id = (
-            f"v5_verisure_owa.{installation.number}"
-            f"_{self._unique_id_kind}_{camera_device.zone_id}"
-        )
-        if self._camera_name is not None:
-            self._attr_name = self._camera_name
+        suffix = "_full" if self._mode == "full" else ""
+        self._attr_unique_id = f"v5_verisure_owa.{installation.number}_camera{suffix}_{camera_device.zone_id}"
+        if self._mode == "full":
+            self._attr_name = "Full Image"
         self._attr_device_info = camera_device_info(installation, camera_device)
 
     async def async_camera_image(
@@ -163,5 +159,3 @@ class VerisureCameraFull(VerisureCamera):
     """Full-resolution variant of VerisureCamera."""
 
     _mode = "full"
-    _unique_id_kind = "camera_full"
-    _camera_name = "Full Image"

--- a/custom_components/verisure_owa/card_resources.py
+++ b/custom_components/verisure_owa/card_resources.py
@@ -1,0 +1,84 @@
+"""Lovelace card resource registration for the Verisure OWA cards.
+
+The integration ships three custom Lovelace cards under www/. Each one is
+registered as a Lovelace resource (preferred) so it survives HA restarts,
+or — if the resources storage isn't available — falls back to
+add_extra_js_url for the lifetime of the running session.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components import frontend
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _register_card_resource(
+    hass: HomeAssistant,
+    base_url: str,
+    card_url: str,
+    storage_key: str,
+) -> None:
+    """Register a card JS file as a Lovelace resource.
+
+    Falls back to add_extra_js_url if Lovelace resources are unavailable.
+    ``storage_key`` is used to track the resource ID in hass.data[DOMAIN].
+    """
+    try:
+        lovelace_data = hass.data.get("lovelace")
+        if lovelace_data and hasattr(lovelace_data, "resources"):
+            resources = lovelace_data.resources
+            if hasattr(resources, "async_create_item"):
+                if not resources.loaded:
+                    await resources.async_load()
+                    resources.loaded = True
+                for item in resources.async_items():
+                    url = item.get("url", "")
+                    if url == card_url:
+                        return  # Already current version
+                    if url.startswith(base_url):
+                        await resources.async_update_item(item["id"], {"url": card_url})
+                        hass.data.setdefault(DOMAIN, {})[storage_key] = item["id"]
+                        return
+                item = await resources.async_create_item(
+                    {"res_type": "module", "url": card_url}
+                )
+                hass.data.setdefault(DOMAIN, {})[storage_key] = item["id"]
+                return
+    except Exception:  # pylint: disable=broad-exception-caught
+        _LOGGER.debug(
+            "[setup] Could not register %s as Lovelace resource, falling back to add_extra_js_url",
+            base_url,
+        )
+    try:
+        frontend.add_extra_js_url(hass, card_url)
+    except (KeyError, Exception):  # pylint: disable=broad-exception-caught
+        _LOGGER.debug("[setup] Could not register %s via add_extra_js_url", base_url)
+
+
+async def _unregister_card_resource(
+    hass: HomeAssistant,
+    card_url: str,
+    storage_key: str,
+) -> None:
+    """Remove a card Lovelace resource on unload."""
+    resource_id = hass.data.get(DOMAIN, {}).get(storage_key)
+    if not resource_id:
+        try:
+            frontend.remove_extra_js_url(hass, card_url)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        return
+    try:
+        lovelace_data = hass.data.get("lovelace")
+        if lovelace_data and hasattr(lovelace_data, "resources"):
+            resources = lovelace_data.resources
+            if hasattr(resources, "async_delete_item"):
+                await resources.async_delete_item(resource_id)
+    except Exception:  # pylint: disable=broad-exception-caught
+        _LOGGER.debug("[teardown] Could not remove Lovelace resource %s", resource_id)

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -78,7 +78,7 @@ VERSION = 4
 
 _LOGGER = logging.getLogger(__name__)
 
-_NOTIFY_EXCLUDE = {"notify", "send_message", "persistent_notification"}
+_NOTIFY_EXCLUDE = {"notify", "send_message"}
 
 PANEL_OPTION_KEYS = (
     CONF_ENABLE_PERIMETER_PANEL,

--- a/custom_components/verisure_owa/coordinators.py
+++ b/custom_components/verisure_owa/coordinators.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -117,6 +118,31 @@ async def _handle_session_expired(client: VerisureOwaClient) -> None:
         await client.login()
     except VerisureOwaError as err:
         raise ConfigEntryAuthFailed(f"Re-authentication failed: {err}") from err
+
+
+async def _fetch_with_session_recovery[T](
+    client: VerisureOwaClient,
+    fetcher: Callable[[], Awaitable[T]],
+    label: str,
+) -> T:
+    """Run *fetcher* with one-shot session-expired recovery.
+
+    On SessionExpiredError, re-login then retry once. WAFBlockedError and any
+    remaining VerisureOwaError are wrapped as UpdateFailed messages keyed on
+    *label* — the human-readable subject for the failure.
+    """
+    try:
+        return await fetcher()
+    except SessionExpiredError:
+        await _handle_session_expired(client)
+        try:
+            return await fetcher()
+        except VerisureOwaError as err:
+            raise UpdateFailed(f"{label} update failed: {err}") from err
+    except WAFBlockedError as err:
+        raise UpdateFailed(f"WAF blocked {label.lower()} request: {err}") from err
+    except VerisureOwaError as err:
+        raise UpdateFailed(f"{label} update failed: {err}") from err
 
 
 # ── AlarmCoordinator ─────────────────────────────────────────────────────────
@@ -245,38 +271,23 @@ class AlarmCoordinator(DataUpdateCoordinator[AlarmStatusData]):
             sorted(self._capabilities),
         )
 
+    async def _fetch(self) -> AlarmStatusData:
+        status = await self._queue.submit(
+            self._client.get_general_status,
+            self._installation,
+            priority=ApiQueue.BACKGROUND,
+        )
+        return AlarmStatusData(
+            status=status,
+            protom_response=self._client.protom_response,
+        )
+
     async def _async_update_data(self) -> AlarmStatusData:
         """Fetch alarm status via the API queue."""
         await self._populate_capabilities()
-        try:
-            status = await self._queue.submit(
-                self._client.get_general_status,
-                self._installation,
-                priority=ApiQueue.BACKGROUND,
-            )
-            return AlarmStatusData(
-                status=status,
-                protom_response=self._client.protom_response,
-            )
-        except SessionExpiredError:
-            await _handle_session_expired(self._client)
-            # Retry once after re-login
-            try:
-                status = await self._queue.submit(
-                    self._client.get_general_status,
-                    self._installation,
-                    priority=ApiQueue.BACKGROUND,
-                )
-                return AlarmStatusData(
-                    status=status,
-                    protom_response=self._client.protom_response,
-                )
-            except VerisureOwaError as err:
-                raise UpdateFailed(f"Alarm status update failed: {err}") from err
-        except WAFBlockedError as err:
-            raise UpdateFailed(f"WAF blocked alarm status request: {err}") from err
-        except VerisureOwaError as err:
-            raise UpdateFailed(f"Alarm status update failed: {err}") from err
+        return await _fetch_with_session_recovery(
+            self._client, self._fetch, "Alarm status"
+        )
 
 
 # ── SentinelCoordinator ──────────────────────────────────────────────────────
@@ -329,18 +340,9 @@ class SentinelCoordinator(DataUpdateCoordinator[SentinelData]):
 
     async def _async_update_data(self) -> SentinelData:
         """Fetch sentinel data via the API queue."""
-        try:
-            return await self._fetch_data()
-        except SessionExpiredError:
-            await _handle_session_expired(self._client)
-            try:
-                return await self._fetch_data()
-            except VerisureOwaError as err:
-                raise UpdateFailed(f"Sentinel update failed: {err}") from err
-        except WAFBlockedError as err:
-            raise UpdateFailed(f"WAF blocked sentinel request: {err}") from err
-        except VerisureOwaError as err:
-            raise UpdateFailed(f"Sentinel update failed: {err}") from err
+        return await _fetch_with_session_recovery(
+            self._client, self._fetch_data, "Sentinel"
+        )
 
 
 # ── LockCoordinator ──────────────────────────────────────────────────────────
@@ -370,30 +372,17 @@ class LockCoordinator(DataUpdateCoordinator[LockData]):
         self._queue = queue
         self._installation = installation
 
+    async def _fetch(self) -> LockData:
+        modes = await self._queue.submit(
+            self._client.get_lock_modes,
+            self._installation,
+            priority=ApiQueue.BACKGROUND,
+        )
+        return LockData(modes=modes)
+
     async def _async_update_data(self) -> LockData:
         """Fetch lock modes via the API queue."""
-        try:
-            modes = await self._queue.submit(
-                self._client.get_lock_modes,
-                self._installation,
-                priority=ApiQueue.BACKGROUND,
-            )
-            return LockData(modes=modes)
-        except SessionExpiredError:
-            await _handle_session_expired(self._client)
-            try:
-                modes = await self._queue.submit(
-                    self._client.get_lock_modes,
-                    self._installation,
-                    priority=ApiQueue.BACKGROUND,
-                )
-                return LockData(modes=modes)
-            except VerisureOwaError as err:
-                raise UpdateFailed(f"Lock update failed: {err}") from err
-        except WAFBlockedError as err:
-            raise UpdateFailed(f"WAF blocked lock request: {err}") from err
-        except VerisureOwaError as err:
-            raise UpdateFailed(f"Lock update failed: {err}") from err
+        return await _fetch_with_session_recovery(self._client, self._fetch, "Lock")
 
 
 # ── CameraCoordinator ────────────────────────────────────────────────────────

--- a/custom_components/verisure_owa/coordinators.py
+++ b/custom_components/verisure_owa/coordinators.py
@@ -9,6 +9,7 @@ Four coordinators replace per-entity independent polling:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -309,18 +310,20 @@ class SentinelCoordinator(DataUpdateCoordinator[SentinelData]):
         self._zone = zone
 
     async def _fetch_data(self) -> SentinelData:
-        """Fetch sentinel and air quality data sequentially."""
-        sentinel = await self._queue.submit(
-            self._client.get_sentinel_data,
-            self.installation,
-            self.service,
-            priority=ApiQueue.BACKGROUND,
-        )
-        air_quality = await self._queue.submit(
-            self._client.get_air_quality_data,
-            self.installation,
-            self._zone,
-            priority=ApiQueue.BACKGROUND,
+        """Fetch sentinel and air quality data concurrently."""
+        sentinel, air_quality = await asyncio.gather(
+            self._queue.submit(
+                self._client.get_sentinel_data,
+                self.installation,
+                self.service,
+                priority=ApiQueue.BACKGROUND,
+            ),
+            self._queue.submit(
+                self._client.get_air_quality_data,
+                self.installation,
+                self._zone,
+                priority=ApiQueue.BACKGROUND,
+            ),
         )
         return SentinelData(sentinel=sentinel, air_quality=air_quality)
 
@@ -411,6 +414,7 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
         installation: Installation,
         *,
         cameras: list[CameraDevice],
+        full_image_fetcher: Any | None = None,
         config_entry: ConfigEntry | None = None,
     ) -> None:
         super().__init__(
@@ -424,6 +428,10 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
         self._queue = queue
         self._installation = installation
         self._cameras = cameras
+        # Optional coalescing fetcher (typically `hub.fetch_full_image`) so
+        # poll-driven full-image requests share an in-flight cache with
+        # capture-driven requests on the same camera.
+        self._full_image_fetcher = full_image_fetcher
 
     async def _fetch_thumbnails(
         self, previous: CameraData | None
@@ -493,13 +501,21 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
             )
             return None
         try:
-            full_bytes = await self._queue.submit(
-                self._client.get_full_image,
-                self._installation,
-                thumbnail.id_signal,
-                thumbnail.signal_type,
-                priority=ApiQueue.BACKGROUND,
-            )
+            if self._full_image_fetcher is not None:
+                full_bytes = await self._full_image_fetcher(
+                    self._installation,
+                    thumbnail.id_signal,
+                    thumbnail.signal_type,
+                    priority=ApiQueue.BACKGROUND,
+                )
+            else:
+                full_bytes = await self._queue.submit(
+                    self._client.get_full_image,
+                    self._installation,
+                    thumbnail.id_signal,
+                    thumbnail.signal_type,
+                    priority=ApiQueue.BACKGROUND,
+                )
         except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
             _LOGGER.warning(
                 "Failed to fetch full image for camera zone %s",

--- a/custom_components/verisure_owa/coordinators.py
+++ b/custom_components/verisure_owa/coordinators.py
@@ -524,18 +524,11 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
     async def _async_update_data(self) -> CameraData:
         """Fetch camera thumbnails and full images for any that changed."""
         previous = self.data
-        try:
-            thumbnails = await self._fetch_thumbnails(previous)
-        except SessionExpiredError:
-            await _handle_session_expired(self._client)
-            try:
-                thumbnails = await self._fetch_thumbnails(previous)
-            except WAFBlockedError as err:
-                raise UpdateFailed(f"WAF blocked camera request: {err}") from err
-            except VerisureOwaError as err:
-                raise UpdateFailed(f"Camera update failed: {err}") from err
-        except WAFBlockedError as err:
-            raise UpdateFailed(f"WAF blocked camera request: {err}") from err
+        thumbnails = await _fetch_with_session_recovery(
+            self._client,
+            lambda: self._fetch_thumbnails(previous),
+            "Camera",
+        )
 
         # Carry forward previous full images
         full_images: dict[str, bytes] = {}
@@ -655,18 +648,9 @@ class ActivityCoordinator(DataUpdateCoordinator[ActivityData]):
         # events out of the first-poll baseline — causing them to re-fire
         # on the bus on the next poll.
         await self.async_load_persisted()
-        try:
-            events = await self._fetch()
-        except SessionExpiredError:
-            await _handle_session_expired(self._client)
-            try:
-                events = await self._fetch()
-            except VerisureOwaError as err:
-                raise UpdateFailed(f"Activity update failed: {err}") from err
-        except WAFBlockedError as err:
-            raise UpdateFailed(f"WAF blocked activity request: {err}") from err
-        except VerisureOwaError as err:
-            raise UpdateFailed(f"Activity update failed: {err}") from err
+        events = await _fetch_with_session_recovery(
+            self._client, self._fetch, "Activity"
+        )
 
         polled = [
             ev

--- a/custom_components/verisure_owa/coordinators.py
+++ b/custom_components/verisure_owa/coordinators.py
@@ -137,6 +137,8 @@ async def _fetch_with_session_recovery[T](
         await _handle_session_expired(client)
         try:
             return await fetcher()
+        except WAFBlockedError as err:
+            raise UpdateFailed(f"WAF blocked {label.lower()} request: {err}") from err
         except VerisureOwaError as err:
             raise UpdateFailed(f"{label} update failed: {err}") from err
     except WAFBlockedError as err:

--- a/custom_components/verisure_owa/discovery.py
+++ b/custom_components/verisure_owa/discovery.py
@@ -160,8 +160,7 @@ def _schedule_lock_config_retry(
 
     unsub = async_call_later(hass, delay, _retry)
     lock_entity.add_config_retry_unsub(unsub)
-    # Mirror the handle at entry-scope so async_unload_entry can cancel any
-    # in-flight retries even if the per-entity teardown races with the timer.
+    # Also tracked at entry scope so unload can cancel pending retries.
     if hub.config_entry is not None:
         entry_data = hass.data.get(DOMAIN, {}).get(hub.config_entry.entry_id)
         if entry_data is not None:

--- a/custom_components/verisure_owa/discovery.py
+++ b/custom_components/verisure_owa/discovery.py
@@ -1,0 +1,256 @@
+"""Background discovery for cameras and locks.
+
+Cameras and locks are discovered asynchronously after async_setup_entry
+returns so a transient API failure during discovery doesn't block the
+integration from coming up. Each discovery path is best-effort: failures
+are logged but never raise.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinators import CameraCoordinator
+
+if TYPE_CHECKING:
+    from .hub import VerisureDevice, VerisureHub
+    from .lock import VerisureLock
+    from .verisure_owa_api import Installation
+
+_LOGGER = logging.getLogger(__name__)
+
+# Backoff schedule for the lock-config retry chain.
+_LOCK_CONFIG_RETRY_DELAYS = (60, 120, 300)  # seconds between attempts
+
+
+async def _discover_cameras(
+    hass: HomeAssistant,
+    hub: VerisureHub,
+    installation: Installation,
+    entry_data: dict[str, Any],
+    entry: ConfigEntry,
+) -> None:
+    """Discover camera devices for an installation and add entities."""
+    from .button import VerisureCaptureButton
+    from .camera import VerisureCamera, VerisureCameraFull
+
+    _LOGGER.debug(
+        "[camera_discovery] Fetching camera devices for installation %s (%s)",
+        installation.number,
+        installation.alias,
+    )
+    try:
+        cameras = await hub.get_camera_devices(installation)
+    except Exception:  # pylint: disable=broad-exception-caught  # background discovery must not crash
+        _LOGGER.warning(
+            "[camera_discovery] Failed to get camera devices for %s",
+            installation.number,
+            exc_info=True,
+        )
+        cameras = []
+
+    _LOGGER.debug(
+        "[camera_discovery] Installation %s: found %d camera(s): %s",
+        installation.number,
+        len(cameras),
+        [c.zone_id for c in cameras],
+    )
+
+    if cameras:
+        camera_coord = CameraCoordinator(
+            hass,
+            hub.client,
+            hub.api_queue,
+            installation,
+            cameras=cameras,
+            full_image_fetcher=hub.fetch_full_image,
+            config_entry=entry,
+        )
+        entry_data["camera_coordinator"] = camera_coord
+        entry.async_create_background_task(
+            hass,
+            camera_coord.async_refresh(),
+            "verisure_owa_camera_refresh",
+        )
+
+        camera_add = entry_data.get("camera_add_entities")
+        button_add = entry_data.get("button_add_entities")
+        _LOGGER.debug(
+            "[camera_discovery] Installation %s: camera_add=%s button_add=%s",
+            installation.number,
+            camera_add is not None,
+            button_add is not None,
+        )
+        if camera_add:
+            camera_add(
+                [
+                    VerisureCamera(camera_coord, hub, installation, cam)
+                    for cam in cameras
+                ]
+                + [
+                    VerisureCameraFull(camera_coord, hub, installation, cam)
+                    for cam in cameras
+                ],
+                False,
+            )
+        if button_add:
+            button_add(
+                [VerisureCaptureButton(hub, installation, cam) for cam in cameras],
+                True,
+            )
+
+
+def _schedule_lock_config_retry(
+    hass: HomeAssistant,
+    hub: VerisureHub,
+    installation: Installation,
+    lock_entity: VerisureLock,
+    attempt: int = 0,
+) -> None:
+    """Schedule a background retry to fetch lock config."""
+    from homeassistant.helpers.event import async_call_later
+
+    if attempt >= len(_LOCK_CONFIG_RETRY_DELAYS):
+        _LOGGER.info(
+            "Lock config retry exhausted for %s device %s",
+            installation.number,
+            lock_entity.device_id,
+        )
+        return
+
+    delay = _LOCK_CONFIG_RETRY_DELAYS[attempt]
+
+    async def _retry(_now: Any) -> None:
+        # Guard: entity may have been removed while the timer was pending.
+        if lock_entity.hass is None:
+            return
+
+        try:
+            config = await hub.get_lock_config(
+                installation,
+                lock_entity.device_id,
+                priority=hub.api_queue.BACKGROUND,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+            config = None
+
+        if config is not None:
+            _LOGGER.info(
+                "Lock config retry succeeded for %s device %s (attempt %d)",
+                installation.number,
+                lock_entity.device_id,
+                attempt + 1,
+            )
+            lock_entity.update_lock_config(config)
+        else:
+            _LOGGER.debug(
+                "Lock config retry %d failed for %s device %s, scheduling next retry",
+                attempt + 1,
+                installation.number,
+                lock_entity.device_id,
+            )
+            _schedule_lock_config_retry(
+                hass, hub, installation, lock_entity, attempt + 1
+            )
+
+    unsub = async_call_later(hass, delay, _retry)
+    lock_entity.add_config_retry_unsub(unsub)
+    # Mirror the handle at entry-scope so async_unload_entry can cancel any
+    # in-flight retries even if the per-entity teardown races with the timer.
+    if hub.config_entry is not None:
+        entry_data = hass.data.get(DOMAIN, {}).get(hub.config_entry.entry_id)
+        if entry_data is not None:
+            entry_data.setdefault("lock_config_retry_unsubs", []).append(unsub)
+
+
+async def _discover_locks(
+    hass: HomeAssistant,
+    hub: VerisureHub,
+    installation: Installation,
+    entry_data: dict[str, Any],
+) -> None:
+    """Discover lock devices for an installation and add entities."""
+    from .lock import (
+        DOORLOCK_SERVICE,
+        LOCK_STATUS_UNKNOWN,
+        VerisureLock,
+    )
+    from .verisure_owa_api import SmartLock, SmartLockMode
+    from .verisure_owa_api.client import SMARTLOCK_DEVICE_ID
+
+    try:
+        services = await hub.get_services(installation)
+    except Exception:  # pylint: disable=broad-exception-caught  # background discovery must not crash
+        _LOGGER.warning("Failed to get services for %s", installation.number)
+        return
+
+    has_doorlock = any(s.request == DOORLOCK_SERVICE for s in services)
+    if not has_doorlock:
+        return
+
+    try:
+        lock_modes: list[SmartLockMode] = await hub.get_lock_modes(installation)
+    except Exception:  # pylint: disable=broad-exception-caught  # background discovery must not crash
+        _LOGGER.warning("Failed to get lock modes for %s", installation.number)
+        lock_modes = []
+
+    if not lock_modes:
+        lock_modes = [
+            SmartLockMode(
+                res=None,
+                lock_status=LOCK_STATUS_UNKNOWN,
+                device_id=SMARTLOCK_DEVICE_ID,
+            )
+        ]
+
+    lock_coordinator = entry_data.get("lock_coordinator")
+    lock_add = entry_data.get("lock_add_entities")
+    if lock_add and lock_coordinator is not None:
+        locks = []
+        for mode in lock_modes:
+            device_id = mode.device_id or SMARTLOCK_DEVICE_ID
+            lock_config: SmartLock | None = None
+            try:
+                lock_config = await hub.get_lock_config(installation, device_id)
+            except Exception:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug(
+                    "Could not fetch lock config for %s device %s",
+                    installation.number,
+                    device_id,
+                )
+            locks.append(
+                VerisureLock(
+                    coordinator=lock_coordinator,
+                    installation=installation,
+                    client=hub,
+                    device_id=device_id,
+                    initial_status=mode.lock_status,
+                    lock_config=lock_config,
+                )
+            )
+        lock_add(locks, False)
+
+        # Schedule deferred config retry for locks without config.
+        for lk in locks:
+            if lk.lock_config is None:
+                _schedule_lock_config_retry(hass, hub, installation, lk)
+
+
+async def _async_discover_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Discover cameras and locks in the background after setup."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if entry_data is None:
+        return
+
+    client: VerisureHub = entry_data["hub"]
+    devices: list[VerisureDevice] = entry_data["devices"]
+
+    for device in devices:
+        installation = device.installation
+        await _discover_cameras(hass, client, installation, entry_data, entry)
+        await _discover_locks(hass, client, installation, entry_data)

--- a/custom_components/verisure_owa/hub.py
+++ b/custom_components/verisure_owa/hub.py
@@ -1,5 +1,6 @@
 """VerisureHub and VerisureDevice classes for Verisure OWA integration."""
 
+import asyncio
 import base64
 import logging
 import time
@@ -188,6 +189,9 @@ class VerisureHub:
         self.camera_timestamps: dict[str, str] = {}
         self._camera_devices_cache: dict[str, list[CameraDevice]] = {}
         self._camera_capturing: set[str] = set()  # keys of cameras currently capturing
+        # Coalesce concurrent full-image fetches for the same id_signal — two
+        # dashboard cards on the same camera share one API call.
+        self._full_image_inflight: dict[str, asyncio.Future[bytes | None]] = {}
 
     async def login(self) -> None:
         """Authenticate, preferring a stored refresh token over a password login.
@@ -333,6 +337,49 @@ class VerisureHub:
         finally:
             self._camera_capturing.discard(capture_key)
 
+    async def fetch_full_image(
+        self,
+        installation: Installation,
+        id_signal: str,
+        signal_type: str,
+        *,
+        priority: int | None = None,
+    ) -> bytes | None:
+        """Fetch a full-resolution image, coalescing concurrent calls per signal.
+
+        If another caller is already fetching this `id_signal`, waits on that
+        in-flight result instead of issuing a duplicate API request.
+        """
+        if priority is None:
+            priority = ApiQueue.BACKGROUND
+        key = f"{installation.number}_{id_signal}"
+        inflight = self._full_image_inflight.get(key)
+        if inflight is not None:
+            return await inflight
+
+        future: asyncio.Future[bytes | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+        self._full_image_inflight[key] = future
+        try:
+            result = await self._api_queue.submit(
+                self.client.get_full_image,
+                installation,
+                id_signal,
+                signal_type,
+                priority=priority,
+            )
+        except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+            if not future.done():
+                future.set_exception(err)
+            raise
+        else:
+            if not future.done():
+                future.set_result(result)
+            return result
+        finally:
+            self._full_image_inflight.pop(key, None)
+
     async def _fetch_and_store_full_image(
         self,
         installation: Installation,
@@ -340,9 +387,10 @@ class VerisureHub:
         thumbnail: ThumbnailResponse,
     ) -> None:
         """Fetch the full-resolution photo and store it, then notify the frontend."""
+        if not thumbnail.id_signal or not thumbnail.signal_type:
+            return
         try:
-            full_bytes = await self._api_queue.submit(
-                self.client.get_full_image,
+            full_bytes = await self.fetch_full_image(
                 installation,
                 thumbnail.id_signal,
                 thumbnail.signal_type,

--- a/custom_components/verisure_owa/hub.py
+++ b/custom_components/verisure_owa/hub.py
@@ -177,7 +177,6 @@ class VerisureHub:
             refresh_token=domain_config.get(CONF_REFRESH_TOKEN),
             on_refresh_token_changed=self._persist_refresh_token,
         )
-        self.installations: list[Installation] = []
         self._api_queue = ApiQueue(
             interval=domain_config[CONF_DELAY_CHECK_OPERATION],
         )
@@ -189,8 +188,6 @@ class VerisureHub:
         self.camera_timestamps: dict[str, str] = {}
         self._camera_devices_cache: dict[str, list[CameraDevice]] = {}
         self._camera_capturing: set[str] = set()  # keys of cameras currently capturing
-        self._full_images: dict[str, bytes] = {}
-        self._full_timestamps: dict[str, str] = {}
 
     async def login(self) -> None:
         """Authenticate, preferring a stored refresh token over a password login.
@@ -316,9 +313,7 @@ class VerisureHub:
             )
 
             # Push thumbnail into the camera coordinator so entities update
-            self._update_camera_coordinator_thumbnail(
-                installation, device.zone_id, thumbnail
-            )
+            self._update_camera_coordinator_thumbnail(device.zone_id, thumbnail)
 
             if image_bytes is None:
                 async_dispatcher_send(
@@ -337,38 +332,6 @@ class VerisureHub:
             return image_bytes, thumbnail
         finally:
             self._camera_capturing.discard(capture_key)
-
-    async def fetch_latest_thumbnail(
-        self, installation: Installation, camera_device: CameraDevice
-    ) -> None:
-        """Fetch the current thumbnail from the API and store it."""
-        try:
-            thumbnail = await self._api_queue.submit(
-                self.client.get_thumbnail,
-                installation,
-                camera_device.device_type,
-                camera_device.zone_id,
-                priority=ApiQueue.BACKGROUND,
-            )
-        except Exception:  # pylint: disable=broad-exception-caught  # API call may raise anything
-            _LOGGER.debug(
-                "[hub] Could not fetch thumbnail for %s on startup",
-                camera_device.name,
-            )
-            return
-
-        image_bytes = self._validate_and_store_image(
-            thumbnail, installation, camera_device, log_warnings=False
-        )
-        if image_bytes is not None:
-            self._update_camera_coordinator_thumbnail(
-                installation, camera_device.zone_id, thumbnail
-            )
-
-        if thumbnail.id_signal and thumbnail.signal_type:
-            self.hass.async_create_task(
-                self._fetch_and_store_full_image(installation, camera_device, thumbnail)
-            )
 
     async def _fetch_and_store_full_image(
         self,
@@ -396,15 +359,8 @@ class VerisureHub:
         if not full_bytes or not full_bytes.startswith(b"\xff\xd8"):
             return
 
-        key = f"{installation.number}_{camera_device.zone_id}"
-        self._full_images[key] = full_bytes
-        if thumbnail.timestamp:
-            self._full_timestamps[key] = thumbnail.timestamp
-
         # Push full image into the camera coordinator so entities update
-        self._update_camera_coordinator_full_image(
-            installation, camera_device.zone_id, full_bytes
-        )
+        self._update_camera_coordinator_full_image(camera_device.zone_id, full_bytes)
 
     def _validate_and_store_image(
         self,
@@ -433,11 +389,8 @@ class VerisureHub:
             self.camera_timestamps[key] = thumbnail.timestamp
         return image_bytes
 
-    def _get_camera_coordinator(
-        self,
-        installation: Installation,  # pylint: disable=unused-argument
-    ) -> Any | None:
-        """Return the CameraCoordinator for an installation, if available."""
+    def _get_camera_coordinator(self) -> Any | None:
+        """Return the CameraCoordinator for this entry, if available."""
         entry_id = self.config_entry.entry_id if self.config_entry else None
         if entry_id is None:
             return None
@@ -447,12 +400,12 @@ class VerisureHub:
         return entry_data.get("camera_coordinator")
 
     def _update_camera_coordinator_thumbnail(
-        self, installation: Installation, zone_id: str, thumbnail: ThumbnailResponse
+        self, zone_id: str, thumbnail: ThumbnailResponse
     ) -> None:
         """Push a new thumbnail into the CameraCoordinator's data."""
         if thumbnail is None:
             return
-        camera_coord = self._get_camera_coordinator(installation)
+        camera_coord = self._get_camera_coordinator()
         if camera_coord is None or camera_coord.data is None:
             return
         from .coordinators import CameraData
@@ -465,10 +418,10 @@ class VerisureHub:
         camera_coord.async_set_updated_data(new_data)
 
     def _update_camera_coordinator_full_image(
-        self, installation: Installation, zone_id: str, full_bytes: bytes
+        self, zone_id: str, full_bytes: bytes
     ) -> None:
         """Push a new full-resolution image into the CameraCoordinator's data."""
-        camera_coord = self._get_camera_coordinator(installation)
+        camera_coord = self._get_camera_coordinator()
         if camera_coord is None or camera_coord.data is None:
             return
         from .coordinators import CameraData
@@ -489,14 +442,6 @@ class VerisureHub:
     ) -> str | None:
         """Return the timestamp of the last captured image."""
         return self.camera_timestamps.get(f"{installation_number}_{zone_id}")
-
-    def get_full_image(self, installation_number: str, zone_id: str) -> bytes | None:
-        """Return the last full-resolution image for a camera."""
-        return self._full_images.get(f"{installation_number}_{zone_id}")
-
-    def get_full_timestamp(self, installation_number: str, zone_id: str) -> str | None:
-        """Return the timestamp of the last full-resolution image."""
-        return self._full_timestamps.get(f"{installation_number}_{zone_id}")
 
     def get_authentication_token(self) -> str | None:
         """Get the authentication token."""
@@ -520,15 +465,6 @@ class VerisureHub:
         new_data = {**existing, CONF_REFRESH_TOKEN: value}
         new_data.pop(CONF_PASSWORD, None)
         self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
-
-    async def logout(self) -> bool:
-        """Logout from Verisure."""
-        try:
-            await self.client.logout()
-        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
-            _LOGGER.error("Could not log out from Verisure", exc_info=True)
-            return False
-        return True
 
     async def get_lock_modes(
         self, installation: Installation, *, priority: int | None = None

--- a/custom_components/verisure_owa/hub.py
+++ b/custom_components/verisure_owa/hub.py
@@ -348,37 +348,29 @@ class VerisureHub:
         """Fetch a full-resolution image, coalescing concurrent calls per signal.
 
         If another caller is already fetching this `id_signal`, waits on that
-        in-flight result instead of issuing a duplicate API request.
+        in-flight task instead of issuing a duplicate API request.
         """
         if priority is None:
             priority = ApiQueue.BACKGROUND
         key = f"{installation.number}_{id_signal}"
         inflight = self._full_image_inflight.get(key)
         if inflight is not None:
-            return await inflight
+            # Shield so a cancellation of *this* awaiter doesn't tear down
+            # the shared task that other awaiters still depend on.
+            return await asyncio.shield(inflight)
 
-        future: asyncio.Future[bytes | None] = (
-            asyncio.get_running_loop().create_future()
-        )
-        self._full_image_inflight[key] = future
-        try:
-            result = await self._api_queue.submit(
+        task = asyncio.create_task(
+            self._api_queue.submit(
                 self.client.get_full_image,
                 installation,
                 id_signal,
                 signal_type,
                 priority=priority,
             )
-        except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
-            if not future.done():
-                future.set_exception(err)
-            raise
-        else:
-            if not future.done():
-                future.set_result(result)
-            return result
-        finally:
-            self._full_image_inflight.pop(key, None)
+        )
+        self._full_image_inflight[key] = task
+        task.add_done_callback(lambda _t: self._full_image_inflight.pop(key, None))
+        return await asyncio.shield(task)
 
     async def _fetch_and_store_full_image(
         self,

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -230,13 +230,6 @@ class VerisureLock(  # type: ignore[override]
 
     # -- Lock/unlock operations ----------------------------------------------
 
-    def _force_state(self, state: str) -> None:
-        """Force entity state and schedule HA update."""
-        self._last_state = self._state
-        self._state = state
-        if self.hass is not None:
-            self.async_schedule_update_ha_state()
-
     async def _change_lock_mode(
         self,
         lock_state: bool,

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -70,7 +70,7 @@ class VerisureLock(  # type: ignore[override]
         initial_status: str = LOCK_STATUS_LOCKED,
         lock_config: SmartLock | None = None,
     ) -> None:
-        CoordinatorEntity.__init__(self, coordinator)
+        CoordinatorEntity.__init__(self, coordinator)  # type: ignore[arg-type]
         VerisureEntity.__init__(self, installation, client)
         self._state = (
             initial_status

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DOMAIN, VerisureHub
 from .coordinators import LockCoordinator
+from .entity import VerisureEntity
 from .verisure_owa_api import (
     Installation,
     VerisureOwaError,
@@ -52,6 +53,7 @@ async def async_setup_entry(
 
 
 class VerisureLock(  # type: ignore[override]
+    VerisureEntity,
     CoordinatorEntity[LockCoordinator],
     lock.LockEntity,
 ):
@@ -68,9 +70,8 @@ class VerisureLock(  # type: ignore[override]
         initial_status: str = LOCK_STATUS_LOCKED,
         lock_config: SmartLock | None = None,
     ) -> None:
-        super().__init__(coordinator)
-        self._installation = installation
-        self._client = client
+        CoordinatorEntity.__init__(self, coordinator)
+        VerisureEntity.__init__(self, installation, client)
         self._state = (
             initial_status
             if initial_status != LOCK_STATUS_UNKNOWN
@@ -113,16 +114,6 @@ class VerisureLock(  # type: ignore[override]
         self._config_retry_unsubs: list[Callable[[], None]] = []
 
     # -- Properties ----------------------------------------------------------
-
-    @property
-    def installation(self) -> Installation:
-        """Return the installation."""
-        return self._installation
-
-    @property
-    def client(self) -> VerisureHub:
-        """Return the client hub."""
-        return self._client
 
     @property
     def lock_config(self) -> SmartLock | None:

--- a/custom_components/verisure_owa/sensor.py
+++ b/custom_components/verisure_owa/sensor.py
@@ -80,17 +80,24 @@ async def async_setup_entry(
         async_add_entities(sensors, False)
 
 
-class SentinelTemperature(  # type: ignore[override]
+AIR_QUALITY_LABELS: dict[str, str] = {
+    "1": "Good",
+    "2": "Fair",
+    "3": "Poor",
+}
+
+
+class SentinelSensorBase(  # type: ignore[override]
     CoordinatorEntity[SentinelCoordinator],
     SensorEntity,
 ):
-    """Sentinel temperature sensor."""
+    """Shared init for sentinel sensors — wires unique_id and device_info.
+
+    Subclasses set _unique_id_suffix and override native_value.
+    """
 
     _attr_has_entity_name = True
-    _attr_name = "Temperature"
-    _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _unique_id_suffix: str = ""
 
     def __init__(
         self,
@@ -102,8 +109,19 @@ class SentinelTemperature(  # type: ignore[override]
         super().__init__(coordinator)
         self._attr_device_info = securitas_device_info(installation)
         self._attr_unique_id = (
-            f"v5_verisure_owa.{installation.number}_temperature_{service_id}"
+            f"v5_verisure_owa.{installation.number}"
+            f"_{self._unique_id_suffix}_{service_id}"
         )
+
+
+class SentinelTemperature(SentinelSensorBase):
+    """Sentinel temperature sensor."""
+
+    _attr_name = "Temperature"
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _unique_id_suffix = "temperature"
 
     @property
     def native_value(self) -> float | None:  # type: ignore[override]
@@ -113,30 +131,14 @@ class SentinelTemperature(  # type: ignore[override]
         return self.coordinator.data.sentinel.temperature
 
 
-class SentinelHumidity(  # type: ignore[override]
-    CoordinatorEntity[SentinelCoordinator],
-    SensorEntity,
-):
+class SentinelHumidity(SentinelSensorBase):
     """Sentinel Humidity sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "Humidity"
     _attr_device_class = SensorDeviceClass.HUMIDITY
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = PERCENTAGE
-
-    def __init__(
-        self,
-        coordinator: SentinelCoordinator,
-        installation: Installation,
-        service_id: int,
-    ) -> None:
-        """Init the component."""
-        super().__init__(coordinator)
-        self._attr_device_info = securitas_device_info(installation)
-        self._attr_unique_id = (
-            f"v5_verisure_owa.{installation.number}_humidity_{service_id}"
-        )
+    _unique_id_suffix = "humidity"
 
     @property
     def native_value(self) -> float | None:  # type: ignore[override]
@@ -146,35 +148,12 @@ class SentinelHumidity(  # type: ignore[override]
         return self.coordinator.data.sentinel.humidity
 
 
-AIR_QUALITY_LABELS: dict[str, str] = {
-    "1": "Good",
-    "2": "Fair",
-    "3": "Poor",
-}
-
-
-class SentinelAirQuality(  # type: ignore[override]
-    CoordinatorEntity[SentinelCoordinator],
-    SensorEntity,
-):
+class SentinelAirQuality(SentinelSensorBase):
     """Air Quality sensor — numeric value from the most recent hourly reading."""
 
-    _attr_has_entity_name = True
     _attr_name = "Air Quality"
     _attr_state_class = SensorStateClass.MEASUREMENT
-
-    def __init__(
-        self,
-        coordinator: SentinelCoordinator,
-        installation: Installation,
-        service_id: int,
-    ) -> None:
-        """Init the component."""
-        super().__init__(coordinator)
-        self._attr_device_info = securitas_device_info(installation)
-        self._attr_unique_id = (
-            f"v5_verisure_owa.{installation.number}_airquality_{service_id}"
-        )
+    _unique_id_suffix = "airquality"
 
     @property
     def native_value(self) -> int | None:  # type: ignore[override]
@@ -184,27 +163,11 @@ class SentinelAirQuality(  # type: ignore[override]
         return self.coordinator.data.air_quality.value
 
 
-class SentinelAirQualityStatus(  # type: ignore[override]
-    CoordinatorEntity[SentinelCoordinator],
-    SensorEntity,
-):
+class SentinelAirQualityStatus(SentinelSensorBase):
     """Air Quality Status sensor — categorical status (Good/Fair/Poor/Bad)."""
 
-    _attr_has_entity_name = True
     _attr_name = "Air Quality Status"
-
-    def __init__(
-        self,
-        coordinator: SentinelCoordinator,
-        installation: Installation,
-        service_id: int,
-    ) -> None:
-        """Init the component."""
-        super().__init__(coordinator)
-        self._attr_device_info = securitas_device_info(installation)
-        self._attr_unique_id = (
-            f"v5_verisure_owa.{installation.number}_airquality_status_{service_id}"
-        )
+    _unique_id_suffix = "airquality_status"
 
     @property
     def native_value(self) -> str | None:  # type: ignore[override]

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -959,7 +959,8 @@ class VerisureOwaClient:
                     f"Arm command failed: {raw.get('msg', 'unknown error')}"
                 )
 
-        self.protom_response = raw["protomResponse"]
+        if raw.get("protomResponse"):
+            self.protom_response = raw["protomResponse"]
         return OperationStatus.model_validate(raw)
 
     async def disarm(
@@ -1082,7 +1083,8 @@ class VerisureOwaClient:
 
         raw = await self._poll_operation(_check)
 
-        self.protom_response = raw["protomResponse"]
+        if raw.get("protomResponse"):
+            self.protom_response = raw["protomResponse"]
         return OperationStatus.model_validate(raw)
 
     async def get_general_status(self, installation: Installation) -> SStatus:
@@ -1387,7 +1389,8 @@ class VerisureOwaClient:
         raw = await self._poll_operation(_check)
 
         # ── Process result ──
-        self.protom_response = raw["protomResponse"]
+        if raw.get("protomResponse"):
+            self.protom_response = raw["protomResponse"]
         return SmartLockModeStatus.model_validate(raw)
 
     # ── Camera operations ──────────────────────────────────────────────────

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -859,6 +859,57 @@ class VerisureOwaClient:
 
         return result
 
+    async def _submit_and_poll(
+        self,
+        *,
+        installation: Installation,
+        submit_op: str,
+        submit_query: str,
+        submit_vars: dict[str, Any],
+        submit_envelope_cls: type,
+        submit_data_field: str,
+        status_op: str,
+        status_query: str,
+        status_data_field: str,
+        status_vars_builder: Callable[[str, int], dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Submit a mutation, extract its referenceId, then poll status until done.
+
+        Common scaffold for arm/disarm/check_alarm/change_lock_mode. Returns
+        the raw status dict from the final poll response — callers handle
+        operation-specific error semantics and result-model validation.
+        """
+        submit_content = {
+            "operationName": submit_op,
+            "variables": submit_vars,
+            "query": submit_query,
+        }
+        envelope = await self._execute_graphql(
+            submit_content,
+            submit_op,
+            submit_envelope_cls,
+            installation=installation,
+        )
+        inner = getattr(envelope.data, submit_data_field)
+        reference_id: str = inner.reference_id
+
+        counter = 0
+
+        async def _check() -> dict[str, Any]:
+            nonlocal counter
+            counter += 1
+            poll_content = {
+                "operationName": status_op,
+                "variables": status_vars_builder(reference_id, counter),
+                "query": status_query,
+            }
+            response = await self._execute_raw(
+                poll_content, status_op, installation=installation
+            )
+            return self._extract_response_data(response, status_data_field)
+
+        return await self._poll_operation(_check)
+
     # ── Alarm operations ──────────────────────────────────────────────────
 
     async def arm(
@@ -887,8 +938,7 @@ class VerisureOwaClient:
             VerisureOwaError: If arming fails with a blocking error.
             OperationTimeoutError: If polling times out.
         """
-        # ── Submit arm request ──
-        variables: dict[str, Any] = {
+        submit_vars: dict[str, Any] = {
             "request": command,
             "numinst": installation.number,
             "panel": installation.panel,
@@ -896,48 +946,35 @@ class VerisureOwaClient:
             "armAndLock": False,
         }
         if force_id is not None:
-            variables["forceArmingRemoteId"] = force_id
+            submit_vars["forceArmingRemoteId"] = force_id
         if suid is not None:
-            variables["suid"] = suid
+            submit_vars["suid"] = suid
 
-        content = {
-            "operationName": "xSArmPanel",
-            "variables": variables,
-            "query": ARM_PANEL_MUTATION,
-        }
-        envelope = await self._execute_graphql(
-            content, "xSArmPanel", ArmPanelEnvelope, installation=installation
-        )
-        reference_id = envelope.data.xSArmPanel.reference_id
-
-        # ── Poll arm status ──
-        counter = 0
-
-        async def _check() -> dict[str, Any]:
-            nonlocal counter
-            counter += 1
+        def status_vars(ref_id: str, counter: int) -> dict[str, Any]:
             poll_vars: dict[str, Any] = {
                 "request": command,
                 "numinst": installation.number,
                 "panel": installation.panel,
-                "referenceId": reference_id,
+                "referenceId": ref_id,
                 "counter": counter,
                 "armAndLock": False,
             }
             if force_id is not None:
                 poll_vars["forceArmingRemoteId"] = force_id
+            return poll_vars
 
-            poll_content = {
-                "operationName": "ArmStatus",
-                "variables": poll_vars,
-                "query": ARM_STATUS_QUERY,
-            }
-            response = await self._execute_raw(
-                poll_content, "ArmStatus", installation=installation
-            )
-            return self._extract_response_data(response, "xSArmStatus")
-
-        raw = await self._poll_operation(_check)
+        raw = await self._submit_and_poll(
+            installation=installation,
+            submit_op="xSArmPanel",
+            submit_query=ARM_PANEL_MUTATION,
+            submit_vars=submit_vars,
+            submit_envelope_cls=ArmPanelEnvelope,
+            submit_data_field="xSArmPanel",
+            status_op="ArmStatus",
+            status_query=ARM_STATUS_QUERY,
+            status_data_field="xSArmStatus",
+            status_vars_builder=status_vars,
+        )
 
         # ── Process result ──
         error = raw.get("error")
@@ -986,46 +1023,33 @@ class VerisureOwaClient:
         # Capture current status at request time for consistent polling
         current_status = self.protom_response
 
-        # ── Submit disarm request ──
-        content = {
-            "operationName": "xSDisarmPanel",
-            "variables": {
+        def status_vars(ref_id: str, counter: int) -> dict[str, Any]:
+            return {
+                "request": command,
+                "numinst": installation.number,
+                "panel": installation.panel,
+                "currentStatus": current_status,
+                "referenceId": ref_id,
+                "counter": counter,
+            }
+
+        raw = await self._submit_and_poll(
+            installation=installation,
+            submit_op="xSDisarmPanel",
+            submit_query=DISARM_PANEL_MUTATION,
+            submit_vars={
                 "request": command,
                 "numinst": installation.number,
                 "panel": installation.panel,
                 "currentStatus": current_status,
             },
-            "query": DISARM_PANEL_MUTATION,
-        }
-        envelope = await self._execute_graphql(
-            content, "xSDisarmPanel", DisarmPanelEnvelope, installation=installation
+            submit_envelope_cls=DisarmPanelEnvelope,
+            submit_data_field="xSDisarmPanel",
+            status_op="DisarmStatus",
+            status_query=DISARM_STATUS_QUERY,
+            status_data_field="xSDisarmStatus",
+            status_vars_builder=status_vars,
         )
-        reference_id = envelope.data.xSDisarmPanel.reference_id
-
-        # ── Poll disarm status ──
-        counter = 0
-
-        async def _check() -> dict[str, Any]:
-            nonlocal counter
-            counter += 1
-            poll_content = {
-                "operationName": "DisarmStatus",
-                "variables": {
-                    "request": command,
-                    "numinst": installation.number,
-                    "panel": installation.panel,
-                    "currentStatus": current_status,
-                    "referenceId": reference_id,
-                    "counter": counter,
-                },
-                "query": DISARM_STATUS_QUERY,
-            }
-            response = await self._execute_raw(
-                poll_content, "DisarmStatus", installation=installation
-            )
-            return self._extract_response_data(response, "xSDisarmStatus")
-
-        raw = await self._poll_operation(_check)
 
         # ── Process result ──
         if raw.get("res") == "ERROR":
@@ -1050,38 +1074,30 @@ class VerisureOwaClient:
         Raises:
             OperationTimeoutError: If polling times out.
         """
-        # ── Submit check alarm request ──
-        content = {
-            "operationName": "CheckAlarm",
-            "variables": {
+
+        def status_vars(ref_id: str, _counter: int) -> dict[str, Any]:
+            return {
+                "numinst": installation.number,
+                "panel": installation.panel,
+                "referenceId": ref_id,
+                "idService": ALARM_STATUS_SERVICE_ID,
+            }
+
+        raw = await self._submit_and_poll(
+            installation=installation,
+            submit_op="CheckAlarm",
+            submit_query=CHECK_ALARM_QUERY,
+            submit_vars={
                 "numinst": installation.number,
                 "panel": installation.panel,
             },
-            "query": CHECK_ALARM_QUERY,
-        }
-        envelope = await self._execute_graphql(
-            content, "CheckAlarm", CheckAlarmEnvelope, installation=installation
+            submit_envelope_cls=CheckAlarmEnvelope,
+            submit_data_field="xSCheckAlarm",
+            status_op="CheckAlarmStatus",
+            status_query=CHECK_ALARM_STATUS_QUERY,
+            status_data_field="xSCheckAlarmStatus",
+            status_vars_builder=status_vars,
         )
-        reference_id = envelope.data.xSCheckAlarm.reference_id
-
-        # ── Poll check alarm status ──
-        async def _check() -> dict[str, Any]:
-            poll_content = {
-                "operationName": "CheckAlarmStatus",
-                "variables": {
-                    "numinst": installation.number,
-                    "panel": installation.panel,
-                    "referenceId": reference_id,
-                    "idService": ALARM_STATUS_SERVICE_ID,
-                },
-                "query": CHECK_ALARM_STATUS_QUERY,
-            }
-            response = await self._execute_raw(
-                poll_content, "CheckAlarmStatus", installation=installation
-            )
-            return self._extract_response_data(response, "xSCheckAlarmStatus")
-
-        raw = await self._poll_operation(_check)
 
         if raw.get("protomResponse"):
             self.protom_response = raw["protomResponse"]
@@ -1101,8 +1117,7 @@ class VerisureOwaClient:
         envelope = await self._execute_graphql(
             content, "Status", GeneralStatusEnvelope, installation=installation
         )
-        raw_data = envelope.data.xSStatus
-        return SStatus.model_validate(raw_data.model_dump(by_alias=True))
+        return envelope.data.xSStatus
 
     async def _get_exceptions(
         self,
@@ -1342,51 +1357,34 @@ class VerisureOwaClient:
         Raises:
             OperationTimeoutError: If polling times out.
         """
-        # ── Submit change lock mode request ──
-        submit_content = {
-            "operationName": "xSChangeSmartlockMode",
-            "variables": {
+
+        def status_vars(ref_id: str, counter: int) -> dict[str, Any]:
+            return {
+                "counter": counter,
+                "deviceId": device_id,
+                "numinst": installation.number,
+                "panel": installation.panel,
+                "referenceId": ref_id,
+            }
+
+        raw = await self._submit_and_poll(
+            installation=installation,
+            submit_op="xSChangeSmartlockMode",
+            submit_query=CHANGE_LOCK_MODE_MUTATION,
+            submit_vars={
                 "numinst": installation.number,
                 "panel": installation.panel,
                 "deviceType": SMARTLOCK_DEVICE_TYPE,
                 "deviceId": device_id,
                 "lock": lock,
             },
-            "query": CHANGE_LOCK_MODE_MUTATION,
-        }
-        envelope = await self._execute_graphql(
-            submit_content,
-            "xSChangeSmartlockMode",
-            ChangeLockModeEnvelope,
-            installation=installation,
+            submit_envelope_cls=ChangeLockModeEnvelope,
+            submit_data_field="xSChangeSmartlockMode",
+            status_op="xSChangeSmartlockModeStatus",
+            status_query=CHANGE_LOCK_MODE_STATUS_QUERY,
+            status_data_field="xSChangeSmartlockModeStatus",
+            status_vars_builder=status_vars,
         )
-        reference_id = envelope.data.xSChangeSmartlockMode.reference_id
-
-        # ── Poll change lock mode status ──
-        counter = 0
-
-        async def _check() -> dict[str, Any]:
-            nonlocal counter
-            counter += 1
-            poll_content = {
-                "operationName": "xSChangeSmartlockModeStatus",
-                "variables": {
-                    "counter": counter,
-                    "deviceId": device_id,
-                    "numinst": installation.number,
-                    "panel": installation.panel,
-                    "referenceId": reference_id,
-                },
-                "query": CHANGE_LOCK_MODE_STATUS_QUERY,
-            }
-            response = await self._execute_raw(
-                poll_content,
-                "xSChangeSmartlockModeStatus",
-                installation=installation,
-            )
-            return self._extract_response_data(response, "xSChangeSmartlockModeStatus")
-
-        raw = await self._poll_operation(_check)
 
         # ── Process result ──
         if raw.get("protomResponse"):

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -1284,48 +1284,31 @@ class VerisureOwaClient:
         Returns:
             SmartLock with lock configuration, or SmartLock() on failure.
         """
-        # Submit danalock config request
-        submit_content = {
-            "operationName": "xSGetDanalockConfig",
-            "variables": {
+
+        def status_vars(ref_id: str, counter: int) -> dict[str, Any]:
+            return {
+                "numinst": installation.number,
+                "referenceId": ref_id,
+                "counter": counter,
+            }
+
+        raw = await self._submit_and_poll(
+            installation=installation,
+            submit_op="xSGetDanalockConfig",
+            submit_query=DANALOCK_CONFIG_QUERY,
+            submit_vars={
                 "numinst": installation.number,
                 "panel": installation.panel,
                 "deviceType": SMARTLOCK_DEVICE_TYPE,
                 "deviceId": device_id,
             },
-            "query": DANALOCK_CONFIG_QUERY,
-        }
-        envelope = await self._execute_graphql(
-            submit_content,
-            "xSGetDanalockConfig",
-            DanalockConfigEnvelope,
-            installation=installation,
+            submit_envelope_cls=DanalockConfigEnvelope,
+            submit_data_field="xSGetDanalockConfig",
+            status_op="xSGetDanalockConfigStatus",
+            status_query=DANALOCK_CONFIG_STATUS_QUERY,
+            status_data_field="xSGetDanalockConfigStatus",
+            status_vars_builder=status_vars,
         )
-        reference_id = envelope.data.xSGetDanalockConfig.reference_id
-
-        # Poll for status
-        counter = 0
-
-        async def _check() -> dict[str, Any]:
-            nonlocal counter
-            counter += 1
-            poll_content = {
-                "operationName": "xSGetDanalockConfigStatus",
-                "variables": {
-                    "numinst": installation.number,
-                    "referenceId": reference_id,
-                    "counter": counter,
-                },
-                "query": DANALOCK_CONFIG_STATUS_QUERY,
-            }
-            response = await self._execute_raw(
-                poll_content,
-                "xSGetDanalockConfigStatus",
-                installation=installation,
-            )
-            return self._extract_response_data(response, "xSGetDanalockConfigStatus")
-
-        raw = await self._poll_operation(_check)
 
         if raw.get("res") != "OK":
             return SmartLock()

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -127,7 +127,7 @@ def generate_uuid() -> str:
     return str(uuid4()).replace("-", "")[0:16]
 
 
-def generate_device_id(_lang: str) -> str:
+def generate_device_id() -> str:
     """Create a device identifier for the API."""
     return secrets.token_urlsafe(16) + ":APA91b" + secrets.token_urlsafe(130)[0:134]
 
@@ -194,8 +194,6 @@ class VerisureOwaClient:
         self.device_brand: str = "samsung"
         self.device_name: str = "SM-S901U"
         self.device_os_version: str = "12"
-        self.device_resolution: str = ""
-        self.device_type: str = ""
         self.device_version: str = "10.102.0"
 
         # Polling configuration
@@ -411,7 +409,6 @@ class VerisureOwaClient:
     def _check_graphql_errors(
         self,
         response_dict: dict[str, Any],
-        operation: str,  # pylint: disable=unused-argument
     ) -> None:
         """Check for GraphQL-level errors in the response and raise if needed."""
         if "errors" not in response_dict:
@@ -541,7 +538,7 @@ class VerisureOwaClient:
 
         # Check for GraphQL errors — raises SessionExpiredError for 403
         try:
-            self._check_graphql_errors(response_dict, operation)
+            self._check_graphql_errors(response_dict)
         except SessionExpiredError:
             if _retried or operation in _AUTH_OPERATIONS:
                 raise
@@ -599,9 +596,9 @@ class VerisureOwaClient:
                 "lang": self.language,
                 "idDevice": self.device_id,
                 "idDeviceIndigitall": self.id_device_indigitall,
-                "deviceType": self.device_type,
+                "deviceType": "",
                 "deviceVersion": self.device_version,
-                "deviceResolution": self.device_resolution,
+                "deviceResolution": "",
                 "deviceName": self.device_name,
                 "deviceBrand": self.device_brand,
                 "deviceOsVersion": self.device_os_version,
@@ -679,9 +676,9 @@ class VerisureOwaClient:
                 "callby": API_CALLBY,
                 "idDevice": self.device_id,
                 "idDeviceIndigitall": self.id_device_indigitall,
-                "deviceType": self.device_type,
+                "deviceType": "",
                 "deviceVersion": self.device_version,
-                "deviceResolution": self.device_resolution,
+                "deviceResolution": "",
                 "deviceName": self.device_name,
                 "deviceBrand": self.device_brand,
                 "deviceOsVersion": self.device_os_version,

--- a/custom_components/verisure_owa/verisure_owa_api/client.py
+++ b/custom_components/verisure_owa/verisure_owa_api/client.py
@@ -1490,57 +1490,47 @@ class VerisureOwaClient:
         )
         reference_id = submit_envelope.data.xSRequestImages.reference_id
 
-        thumbnail: ThumbnailResponse | None = None
+        counter = 0
 
-        async def _poll_capture_result() -> None:
-            nonlocal thumbnail
-            counter = 0
-
-            # Poll status at 10s intervals until it transitions from
-            # "processing" to done (~40-60s for YR/PIR cameras).
-            # Then fetch the thumbnail once.
-            while True:
-                counter += 1
-                status_content = {
-                    "operationName": "RequestImagesStatus",
-                    "variables": {
-                        "numinst": installation.number,
-                        "panel": installation.panel,
-                        "devices": [device_code],
-                        "referenceId": reference_id,
-                        "counter": counter,
-                    },
-                    "query": REQUEST_IMAGES_STATUS_QUERY,
-                }
-                status_envelope = await self._execute_graphql(
-                    status_content,
-                    "RequestImagesStatus",
-                    RequestImagesStatusEnvelope,
-                    installation=installation,
-                )
-                inner = status_envelope.data.xSRequestImagesStatus
-                msg = inner.msg or ""
-                if "processing" not in msg and inner.res != "WAIT":
-                    break
-                await asyncio.sleep(10)
-
-            # Status done — fetch the updated thumbnail
-            thumbnail = await self.get_thumbnail(installation, device_type, zone_id)
+        async def _check() -> dict[str, Any]:
+            nonlocal counter
+            counter += 1
+            status_content = {
+                "operationName": "RequestImagesStatus",
+                "variables": {
+                    "numinst": installation.number,
+                    "panel": installation.panel,
+                    "devices": [device_code],
+                    "referenceId": reference_id,
+                    "counter": counter,
+                },
+                "query": REQUEST_IMAGES_STATUS_QUERY,
+            }
+            status_envelope = await self._execute_graphql(
+                status_content,
+                "RequestImagesStatus",
+                RequestImagesStatusEnvelope,
+                installation=installation,
+            )
+            inner = status_envelope.data.xSRequestImagesStatus
+            msg = inner.msg or ""
+            # _poll_operation continues while res=="WAIT"; remap the
+            # "processing" message into WAIT so the same machinery applies.
+            res = "WAIT" if "processing" in msg else inner.res
+            return {"res": res, "msg": msg}
 
         try:
-            await asyncio.wait_for(_poll_capture_result(), timeout=capture_timeout)
-        except (TimeoutError, asyncio.TimeoutError):
+            await self._poll_operation(_check, timeout=capture_timeout)
+        except OperationTimeoutError:
             _LOGGER.warning(
                 "Image capture timed out after %.0f seconds for %s",
                 capture_timeout,
                 zone_id,
             )
-            if thumbnail is None:
-                # Status polling consumed the entire timeout — fetch one
-                # final thumbnail as the CDN may have caught up.
-                thumbnail = await self.get_thumbnail(installation, device_type, zone_id)
 
-        return thumbnail  # type: ignore[return-value]
+        # Whether status finished or polling timed out, fetch the latest
+        # thumbnail — the CDN may have caught up while we were polling.
+        return await self.get_thumbnail(installation, device_type, zone_id)
 
     async def get_thumbnail(
         self,

--- a/custom_components/verisure_owa/verisure_owa_api/examples/basic_operations.py
+++ b/custom_components/verisure_owa/verisure_owa_api/examples/basic_operations.py
@@ -43,7 +43,7 @@ async def main():
     country = "ES"
     async with aiohttp.ClientSession() as aiohttp_session:
         uuid = generate_uuid()
-        device_id = generate_device_id(country)
+        device_id = generate_device_id()
         id_device_indigitall = str(uuid4())
         api_domains = ApiDomains()
         transport = HttpTransport(

--- a/custom_components/verisure_owa/verisure_owa_api/models.py
+++ b/custom_components/verisure_owa/verisure_owa_api/models.py
@@ -256,6 +256,7 @@ class SStatus(BaseModel):
         default=None, validation_alias="timestampUpdate"
     )
     wifi_connected: bool | None = Field(default=None, validation_alias="wifiConnected")
+    exceptions: list[dict[str, Any]] | None = None
 
 
 class OtpPhone(BaseModel):

--- a/custom_components/verisure_owa/verisure_owa_api/models.py
+++ b/custom_components/verisure_owa/verisure_owa_api/models.py
@@ -233,7 +233,7 @@ class OperationStatus(_NullSafeBase):
     status: str = ""
     installation_number: str = Field(default="", validation_alias="numinst")
     protom_response: str = Field(default="", validation_alias="protomResponse")
-    protom_response_data: str = Field(default="", validation_alias="protomResponseDate")
+    protom_response_date: str = Field(default="", validation_alias="protomResponseDate")
     request_id: str = Field(default="", validation_alias="requestId")
     error: dict[str, Any] | None = None
 

--- a/custom_components/verisure_owa/verisure_owa_api/responses.py
+++ b/custom_components/verisure_owa/verisure_owa_api/responses.py
@@ -13,6 +13,7 @@ from .models import (
     Installation,
     LockFeatures,
     SmartLock,
+    SStatus,
     ThumbnailResponse,
 )
 from .pydantic_utils import NullSafeBase as _NullSafeBase
@@ -68,19 +69,6 @@ class _OperationResult(_NullSafeBase):
     )
     request_id: str | None = Field(default=None, validation_alias="requestId")
     error: PanelError | None = None
-
-
-class _GeneralStatus(BaseModel):
-    """Current status of the alarm system."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    status: str | None = None
-    timestamp_update: str | None = Field(
-        default=None, validation_alias="timestampUpdate"
-    )
-    wifi_connected: bool | None = Field(default=None, validation_alias="wifiConnected")
-    exceptions: list[dict[str, Any]] | None = None
 
 
 # ── Auth envelopes ─────────────────────────────────────────────────────────────
@@ -227,7 +215,7 @@ class GeneralStatusEnvelope(BaseModel):
     """Response envelope for xSStatus."""
 
     class Data(BaseModel):
-        xSStatus: _GeneralStatus  # noqa: N815
+        xSStatus: SStatus  # noqa: N815
 
     data: Data
 

--- a/custom_components/verisure_owa/verisure_owa_api/responses.py
+++ b/custom_components/verisure_owa/verisure_owa_api/responses.py
@@ -63,7 +63,7 @@ class _OperationResult(_NullSafeBase):
     status: str | None = None
     numinst: str | None = None
     protom_response: str | None = Field(default=None, validation_alias="protomResponse")
-    protom_response_data: str | None = Field(
+    protom_response_date: str | None = Field(
         None, validation_alias="protomResponseDate"
     )
     request_id: str | None = Field(default=None, validation_alias="requestId")

--- a/custom_components/verisure_owa/www/verisure-owa-alarm-card.js
+++ b/custom_components/verisure_owa/www/verisure-owa-alarm-card.js
@@ -21,6 +21,8 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js";
+
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 const FEATURE = {
   ARM_HOME: 1,
@@ -142,12 +144,7 @@ const TRANSLATIONS = {
 // pt-BR falls back to pt
 TRANSLATIONS["pt-BR"] = TRANSLATIONS.pt;
 
-function _t(lang, key, vars) {
-  const l = TRANSLATIONS[lang] || TRANSLATIONS[lang?.split("-")[0]] || TRANSLATIONS.en;
-  let s = l[key] || TRANSLATIONS.en[key] || key;
-  if (vars) Object.entries(vars).forEach(([k, v]) => { s = s.replace(`{${k}}`, v); });
-  return s;
-}
+const _t = (lang, key, vars) => formatTranslation(lang, TRANSLATIONS, key, vars);
 
 // ── Per-state visual config ───────────────────────────────────────────────────
 const STATE_CFG = {
@@ -443,15 +440,6 @@ class VerisureOwaAlarmCard extends HTMLElement {
     }
   }
 
-  // ── HTML escaping — prevents XSS via user-controlled strings ───────────────
-  _esc(str) {
-    return String(str)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#39;");
-  }
 
   // ── UI state helpers ────────────────────────────────────────────────────────
   _resetUI() {
@@ -490,7 +478,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
     const lang = this._hass.language || "en";
     const stateObj = this._hass.states[this._config.entity];
     if (!stateObj) {
-      this.shadowRoot.innerHTML = `<ha-card><div class="missing">${_t(lang, "entity_not_found", { entity: this._esc(this._config.entity) })}</div></ha-card>`;
+      this.shadowRoot.innerHTML = `<ha-card><div class="missing">${_t(lang, "entity_not_found", { entity: escHtml(this._config.entity) })}</div></ha-card>`;
       return;
     }
 
@@ -533,7 +521,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
               <ha-icon icon="${cfg.icon}"></ha-icon>
             </div>
             <div class="title-block">
-              <div class="entity-name">${this._esc(name)}</div>
+              <div class="entity-name">${escHtml(name)}</div>
               <div class="state-pill">${cfg.label}</div>
             </div>
             ${refreshEntity ? `<button class="refresh-btn" type="button" data-action="refresh" title="${_t(lang, "refresh")}" aria-label="${_t(lang, "refresh")}"><ha-icon icon="mdi:refresh"></ha-icon></button>` : ""}
@@ -604,7 +592,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
   // ── Force arm section ───────────────────────────────────────────────────────
   _renderForceArm(sensors, lang) {
     const list = sensors.length
-      ? `<ul class="sensor-list">${sensors.map(s => `<li>${this._esc(s)}</li>`).join("")}</ul>`
+      ? `<ul class="sensor-list">${sensors.map(s => `<li>${escHtml(s)}</li>`).join("")}</ul>`
       : "";
     return `
       <div class="force-section">

--- a/custom_components/verisure_owa/www/verisure-owa-camera-card.js
+++ b/custom_components/verisure_owa/www/verisure-owa-camera-card.js
@@ -218,6 +218,10 @@ class VerisureOwaCameraCard extends HTMLElement {
     this._fullEntityId = null;
     this._refreshing = false;
     this._fallbackTimer = null;
+    // Cache for entity lookups indexed by device_id. Invalidated whenever
+    // hass.entities is a new object (HA replaces it atomically on changes).
+    this._entitiesIndex = null;
+    this._entitiesRef = null;
   }
 
   setConfig(config) {
@@ -413,16 +417,34 @@ class VerisureOwaCameraCard extends HTMLElement {
     }
   }
 
+  _entitiesByDeviceId(hass) {
+    if (this._entitiesIndex && this._entitiesRef === hass.entities) {
+      return this._entitiesIndex;
+    }
+    const index = new Map();
+    for (const [eid, entry] of Object.entries(hass.entities || {})) {
+      if (!entry?.device_id) continue;
+      let bucket = index.get(entry.device_id);
+      if (!bucket) {
+        bucket = [];
+        index.set(entry.device_id, bucket);
+      }
+      bucket.push(eid);
+    }
+    this._entitiesIndex = index;
+    this._entitiesRef = hass.entities;
+    return index;
+  }
+
   _findCaptureButton(hass, cameraEntityId) {
     if (!hass?.entities || !cameraEntityId) return null;
     const cameraEntry = hass.entities[cameraEntityId];
     if (!cameraEntry?.device_id) return null;
-    const deviceId = cameraEntry.device_id;
     // Camera and its capture button share the same per-camera sub-device.
     // There is exactly one mdi:camera button per camera device.
-    for (const [eid, entry] of Object.entries(hass.entities)) {
+    const bucket = this._entitiesByDeviceId(hass).get(cameraEntry.device_id) || [];
+    for (const eid of bucket) {
       if (!eid.startsWith("button.")) continue;
-      if (entry.device_id !== deviceId) continue;
       const stateObj = hass.states[eid];
       if (stateObj?.attributes?.icon === "mdi:camera") return eid;
     }
@@ -433,12 +455,11 @@ class VerisureOwaCameraCard extends HTMLElement {
     if (!hass?.entities || !cameraEntityId) return null;
     const cameraEntry = hass.entities[cameraEntityId];
     if (!cameraEntry?.device_id) return null;
-    const deviceId = cameraEntry.device_id;
     // The full-resolution entity shares the same device and has a "_full_image" suffix.
-    for (const [eid, entry] of Object.entries(hass.entities)) {
+    const bucket = this._entitiesByDeviceId(hass).get(cameraEntry.device_id) || [];
+    for (const eid of bucket) {
       if (!eid.startsWith("camera.")) continue;
       if (eid === cameraEntityId) continue;
-      if (entry.device_id !== deviceId) continue;
       if (eid.endsWith("_full_image")) return eid;
     }
     return null;

--- a/custom_components/verisure_owa/www/verisure-owa-camera-card.js
+++ b/custom_components/verisure_owa/www/verisure-owa-camera-card.js
@@ -14,6 +14,8 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js";
+
 // ── Translations ──────────────────────────────────────────────────────────────
 
 const TRANSLATIONS = {
@@ -103,22 +105,7 @@ const TRANSLATIONS = {
   },
 };
 
-function _t(lang, key, vars) {
-  const l = TRANSLATIONS[lang] || TRANSLATIONS[lang?.split("-")[0]] || TRANSLATIONS.en;
-  let s = l[key] || TRANSLATIONS.en[key] || key;
-  if (vars) Object.entries(vars).forEach(([k, v]) => { s = s.replace(`{${k}}`, v); });
-  return s;
-}
-
-// ── Utilities ─────────────────────────────────────────────────────────────────
-
-function _escHtml(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
+const _t = (lang, key, vars) => formatTranslation(lang, TRANSLATIONS, key, vars);
 
 // ── Editor ────────────────────────────────────────────────────────────────────
 
@@ -254,7 +241,7 @@ class VerisureOwaCameraCard extends HTMLElement {
       this.shadowRoot.innerHTML = `
       <ha-card>
         <div style="padding:16px;color:var(--error-color)">
-          ${_escHtml(_t(lang, "entity_not_found", { entity: entityId }))}
+          ${escHtml(_t(lang, "entity_not_found", { entity: entityId }))}
         </div>
       </ha-card>`;
       return;
@@ -345,10 +332,10 @@ class VerisureOwaCameraCard extends HTMLElement {
     </style>
     <ha-card>
       <div class="img-wrapper" id="img-wrapper">
-        <img class="camera-img" src="${_escHtml(imgUrl)}" alt="${_escHtml(name)}" />
+        <img class="camera-img" src="${escHtml(imgUrl)}" alt="${escHtml(name)}" />
         <div class="overlay">
-          <span class="name">${_escHtml(name)}</span>
-          ${timestamp ? `<span class="timestamp" title="${_escHtml(absolute)}">${_escHtml(relative)}</span>` : ""}
+          <span class="name">${escHtml(name)}</span>
+          ${timestamp ? `<span class="timestamp" title="${escHtml(absolute)}">${escHtml(relative)}</span>` : ""}
         </div>
         <button class="refresh-btn${this._refreshing ? " spinning" : ""}" id="refresh-btn" ${hasCapture ? "" : "hidden"}>
           <ha-icon icon="mdi:refresh"></ha-icon>

--- a/custom_components/verisure_owa/www/verisure-owa-card-utils.js
+++ b/custom_components/verisure_owa/www/verisure-owa-card-utils.js
@@ -1,0 +1,36 @@
+// Shared utilities for the Verisure OWA Lovelace cards.
+//
+// Loaded as an ES module (the cards' static path is served with
+// cache_headers=False, so updates here propagate alongside card updates).
+
+export function escHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Lookup a translation table entry by flat or dot-path key, with English fallback
+// and {var} interpolation. Each card passes its own TRANSLATIONS table.
+export function formatTranslation(lang, translations, key, vars) {
+  const enTable = translations.en || {};
+  const langTable =
+    translations[lang] ||
+    translations[lang?.split("-")[0]] ||
+    enTable;
+  const lookup = (table) =>
+    key.split(".").reduce(
+      (acc, k) => (acc != null && acc[k] !== undefined ? acc[k] : null),
+      table,
+    );
+  let v = lookup(langTable);
+  if (v == null) v = lookup(enTable) || key;
+  if (vars) {
+    for (const [name, val] of Object.entries(vars)) {
+      v = v.replace(new RegExp(`\\{${name}\\}`, "g"), val);
+    }
+  }
+  return v;
+}

--- a/custom_components/verisure_owa/www/verisure-owa-events-card.js
+++ b/custom_components/verisure_owa/www/verisure-owa-events-card.js
@@ -18,6 +18,8 @@
  *   title: "Recent activity"            # optional
  */
 
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js";
+
 // ── Translations ─────────────────────────────────────────────────────────────
 
 const TRANSLATIONS = {
@@ -247,20 +249,7 @@ const TRANSLATIONS = {
   },
 };
 
-function _t(lang, key, vars) {
-  const l = TRANSLATIONS[lang] || TRANSLATIONS[lang?.split("-")[0]] || TRANSLATIONS.en;
-  let v = key.split(".").reduce((acc, k) => (acc && acc[k] !== undefined ? acc[k] : null), l);
-  if (v == null) {
-    // Fallback to English for missing keys
-    v = key.split(".").reduce((acc, k) => (acc && acc[k] !== undefined ? acc[k] : null), TRANSLATIONS.en) || key;
-  }
-  if (vars) {
-    for (const [name, val] of Object.entries(vars)) {
-      v = v.replace(new RegExp(`\\{${name}\\}`, "g"), val);
-    }
-  }
-  return v;
-}
+const _t = (lang, key, vars) => formatTranslation(lang, TRANSLATIONS, key, vars);
 
 // ── Per-category icon and color ──────────────────────────────────────────────
 
@@ -297,14 +286,6 @@ const CATEGORY_COLORS = {
 };
 
 // ── Utilities ─────────────────────────────────────────────────────────────────
-
-function _escHtml(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 function _hassLang(hass) {
   return hass?.locale?.language || hass?.language || "en";
@@ -343,8 +324,8 @@ function _relativeTime(timeStr, lang) {
 
 /** Format an event's actor as "by Luci" or "(Cucina)" or "" */
 function _formatActor(event, lang) {
-  if (event.verisure_user) return `${_t(lang, "by")} ${_escHtml(event.verisure_user)}`;
-  if (event.device_name) return `(${_escHtml(event.device_name)})`;
+  if (event.verisure_user) return `${_t(lang, "by")} ${escHtml(event.verisure_user)}`;
+  if (event.device_name) return `(${escHtml(event.device_name)})`;
   return "";
 }
 
@@ -375,9 +356,9 @@ const DETAIL_FIELDS = [
 function _renderExceptions(exceptions, lang) {
   if (!Array.isArray(exceptions) || exceptions.length === 0) return "";
   const items = exceptions.map((exc) => {
-    const aliasText = exc.alias ? _escHtml(exc.alias) : "";
-    const statusText = _escHtml(_t(lang, `exception_status.${exc.status_key || "unknown"}`));
-    const dt = exc.device_type ? ` <span class="device-type">[${_escHtml(exc.device_type)}]</span>` : "";
+    const aliasText = exc.alias ? escHtml(exc.alias) : "";
+    const statusText = escHtml(_t(lang, `exception_status.${exc.status_key || "unknown"}`));
+    const dt = exc.device_type ? ` <span class="device-type">[${escHtml(exc.device_type)}]</span>` : "";
     return `<li>${aliasText} — <em>${statusText}</em>${dt}</li>`;
   });
   return `<ul class="exceptions">${items.join("")}</ul>`;
@@ -392,11 +373,11 @@ function _renderRows(event, lang) {
     if (key === "exceptions") {
       display = _renderExceptions(val, lang);
     } else if (Array.isArray(val) || (typeof val === "object" && val !== null)) {
-      display = `<pre>${_escHtml(JSON.stringify(val, null, 2))}</pre>`;
+      display = `<pre>${escHtml(JSON.stringify(val, null, 2))}</pre>`;
     } else {
-      display = _escHtml(String(val));
+      display = escHtml(String(val));
     }
-    rows.push(`<tr><th>${_escHtml(key)}</th><td>${display}</td></tr>`);
+    rows.push(`<tr><th>${escHtml(key)}</th><td>${display}</td></tr>`);
   }
   return rows.join("");
 }
@@ -556,12 +537,12 @@ class VerisureOwaEventsCard extends HTMLElement {
     const stateObj = this._hass.states[entityId];
     this._lastRenderedState = stateObj;
     if (!stateObj) {
-      this._writeShell(`<div class="missing">${_escHtml(_t(lang, "entity_not_found", { entity: entityId }))}</div>`);
+      this._writeShell(`<div class="missing">${escHtml(_t(lang, "entity_not_found", { entity: entityId }))}</div>`);
       return;
     }
     const events = stateObj.attributes?.events;
     if (!Array.isArray(events)) {
-      this._writeShell(`<div class="missing">${_escHtml(_t(lang, "not_an_activity_log", { entity: entityId }))}</div>`);
+      this._writeShell(`<div class="missing">${escHtml(_t(lang, "not_an_activity_log", { entity: entityId }))}</div>`);
       return;
     }
 
@@ -582,7 +563,7 @@ class VerisureOwaEventsCard extends HTMLElement {
     }
     const body = limited.length
       ? limited.map((ev) => this._renderRow(ev, lang)).join("")
-      : `<div class="empty">${_escHtml(_t(lang, "no_events"))}</div>`;
+      : `<div class="empty">${escHtml(_t(lang, "no_events"))}</div>`;
 
     this._writeShell(body);
     // Wire refresh button
@@ -691,21 +672,21 @@ class VerisureOwaEventsCard extends HTMLElement {
     const isExpanded = this._expanded.has(id);
     const isInjected = event.injected === true;
     const injectedBadge = isInjected
-      ? `<ha-icon class="injected-badge" icon="mdi:home-assistant" title="${_escHtml(_t(lang, "from_home_assistant"))}"></ha-icon>`
+      ? `<ha-icon class="injected-badge" icon="mdi:home-assistant" title="${escHtml(_t(lang, "from_home_assistant"))}"></ha-icon>`
       : "";
-    const detailsId = `details-${_escHtml(id)}`;
+    const detailsId = `details-${escHtml(id)}`;
     return `
-      <div class="event${isExpanded ? " expanded" : ""}${isInjected ? " injected" : ""}" data-id="${_escHtml(id)}" role="button" tabindex="0" aria-expanded="${isExpanded}" aria-controls="${detailsId}">
-        <ha-icon icon="${_escHtml(icon)}" style="color:${color}"></ha-icon>
+      <div class="event${isExpanded ? " expanded" : ""}${isInjected ? " injected" : ""}" data-id="${escHtml(id)}" role="button" tabindex="0" aria-expanded="${isExpanded}" aria-controls="${detailsId}">
+        <ha-icon icon="${escHtml(icon)}" style="color:${color}"></ha-icon>
         <div class="meta">
           <div class="line1">
-            <span class="category" style="color:${color}">${_escHtml(label)}</span>${actor ? ` <span class="actor">${actor}</span>` : ""}${injectedBadge}
+            <span class="category" style="color:${color}">${escHtml(label)}</span>${actor ? ` <span class="actor">${actor}</span>` : ""}${injectedBadge}
           </div>
-          <div class="line2">${_escHtml(event.alias || "")}</div>
+          <div class="line2">${escHtml(event.alias || "")}</div>
         </div>
-        <div class="time" title="${_escHtml(event.time || "")}">${_escHtml(rel)}</div>
+        <div class="time" title="${escHtml(event.time || "")}">${escHtml(rel)}</div>
       </div>
-      <div class="details-row ${isExpanded ? "expanded" : ""}" id="${detailsId}" data-id="${_escHtml(id)}">
+      <div class="details-row ${isExpanded ? "expanded" : ""}" id="${detailsId}" data-id="${escHtml(id)}">
         ${this._renderDetails(event, lang)}
       </div>
     `;
@@ -716,7 +697,7 @@ class VerisureOwaEventsCard extends HTMLElement {
       event.category === "image_request" ? this._renderImageBlock(event) : "";
     const prompt =
       event.category === "unknown"
-        ? `<div class="unknown-prompt">${_escHtml(_t(lang, "unknown_event_prompt"))}</div>`
+        ? `<div class="unknown-prompt">${escHtml(_t(lang, "unknown_event_prompt"))}</div>`
         : "";
     return `${imageBlock}${prompt}<table class="details">${_renderRows(event, lang)}</table>`;
   }
@@ -727,19 +708,19 @@ class VerisureOwaEventsCard extends HTMLElement {
     // Synthetic ids (prefix `ha-`) can't resolve to a server-side image.
     if (id.startsWith("ha-")) return "";
     const cached = this._imageCache.get(id);
-    const alt = _escHtml(event.device_name || "");
+    const alt = escHtml(event.device_name || "");
     if (cached?.state === "loaded" && cached.dataUrl) {
       return `<img class="event-image" src="${cached.dataUrl}" alt="${alt}" />`;
     }
     if (cached?.state === "error") {
-      return `<div class="event-image-error">${_escHtml(_t(lang, "image_unavailable"))}</div>`;
+      return `<div class="event-image-error">${escHtml(_t(lang, "image_unavailable"))}</div>`;
     }
     // Loading or not-yet-fetched (the row's expand handler kicks off the
     // fetch on first click; both states render the same placeholder).
     return `
       <div class="event-image-loading">
         <ha-icon icon="mdi:loading" class="spin"></ha-icon>
-        <span>${_escHtml(_t(lang, "image_loading"))}</span>
+        <span>${escHtml(_t(lang, "image_loading"))}</span>
       </div>`;
   }
 
@@ -752,9 +733,9 @@ class VerisureOwaEventsCard extends HTMLElement {
     const prevScroll = this.shadowRoot.querySelector(".scroll")?.scrollTop || 0;
     const lang = _hassLang(this._hass);
     const titleHtml = this._config.title
-      ? `<div class="card-header">${_escHtml(this._config.title)}</div>`
+      ? `<div class="card-header">${escHtml(this._config.title)}</div>`
       : "";
-    const refreshLabel = _escHtml(_t(lang, "refresh"));
+    const refreshLabel = escHtml(_t(lang, "refresh"));
     const refreshBtn = `
       <button class="refresh-btn${this._refreshing ? " spinning" : ""}" id="refresh-btn"
               type="button" title="${refreshLabel}" aria-label="${refreshLabel}">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,7 +257,6 @@ def make_securitas_hub_mock(**overrides) -> MagicMock:
     hub.config = {}
     hub.services = {1: []}
     hub.sentinel_services = []
-    hub.installations = []
     hub.login = AsyncMock()
     hub.validate_device = AsyncMock()
     hub.send_sms_code = AsyncMock()
@@ -265,7 +264,6 @@ def make_securitas_hub_mock(**overrides) -> MagicMock:
     hub.send_opt = AsyncMock()
     hub._services_cache = {}
     hub.get_services = AsyncMock(return_value=[])
-    hub.logout = AsyncMock(return_value=True)
     hub.get_authentication_token = MagicMock(return_value=FAKE_JWT)
     hub.get_refresh_token = MagicMock(return_value=FAKE_REFRESH_TOKEN)
     for key, val in overrides.items():

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2185,6 +2185,42 @@ class TestUnmappedProtoCodeLogging:
         ]
         assert len(warnings) == 1
 
+    def test_unmapped_code_warns_again_after_returning_to_mapped_state(self, caplog):
+        """Unmapped → mapped → same unmapped: the second occurrence must
+        warn again so the issue resurfaces in the log instead of being
+        silenced for the entity's lifetime."""
+        import logging
+
+        alarm = make_alarm(config=self._config_without_total())
+
+        unmapped = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="T",
+            protom_response_date="",
+        )
+        disarmed = OperationStatus(
+            operation_status="OK",
+            message="",
+            status="",
+            installation_number="123456",
+            protom_response="D",
+            protom_response_date="",
+        )
+        with caplog.at_level(logging.WARNING, logger="custom_components.verisure_owa"):
+            alarm.update_status_alarm(unmapped)
+            alarm.update_status_alarm(disarmed)
+            alarm.update_status_alarm(unmapped)
+
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and "Unmapped" in r.message
+        ]
+        assert len(warnings) == 2
+
 
 class TestForceArmCodeGate:
     """force_arm trusts the force context as proof of recent PIN auth.

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -228,7 +228,7 @@ class TestForceArmNotificationsConfig:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -307,7 +307,7 @@ def make_alarm(
             status="",
             installation_number="123456",
             protom_response="D",
-            protom_response_data="",
+            protom_response_date="",
         )
 
     # Patch Entity state-writing methods that require a running HA instance.
@@ -350,7 +350,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="D",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.DISARMED
@@ -364,7 +364,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="T",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_AWAY
@@ -378,7 +378,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="P",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_HOME
@@ -392,7 +392,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="Q",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_NIGHT
@@ -407,7 +407,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="Z",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_CUSTOM_BYPASS
@@ -423,7 +423,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.DISARMED
@@ -444,7 +444,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="D",
-            protom_response_data="some-data",
+            protom_response_date="some-data",
         )
         alarm.update_status_alarm(status)
         assert alarm._attr_extra_state_attributes["message"] == "Panel ok"
@@ -466,7 +466,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="Z",  # not in PROTO_TO_ALARM_STATE; forward-compat for new codes
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._last_proto_code == "Z"
@@ -482,7 +482,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="ARMED_TOTAL",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._last_proto_code == "T"
@@ -498,7 +498,7 @@ class TestUpdateStatusAlarm:
             status="",
             installation_number="123456",
             protom_response="t",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._last_proto_code == "T"
@@ -521,7 +521,7 @@ class TestUpdateStatusAlarmPeri:
             status="",
             installation_number="123456",
             protom_response="A",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_AWAY
@@ -535,7 +535,7 @@ class TestUpdateStatusAlarmPeri:
             status="",
             installation_number="123456",
             protom_response="E",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_CUSTOM_BYPASS
@@ -555,7 +555,7 @@ class TestUpdateStatusAlarmPeri:
             status="",
             installation_number="123456",
             protom_response="C",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_CUSTOM_BYPASS
@@ -572,7 +572,7 @@ class TestUpdateStatusAlarmPeri:
             status="",
             installation_number="123456",
             protom_response="Q",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._state == AlarmControlPanelState.ARMED_NIGHT
@@ -699,7 +699,7 @@ class TestAsyncAlarmDisarm:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -755,7 +755,7 @@ class TestAsyncAlarmDisarm:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -782,7 +782,7 @@ class TestAsyncAlarmDisarm:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -811,7 +811,7 @@ class TestSetArmState:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
         alarm.client.disarm_alarm = AsyncMock()
@@ -839,7 +839,7 @@ class TestSetArmState:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -879,7 +879,7 @@ class TestSetArmState:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1074,7 +1074,7 @@ class TestForceState:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1105,7 +1105,7 @@ class TestForceState:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1135,7 +1135,7 @@ class TestForceState:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1166,7 +1166,7 @@ class TestForceState:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1264,7 +1264,7 @@ class TestForceState:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1285,7 +1285,7 @@ class TestForceState:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1592,7 +1592,7 @@ class TestArmMethods:
                 status="",
                 installation_number="123456",
                 protom_response="P",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1616,7 +1616,7 @@ class TestArmMethods:
                 status="",
                 installation_number="123456",
                 protom_response="Q",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1639,7 +1639,7 @@ class TestArmMethods:
                 status="",
                 installation_number="123456",
                 protom_response="E",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1674,7 +1674,7 @@ class TestArmMethods:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1701,7 +1701,7 @@ class TestArmMethods:
                 status="",
                 installation_number="123456",
                 protom_response="P",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1777,7 +1777,7 @@ class TestForceArmContext:
                 status="",
                 installation_number="123456",
                 protom_response="P",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1865,7 +1865,7 @@ class TestForceArmContext:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -1981,7 +1981,7 @@ class TestForceArmContext:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -2120,7 +2120,7 @@ class TestUnmappedProtoCodeLogging:
             status="",
             installation_number="123456",
             protom_response="T",
-            protom_response_data="",
+            protom_response_date="",
         )
         with caplog.at_level(logging.WARNING, logger="custom_components.verisure_owa"):
             alarm.update_status_alarm(status)
@@ -2145,7 +2145,7 @@ class TestUnmappedProtoCodeLogging:
             status="",
             installation_number="123456",
             protom_response="Z",
-            protom_response_data="",
+            protom_response_date="",
         )
         with caplog.at_level(logging.WARNING, logger="custom_components.verisure_owa"):
             alarm.update_status_alarm(status)
@@ -2172,7 +2172,7 @@ class TestUnmappedProtoCodeLogging:
             status="",
             installation_number="123456",
             protom_response="T",
-            protom_response_data="",
+            protom_response_date="",
         )
         with caplog.at_level(logging.WARNING, logger="custom_components.verisure_owa"):
             alarm.update_status_alarm(status)
@@ -2229,7 +2229,7 @@ class TestForceArmCodeGate:
                 status="",
                 installation_number="123456",
                 protom_response="T",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -2352,7 +2352,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response=proto,
-                protom_response_data="",
+                protom_response_date="",
             )
 
         alarm.client.arm_alarm = track_arm
@@ -2376,7 +2376,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response="C",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -2405,7 +2405,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response=proto,
-                protom_response_data="",
+                protom_response_date="",
             )
 
         alarm.client.arm_alarm = track_arm
@@ -2437,7 +2437,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response="C",
-                protom_response_data="",
+                protom_response_date="",
             )
 
         alarm.client.arm_alarm = track_arm
@@ -2475,7 +2475,7 @@ class TestCompoundArmCommands:
                     status="",
                     installation_number="123456",
                     protom_response="Q",
-                    protom_response_data="",
+                    protom_response_date="",
                 )
             raise VerisureOwaError("PERI1 failed")
 
@@ -2532,9 +2532,9 @@ class TestCompoundArmCommands:
         assert "ARMNIGHT1PERI1" in alarm._resolver.unsupported
         assert alarm._state == AlarmControlPanelState.DISARMED
 
-    async def test_disarm_preserves_protom_response_data_in_state_attrs(self):
+    async def test_disarm_preserves_protom_response_date_in_state_attrs(self):
         """OperationStatus fields beyond protom_response (notably
-        protom_response_data) must survive the disarm path. _build_operation_status
+        protom_response_date) must survive the disarm path. _build_operation_status
         used to drop everything except operation_status/message/protom_response,
         which broke `update_status_alarm`'s `response_data` extra-state-attribute.
         """
@@ -2549,7 +2549,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response="D",
-                protom_response_data="2026-05-07T12:00:00Z",
+                protom_response_date="2026-05-07T12:00:00Z",
             )
         )
 
@@ -2597,7 +2597,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response="Q",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -2647,7 +2647,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response=proto,
-                protom_response_data="",
+                protom_response_date="",
             )
 
         alarm.client.arm_alarm = arm_side_effect
@@ -2680,7 +2680,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response=proto,
-                protom_response_data="",
+                protom_response_date="",
             )
 
         alarm.client.arm_alarm = track_arm
@@ -2718,7 +2718,7 @@ class TestCompoundArmCommands:
                 status="",
                 installation_number="123456",
                 protom_response=proto,
-                protom_response_data="",
+                protom_response_date="",
             )
 
         alarm.client.arm_alarm = track_arm
@@ -2751,7 +2751,7 @@ class TestDynamicDisarm:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -2780,7 +2780,7 @@ class TestDynamicDisarm:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
 
         alarm.client.disarm_alarm = disarm_side_effect
@@ -2807,7 +2807,7 @@ class TestDynamicDisarm:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -2841,7 +2841,7 @@ class TestDynamicDisarm:
                 status="",
                 numinst="123456",
                 protom_response="D",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -2940,7 +2940,7 @@ class TestDynamicDisarm:
                 status="",
                 installation_number="123456",
                 protom_response="A",
-                protom_response_data="",
+                protom_response_date="",
             )
         )
 
@@ -3309,7 +3309,7 @@ class TestLastProtoCode:
             status="",
             installation_number="123456",
             protom_response="C",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._last_proto_code == "C"
@@ -3324,7 +3324,7 @@ class TestLastProtoCode:
             status="",
             installation_number="123456",
             protom_response="D",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._last_proto_code == "D"
@@ -3339,7 +3339,7 @@ class TestLastProtoCode:
             status="",
             installation_number="123456",
             protom_response="",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._last_proto_code == "T"
@@ -3359,7 +3359,7 @@ class TestLastProtoCode:
             status="ARMED_TOTAL",
             installation_number="123456",
             protom_response="ARMED_TOTAL",
-            protom_response_data="",
+            protom_response_date="",
         )
         alarm.update_status_alarm(status)
         assert alarm._last_proto_code == "A"
@@ -3730,7 +3730,7 @@ class TestForceArmWorkflow:
             status="",
             installation_number="123456",
             protom_response="P",
-            protom_response_data="",
+            protom_response_date="",
         )
         # First call raises ArmingExceptionError, second succeeds
         alarm.client.arm_alarm = AsyncMock(side_effect=[exc, success_result])
@@ -3858,7 +3858,7 @@ class TestForceArmWorkflow:
             status="",
             installation_number="123456",
             protom_response="P",
-            protom_response_data="",
+            protom_response_date="",
         )
 
         # Step 1: initial arm fails
@@ -4218,7 +4218,7 @@ class TestPerimeterSubPanel:
                 status="",
                 numinst="123456",
                 protom_response="P",  # PARTIAL_DAY (interior=DAY preserved, peri off)
-                protom_response_data="",
+                protom_response_date="",
             )
         )
         panel.coordinator.async_request_refresh = AsyncMock()
@@ -4483,7 +4483,7 @@ class TestSubPanelStateExtraction:
             operation_status="OK",
             message="",
             protom_response="B",
-            protom_response_data="",
+            protom_response_date="",
             status="B",
         )
         panel.update_status_alarm(op_status)

--- a/tests/test_camera_platform.py
+++ b/tests/test_camera_platform.py
@@ -60,7 +60,6 @@ def mock_hub():
     hub.camera_images = {}
     hub.get_camera_image = MagicMock(return_value=None)
     hub.is_capturing = MagicMock(return_value=False)
-    hub.fetch_latest_thumbnail = AsyncMock()
     return hub
 
 

--- a/tests/test_camera_platform.py
+++ b/tests/test_camera_platform.py
@@ -75,6 +75,17 @@ def mock_coordinator():
 
 
 @pytest.fixture
+def placeholder_bytes():
+    """Pre-populate the camera module's lazy placeholder cache for assertions."""
+    from custom_components.verisure_owa import camera as cam_module
+
+    bytes_ = b"\xff\xd8\xff\xe0test-placeholder"
+    cam_module._PLACEHOLDER_IMAGE = bytes_
+    yield bytes_
+    cam_module._PLACEHOLDER_IMAGE = None
+
+
+@pytest.fixture
 def jpeg_thumbnail():
     """Return a ThumbnailResponse with valid JPEG base64 data."""
     jpeg_bytes = b"\xff\xd8\xff\xe0fake_jpeg"
@@ -132,40 +143,46 @@ class TestVerisureCamera:
 
     @pytest.mark.asyncio
     async def test_camera_image_returns_placeholder_when_empty(
-        self, mock_coordinator, mock_hub, installation, camera_device
+        self,
+        mock_coordinator,
+        mock_hub,
+        installation,
+        camera_device,
+        placeholder_bytes,
     ):
-        from custom_components.verisure_owa.camera import (
-            VerisureCamera,
-            _PLACEHOLDER_IMAGE,
-        )
+        from custom_components.verisure_owa.camera import VerisureCamera
 
         mock_coordinator.data = CameraData(thumbnails={}, full_images={})
         cam = VerisureCamera(mock_coordinator, mock_hub, installation, camera_device)
         result = await cam.async_camera_image()
-        assert result == _PLACEHOLDER_IMAGE
+        assert result == placeholder_bytes
 
     @pytest.mark.asyncio
     async def test_camera_image_returns_placeholder_when_no_data(
-        self, mock_coordinator, mock_hub, installation, camera_device
+        self,
+        mock_coordinator,
+        mock_hub,
+        installation,
+        camera_device,
+        placeholder_bytes,
     ):
-        from custom_components.verisure_owa.camera import (
-            VerisureCamera,
-            _PLACEHOLDER_IMAGE,
-        )
+        from custom_components.verisure_owa.camera import VerisureCamera
 
         mock_coordinator.data = None
         cam = VerisureCamera(mock_coordinator, mock_hub, installation, camera_device)
         result = await cam.async_camera_image()
-        assert result == _PLACEHOLDER_IMAGE
+        assert result == placeholder_bytes
 
     @pytest.mark.asyncio
     async def test_camera_image_returns_placeholder_for_non_jpeg(
-        self, mock_coordinator, mock_hub, installation, camera_device
+        self,
+        mock_coordinator,
+        mock_hub,
+        installation,
+        camera_device,
+        placeholder_bytes,
     ):
-        from custom_components.verisure_owa.camera import (
-            VerisureCamera,
-            _PLACEHOLDER_IMAGE,
-        )
+        from custom_components.verisure_owa.camera import VerisureCamera
 
         # Non-JPEG data (e.g. a file path encoded as base64)
         non_jpeg = ThumbnailResponse(
@@ -176,7 +193,56 @@ class TestVerisureCamera:
         )
         cam = VerisureCamera(mock_coordinator, mock_hub, installation, camera_device)
         result = await cam.async_camera_image()
-        assert result == _PLACEHOLDER_IMAGE
+        assert result == placeholder_bytes
+
+    @pytest.mark.asyncio
+    async def test_placeholder_loaded_via_executor_on_first_call(
+        self, mock_coordinator, mock_hub, installation, camera_device
+    ):
+        """First placeholder access uses hass.async_add_executor_job and caches the result."""
+        from custom_components.verisure_owa import camera as cam_module
+
+        cam_module._PLACEHOLDER_IMAGE = None
+
+        mock_coordinator.data = None
+        cam = cam_module.VerisureCamera(
+            mock_coordinator, mock_hub, installation, camera_device
+        )
+
+        placeholder_bytes = b"\xff\xd8\xff\xe0fake-placeholder"
+        mock_hass = MagicMock()
+        mock_hass.async_add_executor_job = AsyncMock(return_value=placeholder_bytes)
+        cam.hass = mock_hass
+
+        result = await cam.async_camera_image()
+
+        mock_hass.async_add_executor_job.assert_called_once()
+        assert result == placeholder_bytes
+        assert cam_module._PLACEHOLDER_IMAGE == placeholder_bytes
+
+    @pytest.mark.asyncio
+    async def test_placeholder_cached_after_first_load(
+        self, mock_coordinator, mock_hub, installation, camera_device
+    ):
+        """Subsequent placeholder accesses return the cached bytes without re-reading."""
+        from custom_components.verisure_owa import camera as cam_module
+
+        placeholder_bytes = b"\xff\xd8cached-placeholder"
+        cam_module._PLACEHOLDER_IMAGE = placeholder_bytes
+
+        mock_coordinator.data = None
+        cam = cam_module.VerisureCamera(
+            mock_coordinator, mock_hub, installation, camera_device
+        )
+
+        mock_hass = MagicMock()
+        mock_hass.async_add_executor_job = AsyncMock()
+        cam.hass = mock_hass
+
+        result = await cam.async_camera_image()
+
+        mock_hass.async_add_executor_job.assert_not_called()
+        assert result == placeholder_bytes
 
     def test_device_info_uses_camera_sub_device(
         self, mock_coordinator, mock_hub, installation, camera_device
@@ -398,35 +464,39 @@ class TestVerisureCameraFull:
 
     @pytest.mark.asyncio
     async def test_camera_image_returns_placeholder_when_empty(
-        self, mock_coordinator, mock_hub, installation, camera_device
+        self,
+        mock_coordinator,
+        mock_hub,
+        installation,
+        camera_device,
+        placeholder_bytes,
     ):
-        from custom_components.verisure_owa.camera import (
-            VerisureCameraFull,
-            _PLACEHOLDER_IMAGE,
-        )
+        from custom_components.verisure_owa.camera import VerisureCameraFull
 
         mock_coordinator.data = CameraData(thumbnails={}, full_images={})
         cam = VerisureCameraFull(
             mock_coordinator, mock_hub, installation, camera_device
         )
         result = await cam.async_camera_image()
-        assert result == _PLACEHOLDER_IMAGE
+        assert result == placeholder_bytes
 
     @pytest.mark.asyncio
     async def test_camera_image_returns_placeholder_when_no_data(
-        self, mock_coordinator, mock_hub, installation, camera_device
+        self,
+        mock_coordinator,
+        mock_hub,
+        installation,
+        camera_device,
+        placeholder_bytes,
     ):
-        from custom_components.verisure_owa.camera import (
-            VerisureCameraFull,
-            _PLACEHOLDER_IMAGE,
-        )
+        from custom_components.verisure_owa.camera import VerisureCameraFull
 
         mock_coordinator.data = None
         cam = VerisureCameraFull(
             mock_coordinator, mock_hub, installation, camera_device
         )
         result = await cam.async_camera_image()
-        assert result == _PLACEHOLDER_IMAGE
+        assert result == placeholder_bytes
 
     def test_device_info_matches_thumbnail_entity(
         self, mock_coordinator, mock_hub, installation, camera_device

--- a/tests/test_client_alarm.py
+++ b/tests/test_client_alarm.py
@@ -274,6 +274,20 @@ class TestArm:
         # protom_response should be updated on the client
         assert client.protom_response == "T"
 
+    async def test_arm_without_protom_response_does_not_raise(self, client, transport):
+        """If the API response omits protomResponse, arm() preserves the previous value."""
+        submit = arm_submit_response("ref-arm-005")
+        status = arm_status_response(res="OK", status="ARMED")
+        del status["data"]["xSArmStatus"]["protomResponse"]
+        transport.execute.side_effect = [submit, status]
+
+        inst = _make_installation()
+        client.protom_response = "previous-T"
+        result = await client.arm(inst, "ARM1")
+
+        assert result.operation_status == "OK"
+        assert client.protom_response == "previous-T"
+
     async def test_arm_arming_exception_error(self, client, transport):
         """NON_BLOCKING error with allowForcing raises ArmingExceptionError."""
         transport.execute.side_effect = [
@@ -432,6 +446,22 @@ class TestCheckAlarm:
         assert result.operation_status == "OK"
         assert result.status == "ARMED"
         assert client.protom_response == "T"
+
+    async def test_check_alarm_without_protom_response_does_not_raise(
+        self, client, transport
+    ):
+        """If the API response omits protomResponse, check_alarm() preserves the previous value."""
+        check_submit = check_alarm_submit_response("ref-check-002")
+        status = check_alarm_status_response(res="OK", status="ARMED")
+        del status["data"]["xSCheckAlarmStatus"]["protomResponse"]
+        transport.execute.side_effect = [check_submit, status]
+
+        inst = _make_installation()
+        client.protom_response = "previous-T"
+        result = await client.check_alarm(inst)
+
+        assert result.operation_status == "OK"
+        assert client.protom_response == "previous-T"
 
 
 # ── Get general status tests ────────────────────────────────────────────────

--- a/tests/test_client_camera.py
+++ b/tests/test_client_camera.py
@@ -355,6 +355,39 @@ class TestCaptureImage:
         assert result.id_signal == "new-sig"
         assert result.image == "new-image-data"
 
+    async def test_transient_error_during_status_poll_is_retried(
+        self, client, transport
+    ):
+        """ClientConnectorError on a status poll is retried, not propagated."""
+        from aiohttp import ClientConnectorError
+        from aiohttp.client_reqrep import ConnectionKey
+
+        conn_key = ConnectionKey("example.com", 443, False, True, None, None, None)
+        poll_count = 0
+
+        async def _side_effect(*args, **_kwargs):
+            nonlocal poll_count
+            content = args[0] if args else {}
+            op = content.get("operationName") if isinstance(content, dict) else None
+            if op == "RequestImages":
+                return request_images_response("ref-img-001")
+            if op == "RequestImagesStatus":
+                poll_count += 1
+                if poll_count == 1:
+                    raise ClientConnectorError(conn_key, OSError("transient"))
+                return request_images_status_response(res="OK", msg="completed")
+            if op == "mkGetThumbnail":
+                return thumbnail_response(id_signal="new-sig", image="data")
+            raise AssertionError(f"unexpected op: {op}")
+
+        transport.execute.side_effect = _side_effect
+
+        inst = _make_installation()
+        result = await client.capture_image(inst, 1, "QR", "QR01")
+
+        assert result.id_signal == "new-sig"
+        assert poll_count == 2  # First raised transient, second succeeded
+
     async def test_timeout_fetches_final_thumbnail(self, client, transport):
         """When status polling times out, fetches one final thumbnail."""
         call_count = 0

--- a/tests/test_client_lock.py
+++ b/tests/test_client_lock.py
@@ -474,6 +474,20 @@ class TestChangeLockMode:
         with pytest.raises(OperationTimeoutError):
             await client.change_lock_mode(inst, lock=True)
 
+    async def test_without_protom_response_does_not_raise(self, client, transport):
+        """If the API response omits protomResponse, change_lock_mode() preserves the previous value."""
+        submit = change_lock_submit_response("ref-lock-005")
+        status = change_lock_status_response(res="OK", status="LOCKED")
+        del status["data"]["xSChangeSmartlockModeStatus"]["protomResponse"]
+        transport.execute.side_effect = [submit, status]
+
+        inst = _make_installation()
+        client.protom_response = "previous-L"
+        result = await client.change_lock_mode(inst, lock=True)
+
+        assert result.status == "LOCKED"
+        assert client.protom_response == "previous-L"
+
     async def test_unlock_sends_lock_false(self, client, transport):
         """lock=False is passed correctly in the submit variables."""
         transport.execute.side_effect = [

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -188,6 +188,27 @@ class TestAlarmCoordinator:
         with pytest.raises(UpdateFailed):
             await coord._async_update_data()
 
+    @pytest.mark.asyncio
+    async def test_waf_block_on_retry_keeps_dedicated_message(self):
+        """WAFBlockedError on the post-relogin retry preserves the
+        'WAF blocked' diagnostic instead of the generic update-failed one."""
+        hass = _make_hass()
+        client = _make_client()
+        queue = _make_queue()
+        installation = _make_installation()
+
+        client.get_general_status.side_effect = [
+            SessionExpiredError("expired"),
+            WAFBlockedError("blocked on retry"),
+        ]
+        client.login.return_value = None
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        with pytest.raises(UpdateFailed) as exc_info:
+            await coord._async_update_data()
+
+        assert "WAF blocked" in str(exc_info.value)
+
 
 # ── SentinelCoordinator ──────────────────────────────────────────────────────
 

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -238,6 +238,39 @@ class TestSentinelCoordinator:
         assert result.air_quality is air_quality
 
     @pytest.mark.asyncio
+    async def test_fetches_run_concurrently(self):
+        """Sentinel and air-quality fetches dispatch concurrently, not serially."""
+        hass = _make_hass()
+        client = _make_client()
+        queue = _make_queue()
+        installation = _make_installation()
+
+        sentinel_obj = Sentinel(
+            alias="Living Room", air_quality="good", humidity=50, temperature=22
+        )
+        air_quality_obj = AirQuality(value=42, status_current=1)
+        air_quality_started = asyncio.Event()
+
+        async def slow_sentinel(*_args, **_kwargs):
+            # Sentinel can't return until air-quality has also started — only
+            # possible if both are dispatched concurrently.
+            await air_quality_started.wait()
+            return sentinel_obj
+
+        async def air_quality(*_args, **_kwargs):
+            air_quality_started.set()
+            return air_quality_obj
+
+        client.get_sentinel_data.side_effect = slow_sentinel
+        client.get_air_quality_data.side_effect = air_quality
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        result = await asyncio.wait_for(coord._async_update_data(), timeout=1.0)
+
+        assert result.sentinel is sentinel_obj
+        assert result.air_quality is air_quality_obj
+
+    @pytest.mark.asyncio
     async def test_air_quality_none_is_ok(self):
         """Air quality returning None still gives valid SentinelData."""
         hass = _make_hass()

--- a/tests/test_execute_request.py
+++ b/tests/test_execute_request.py
@@ -37,16 +37,16 @@ class TestGenerateDeviceId:
 
     def test_contains_apa91b_marker(self):
         """Device ID contains the ':APA91b' marker."""
-        result = generate_device_id("ES")
+        result = generate_device_id()
         assert ":APA91b" in result
 
     def test_returns_expected_length(self):
         """Device ID is 163 chars: 22 (token_urlsafe(16)) + 7 (':APA91b') + 134."""
-        result = generate_device_id("ES")
+        result = generate_device_id()
         assert len(result) == 22 + 7 + 134
 
     def test_two_calls_return_different_values(self):
         """Two calls return different device IDs."""
-        a = generate_device_id("ES")
-        b = generate_device_id("ES")
+        a = generate_device_id()
+        b = generate_device_id()
         assert a != b

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -493,34 +493,6 @@ class TestCaptureImage:
 class TestFullImageCapture:
     """Tests for full-resolution image fetching and storage in the hub."""
 
-    async def test_capture_stores_full_image(self):
-        """After a successful capture, the full image is stored in _full_images."""
-        hub = make_hub()
-        installation = make_installation()
-        device = make_camera_device()
-
-        full_jpeg = b"\xff\xd8\xff\xe0full"
-        new_thumb = make_thumbnail(
-            id_signal="sig2",
-            image="base64data",
-            timestamp="2026-03-11 10:01:00",
-            signal_type="16",
-        )
-        hub.client.capture_image = AsyncMock(return_value=new_thumb)
-        hub.client.get_full_image = AsyncMock(return_value=full_jpeg)
-        hub._validate_and_store_image = MagicMock(return_value=b"\xff\xd8")
-
-        _tasks = []
-        hub.hass.async_create_task = lambda coro: _tasks.append(coro)
-
-        with patch("custom_components.verisure_owa.hub.async_dispatcher_send"):
-            await hub.capture_image(installation, device)
-            for task in _tasks:
-                await task
-
-        key = f"{installation.number}_{device.zone_id}"
-        assert hub._full_images[key] == full_jpeg
-
     async def test_capture_updates_coordinator_full_image(self):
         """Camera coordinator is updated with full image after capture."""
         from custom_components.verisure_owa.coordinators import CameraData
@@ -589,72 +561,8 @@ class TestFullImageCapture:
 
         hub.client.get_full_image.assert_not_called()
 
-    async def test_get_full_image_returns_none_when_empty(self):
-        """get_full_image returns None when no full image has been stored."""
-        hub = make_hub()
-        installation = make_installation()
-        device = make_camera_device()
-
-        result = hub.get_full_image(installation.number, device.zone_id)
-        assert result is None
-
-    async def test_get_full_image_returns_stored_bytes(self):
-        """get_full_image returns the correct bytes after storage."""
-        hub = make_hub()
-        installation = make_installation()
-        device = make_camera_device()
-
-        key = f"{installation.number}_{device.zone_id}"
-        hub._full_images[key] = b"\xff\xd8full"
-        assert (
-            hub.get_full_image(installation.number, device.zone_id) == b"\xff\xd8full"
-        )
-
-    async def test_get_full_timestamp_returns_stored_value(self):
-        """get_full_timestamp returns the timestamp stored alongside the full image."""
-        hub = make_hub()
-        installation = make_installation()
-        device = make_camera_device()
-
-        key = f"{installation.number}_{device.zone_id}"
-        hub._full_timestamps[key] = "2026-03-25 17:40:41"
-        assert (
-            hub.get_full_timestamp(installation.number, device.zone_id)
-            == "2026-03-25 17:40:41"
-        )
-
-    async def test_fetch_latest_thumbnail_also_fetches_full_image(self):
-        """fetch_latest_thumbnail stores full image and updates coordinator."""
-        hub = make_hub()
-        installation = make_installation()
-        device = make_camera_device()
-
-        full_jpeg = b"\xff\xd8\xff\xe0full"
-        thumb = make_thumbnail(
-            id_signal="sig1",
-            image="base64data",
-            timestamp="2026-03-11 10:00:00",
-            signal_type="16",
-        )
-        hub.client.get_thumbnail = AsyncMock(return_value=thumb)
-        hub.client.get_full_image = AsyncMock(return_value=full_jpeg)
-        hub._validate_and_store_image = MagicMock(return_value=b"\xff\xd8")
-
-        _tasks = []
-        hub.hass.async_create_task = lambda coro: _tasks.append(coro)
-
-        with patch(
-            "custom_components.verisure_owa.hub.async_dispatcher_send",
-        ):
-            await hub.fetch_latest_thumbnail(installation, device)
-            for task in _tasks:
-                await task
-
-        key = f"{installation.number}_{device.zone_id}"
-        assert hub._full_images[key] == full_jpeg
-
     async def test_full_image_not_stored_when_not_jpeg(self):
-        """When get_full_image returns non-JPEG bytes, the full image is not stored."""
+        """When get_full_image returns non-JPEG bytes, the coordinator is not updated."""
         hub = make_hub()
         installation = make_installation()
         device = make_camera_device()
@@ -669,6 +577,7 @@ class TestFullImageCapture:
         hub.client.capture_image = AsyncMock(return_value=new_thumb)
         hub.client.get_full_image = AsyncMock(return_value=non_jpeg)
         hub._validate_and_store_image = MagicMock(return_value=b"\xff\xd8")
+        hub._update_camera_coordinator_full_image = MagicMock()
 
         _tasks = []
         hub.hass.async_create_task = lambda coro: _tasks.append(coro)
@@ -680,11 +589,10 @@ class TestFullImageCapture:
             for task in _tasks:
                 await task
 
-        key = f"{installation.number}_{device.zone_id}"
-        assert key not in hub._full_images
+        hub._update_camera_coordinator_full_image.assert_not_called()
 
     async def test_full_image_not_stored_when_get_full_image_returns_none(self):
-        """When get_full_image returns None, the full image is not stored."""
+        """When get_full_image returns None, the coordinator is not updated."""
         hub = make_hub()
         installation = make_installation()
         device = make_camera_device()
@@ -698,6 +606,7 @@ class TestFullImageCapture:
         hub.client.capture_image = AsyncMock(return_value=new_thumb)
         hub.client.get_full_image = AsyncMock(return_value=None)
         hub._validate_and_store_image = MagicMock(return_value=b"\xff\xd8")
+        hub._update_camera_coordinator_full_image = MagicMock()
 
         _tasks = []
         hub.hass.async_create_task = lambda coro: _tasks.append(coro)
@@ -709,8 +618,7 @@ class TestFullImageCapture:
             for task in _tasks:
                 await task
 
-        key = f"{installation.number}_{device.zone_id}"
-        assert key not in hub._full_images
+        hub._update_camera_coordinator_full_image.assert_not_called()
 
 
 class TestGetServicesPartitionsCache:

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,5 +1,6 @@
 """Tests for VerisureHub orchestration methods."""
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -492,6 +493,39 @@ class TestCaptureImage:
 
 class TestFullImageCapture:
     """Tests for full-resolution image fetching and storage in the hub."""
+
+    async def test_fetch_full_image_coalesces_concurrent_requests(self):
+        """Two concurrent fetch_full_image calls for the same signal share one API call."""
+        hub = make_hub()
+        installation = make_installation()
+
+        api_call_count = 0
+        api_can_finish = asyncio.Event()
+
+        async def slow_get_full_image(*_args, **_kwargs):
+            nonlocal api_call_count
+            api_call_count += 1
+            await api_can_finish.wait()
+            return b"\xff\xd8full-bytes"
+
+        hub.client.get_full_image = AsyncMock(side_effect=slow_get_full_image)
+
+        task1 = asyncio.create_task(hub.fetch_full_image(installation, "sig-A", "16"))
+        task2 = asyncio.create_task(hub.fetch_full_image(installation, "sig-A", "16"))
+
+        # Yield until both tasks have entered fetch_full_image and the first
+        # has reached the slow API call.
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if api_call_count >= 1:
+                break
+
+        api_can_finish.set()
+        r1, r2 = await asyncio.gather(task1, task2)
+
+        assert r1 == b"\xff\xd8full-bytes"
+        assert r2 == b"\xff\xd8full-bytes"
+        assert api_call_count == 1
 
     async def test_capture_updates_coordinator_full_image(self):
         """Camera coordinator is updated with full image after capture."""

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -527,6 +527,39 @@ class TestFullImageCapture:
         assert r2 == b"\xff\xd8full-bytes"
         assert api_call_count == 1
 
+    async def test_fetch_full_image_cancellation_does_not_strand_other_awaiter(self):
+        """Cancelling one fetch_full_image caller must not break a concurrent caller.
+
+        Regression: an earlier Future-based design left a half-set future behind
+        when the originator was cancelled, deadlocking other awaiters of the
+        same in-flight key.
+        """
+        hub = make_hub()
+        installation = make_installation()
+
+        api_can_finish = asyncio.Event()
+
+        async def slow_get_full_image(*_args, **_kwargs):
+            await api_can_finish.wait()
+            return b"\xff\xd8full-bytes"
+
+        hub.client.get_full_image = AsyncMock(side_effect=slow_get_full_image)
+
+        task1 = asyncio.create_task(hub.fetch_full_image(installation, "sig-X", "16"))
+        # Yield so task1 registers the inflight task before task2 looks it up.
+        await asyncio.sleep(0)
+        task2 = asyncio.create_task(hub.fetch_full_image(installation, "sig-X", "16"))
+        await asyncio.sleep(0)
+
+        # Cancel the originator. task2 must still be able to complete.
+        task1.cancel()
+        api_can_finish.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task1
+        result = await asyncio.wait_for(task2, timeout=1.0)
+        assert result == b"\xff\xd8full-bytes"
+
     async def test_capture_updates_coordinator_full_image(self):
         """Camera coordinator is updated with full image after capture."""
         from custom_components.verisure_owa.coordinators import CameraData

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -358,22 +358,6 @@ class TestVerisureHub:
         hub.client.get_services.assert_awaited_once_with(inst)
         assert result == []
 
-    async def test_logout_returns_false_on_failure(self):
-        """logout() should return False when client.logout() raises."""
-        hub = self._make_hub()
-        hub.client = AsyncMock()
-        hub.client.logout = AsyncMock(side_effect=Exception("logout failed"))
-        result = await hub.logout()
-        assert result is False
-
-    async def test_logout_returns_true_on_success(self):
-        """logout() should return True when client.logout() succeeds."""
-        hub = self._make_hub()
-        hub.client = AsyncMock()
-        hub.client.logout = AsyncMock()
-        result = await hub.logout()
-        assert result is True
-
     def test_get_authentication_token(self):
         """get_authentication_token should read session.authentication_token."""
         hub = self._make_hub()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1143,6 +1143,36 @@ class TestAsyncUnloadEntry:
         # DOMAIN should still be in hass.data because entry2 remains
         assert DOMAIN in hass.data
 
+    async def test_unload_cancels_pending_lock_config_retries(self, hass):
+        """async_unload_entry cancels any pending lock-config retry timers."""
+        hub = make_securitas_hub_mock()
+        entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
+        entry.add_to_hass(hass)
+        username = entry.data[CONF_USERNAME]
+
+        unsub_a = MagicMock()
+        unsub_b = MagicMock()
+
+        hass.data[DOMAIN] = {
+            entry.entry_id: {
+                "hub": hub,
+                "devices": [],
+                "lock_config_retry_unsubs": [unsub_a, unsub_b],
+            },
+            "sessions": {username: {"hub": hub, "ref_count": 1}},
+        }
+
+        with patch.object(
+            hass.config_entries,
+            "async_unload_platforms",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await async_unload_entry(hass, entry)
+
+        unsub_a.assert_called_once_with()
+        unsub_b.assert_called_once_with()
+
     async def test_unload_removes_domain_when_empty(self, hass):
         """When the last entry is unloaded, DOMAIN should be removed from hass.data."""
         hub = make_securitas_hub_mock()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -470,7 +470,7 @@ class TestOperationStatus:
         assert op.status == ""
         assert op.installation_number == ""
         assert op.protom_response == ""
-        assert op.protom_response_data == ""
+        assert op.protom_response_date == ""
         assert op.request_id == ""
         assert op.error is None
 
@@ -490,7 +490,7 @@ class TestOperationStatus:
         assert op.message == "Operation completed"
         assert op.installation_number == "123456"
         assert op.protom_response == "T"
-        assert op.protom_response_data == "2024-01-01"
+        assert op.protom_response_date == "2024-01-01"
         assert op.request_id == "req-001"
 
     def test_error_field_can_be_dict(self):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -251,7 +251,7 @@ class TestArmStatusEnvelope:
         assert result.status == "1"
         assert result.numinst == "123456"
         assert result.protom_response == "T"
-        assert result.protom_response_data == "2024-01-15"
+        assert result.protom_response_date == "2024-01-15"
         assert result.request_id == "req-arm-001"
         assert result.error is None
 


### PR DESCRIPTION
## Summary

Six commits of post-rebrand cleanup across the integration: dead-code removal, performance quick wins, a reliability fix, structural refactors, and partial decomposition of `__init__.py`. All work is behaviour-preserving except the `protomResponse` handling fix and the `fetch_full_image` cancellation fix, which close real bugs. 1376 tests passing; ruff/ruff-format/pylint clean; pyright matches baseline exactly.

> ⚠️ **Stacked on PR #459.** This PR's diff currently shows 30 commits because it sits on top of the unmerged `refactor` branch. Once #459 merges, only the 6 commits below remain. Please review #459 first, then this PR.

## My commits (top of stack)

1. **`bda92db` refactor: dead-code sweep** — 10 items: drop `VerisureHub.fetch_latest_thumbnail`, `VerisureHub.logout`, the unused `installations` list, the redundant `_full_images` cache (coordinator's `full_images` is the source of truth), unused `_lang` / `operation` / `installation` parameters, the no-op `persistent_notification` filter entry, the duplicate-keyed `ApiQueue._intervals` map, and the unused `device_resolution` / `device_type` client attributes (wire-shape preserved by inlining empty strings). −210 / +29 LOC.

2. **`27d32ad` perf: 6 quick wins** — lazy-load placeholder JPEG via `hass.async_add_executor_job` (no more sync file read at import); `asyncio.gather` for sentinel + air-quality coordinator fetches; replace the hard-coded 10 s sleep in `capture_image` with `_poll_operation` (honours configured `poll_delay` / `poll_timeout` and inherits transient-error retry); index `hass.entities` by `device_id` in the camera card so `_findCaptureButton` / `_findFullEntity` hit a Map instead of a full scan; mirror lock-config retry handles in `entry_data` so unload cancels in-flight retries that race with platform teardown; coalesce concurrent full-image fetches per `id_signal` via an in-flight task cache on the hub.

3. **`149beb4` fix: protomResponse handling + rename** — `arm` / `check_alarm` / `change_lock_mode` now use `.get("protomResponse")` consistently with `disarm` (was raising KeyError on responses missing the field). Rename `OperationStatus.protom_response_data` → `protom_response_date` to match the actual API field (`protomResponseDate`, a timestamp). HA-exposed `response_data` extra-state-attribute key preserved unchanged.

4. **`c6795fd` refactor: 7 structural cleanups** — alarm panel + lock now inherit from `VerisureEntity` instead of reimplementing `_installation`/`_client`/`_attr_device_info`; collapse `SStatus` ↔ `_GeneralStatus` round-trip in `get_general_status`; extract `SentinelSensorBase` for the four sentinel sensor classes; merge `VerisureCamera` + `VerisureCameraFull` (subclass overrides one `_mode` attr); extract `_fetch_with_session_recovery` for the SessionExpired→retry→WAFBlocked ladder shared by Alarm/Sentinel/Lock coordinators; extract `_submit_and_poll` for the arm/disarm/check_alarm/change_lock_mode quartet's submit-then-poll scaffold; new `verisure-owa-card-utils.js` ES module exporting `escHtml` + `formatTranslation` for the three Lovelace cards (drops `_esc`/`_escHtml` inconsistency).

5. **`b297a28` refactor: extract discovery.py + card_resources.py** — pure code move from `__init__.py` (1032 → 744 LOC). Re-exports preserved so existing tests that import `_discover_cameras` / `_async_discover_devices` / `_register_card_resource` from the package root keep working. The larger decomposition items (models split, alarm_control_panel split, client split) are deferred to follow-up PRs.

6. **`1a2ab59` refactor: address /simplify review feedback** — three independent reviewers flagged seven findings; all addressed. Notably:
   - **Cancellation bug fix in `hub.fetch_full_image`** — replaced the manual `Future` + `try/except/finally` with `asyncio.create_task` + `asyncio.shield`. The previous Future-based design left an unresolved Future behind on `CancelledError` (not caught by `except Exception`), deadlocking concurrent awaiters of the same `id_signal`. Regression test added.
   - Routed `CameraCoordinator` and `ActivityCoordinator` through `_fetch_with_session_recovery` (previously hand-rolled the same ladder).
   - Routed `_get_danalock_config` through `_submit_and_poll` (was the only remaining hand-rolled instance).
   - Collapsed three correlated `VerisureCamera` class attrs to one (`_mode`).
   - Dropped redundant `lock._force_state` override (LSP violation pyright flagged).

## Test plan

- [x] Unit tests: 1376 passing on Python 3.13 against the dev / stable / minimum HA channels (mirrors CI matrix).
- [x] Ruff check + format: clean.
- [x] Pylint: 10.00/10.
- [x] Pyright: 0 new errors vs the `refactor` branch baseline (94 errors, all pre-existing missing-imports + the two `__init_subclass__` warnings on `config_flow.py`).
- [ ] Smoke test on a real install — capture, arm/disarm, lock/unlock, sentinel + air-quality readings — to verify the perf changes (full-image coalescing, asyncio.gather for sentinel) don't introduce subtle behaviour drift on real responses.