### PR TITLE
feat: per-lock auto-lock on arm + auto-disarm on unlock (closes #449)

### DIFF
--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -649,6 +649,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "lock_coordinator": lock_coord,
             "activity_coordinator": activity_coord,
             "activity_listener_unsub": activity_listener_unsub,
+            "config_entry": entry,
         }
 
         # Schedule non-blocking first refresh for each coordinator

--- a/custom_components/verisure_owa/__init__.py
+++ b/custom_components/verisure_owa/__init__.py
@@ -56,6 +56,7 @@ from .const import (  # noqa: F401 — re-exported for backwards compatibility
     CONF_ENABLE_INTERIOR_PANEL,
     CONF_ENABLE_PERIMETER_PANEL,
     CONF_ENABLE_ANNEX_PANEL,
+    CONF_LOCK_AUTOMATIONS,
     CONF_REFRESH_TOKEN,
     DEFAULT_FORCE_ARM_NOTIFICATIONS,
     COUNTRY_CODES,
@@ -208,6 +209,7 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
             CONF_ENABLE_INTERIOR_PANEL,
             CONF_ENABLE_PERIMETER_PANEL,
             CONF_ENABLE_ANNEX_PANEL,
+            CONF_LOCK_AUTOMATIONS,
         )
     ):
         # update entry replacing data with new options

--- a/custom_components/verisure_owa/alarm_control_panel/__init__.py
+++ b/custom_components/verisure_owa/alarm_control_panel/__init__.py
@@ -25,11 +25,20 @@ from homeassistant.helpers.entity_platform import (
 
 from .. import DOMAIN, VerisureDevice, VerisureHub
 from ..const import (
+    CIRCUIT_ANNEX,
+    CIRCUIT_INTERIOR,
+    CIRCUIT_PERIMETER,
     CONF_ENABLE_ANNEX_PANEL,
     CONF_ENABLE_INTERIOR_PANEL,
     CONF_ENABLE_PERIMETER_PANEL,
 )
 from ..coordinators import AlarmCoordinator
+from ..verisure_owa_api.models import (
+    AlarmState,
+    AnnexMode,
+    InteriorMode,
+    PerimeterMode,
+)
 from ._base import BaseVerisureOwaAlarmPanel
 from ._panels import (
     AnnexVerisureOwaAlarmPanel,
@@ -45,7 +54,29 @@ __all__ = [
     "InteriorVerisureOwaAlarmPanel",
     "PerimeterVerisureOwaAlarmPanel",
     "async_setup_entry",
+    "build_partial_disarm_target",
 ]
+
+
+def build_partial_disarm_target(
+    current: AlarmState, circuits: list[str]
+) -> AlarmState:
+    """Build an AlarmState that disarms ``circuits`` and keeps the rest.
+
+    Unknown circuit names are silently ignored — the caller validates
+    against ``LOCK_CIRCUITS``.
+    """
+    return AlarmState(
+        interior=(
+            InteriorMode.OFF if CIRCUIT_INTERIOR in circuits else current.interior
+        ),
+        perimeter=(
+            PerimeterMode.OFF if CIRCUIT_PERIMETER in circuits else current.perimeter
+        ),
+        annex=(
+            AnnexMode.OFF if CIRCUIT_ANNEX in circuits else current.annex
+        ),
+    )
 
 
 async def async_setup_entry(

--- a/custom_components/verisure_owa/alarm_control_panel/__init__.py
+++ b/custom_components/verisure_owa/alarm_control_panel/__init__.py
@@ -76,6 +76,7 @@ async def async_setup_entry(
             hass=hass,
             coordinator=coordinator,
         )
+        entry_data["combined_alarm_panel"] = combined
         alarms.append(combined)
         all_entities.append(combined)
 

--- a/custom_components/verisure_owa/alarm_control_panel/__init__.py
+++ b/custom_components/verisure_owa/alarm_control_panel/__init__.py
@@ -89,35 +89,38 @@ async def async_setup_entry(
         # detection failure at startup (e.g. get_services 5xx) would otherwise
         # permanently hide opted-in entities until the user reloads, even
         # after the coordinator's later background refresh succeeds.
+        axis_panels = entry_data.setdefault("axis_alarm_panels", {}).setdefault(
+            devices.installation.number, {}
+        )
         if enable_peri:
-            all_entities.append(
-                PerimeterVerisureOwaAlarmPanel(
-                    devices.installation,
-                    client=client,
-                    hass=hass,
-                    coordinator=coordinator,
-                )
+            peri_panel = PerimeterVerisureOwaAlarmPanel(
+                devices.installation,
+                client=client,
+                hass=hass,
+                coordinator=coordinator,
             )
+            all_entities.append(peri_panel)
+            axis_panels[peri_panel._AXIS] = peri_panel  # noqa: SLF001
 
         if enable_annex:
-            all_entities.append(
-                AnnexVerisureOwaAlarmPanel(
-                    devices.installation,
-                    client=client,
-                    hass=hass,
-                    coordinator=coordinator,
-                )
+            annex_panel = AnnexVerisureOwaAlarmPanel(
+                devices.installation,
+                client=client,
+                hass=hass,
+                coordinator=coordinator,
             )
+            all_entities.append(annex_panel)
+            axis_panels[annex_panel._AXIS] = annex_panel  # noqa: SLF001
 
         if enable_interior:
-            all_entities.append(
-                InteriorVerisureOwaAlarmPanel(
-                    devices.installation,
-                    client=client,
-                    hass=hass,
-                    coordinator=coordinator,
-                )
+            interior_panel = InteriorVerisureOwaAlarmPanel(
+                devices.installation,
+                client=client,
+                hass=hass,
+                coordinator=coordinator,
             )
+            all_entities.append(interior_panel)
+            axis_panels[interior_panel._AXIS] = interior_panel  # noqa: SLF001
 
     async_add_entities(all_entities, False)
     hass.data[DOMAIN]["alarm_entities"] = {a.installation.number: a for a in alarms}

--- a/custom_components/verisure_owa/alarm_control_panel/__init__.py
+++ b/custom_components/verisure_owa/alarm_control_panel/__init__.py
@@ -25,21 +25,12 @@ from homeassistant.helpers.entity_platform import (
 
 from .. import DOMAIN, VerisureDevice, VerisureHub
 from ..const import (
-    CIRCUIT_ANNEX,
-    CIRCUIT_INTERIOR,
-    CIRCUIT_PERIMETER,
     CONF_ENABLE_ANNEX_PANEL,
     CONF_ENABLE_INTERIOR_PANEL,
     CONF_ENABLE_PERIMETER_PANEL,
 )
 from ..coordinators import AlarmCoordinator
-from ..verisure_owa_api.models import (
-    AlarmState,
-    AnnexMode,
-    InteriorMode,
-    PerimeterMode,
-)
-from ._base import BaseVerisureOwaAlarmPanel
+from ._base import BaseVerisureOwaAlarmPanel, build_partial_disarm_target
 from ._panels import (
     AnnexVerisureOwaAlarmPanel,
     CombinedVerisureOwaAlarmPanel,
@@ -56,27 +47,6 @@ __all__ = [
     "async_setup_entry",
     "build_partial_disarm_target",
 ]
-
-
-def build_partial_disarm_target(
-    current: AlarmState, circuits: list[str]
-) -> AlarmState:
-    """Build an AlarmState that disarms ``circuits`` and keeps the rest.
-
-    Unknown circuit names are silently ignored — the caller validates
-    against ``LOCK_CIRCUITS``.
-    """
-    return AlarmState(
-        interior=(
-            InteriorMode.OFF if CIRCUIT_INTERIOR in circuits else current.interior
-        ),
-        perimeter=(
-            PerimeterMode.OFF if CIRCUIT_PERIMETER in circuits else current.perimeter
-        ),
-        annex=(
-            AnnexMode.OFF if CIRCUIT_ANNEX in circuits else current.annex
-        ),
-    )
 
 
 async def async_setup_entry(

--- a/custom_components/verisure_owa/alarm_control_panel/__init__.py
+++ b/custom_components/verisure_owa/alarm_control_panel/__init__.py
@@ -76,7 +76,9 @@ async def async_setup_entry(
             hass=hass,
             coordinator=coordinator,
         )
-        entry_data["combined_alarm_panel"] = combined
+        entry_data.setdefault("combined_alarm_panels", {})[
+            devices.installation.number
+        ] = combined
         alarms.append(combined)
         all_entities.append(combined)
 

--- a/custom_components/verisure_owa/alarm_control_panel/__init__.py
+++ b/custom_components/verisure_owa/alarm_control_panel/__init__.py
@@ -100,7 +100,7 @@ async def async_setup_entry(
                 coordinator=coordinator,
             )
             all_entities.append(peri_panel)
-            axis_panels[peri_panel._AXIS] = peri_panel  # noqa: SLF001
+            axis_panels[peri_panel._AXIS] = peri_panel  # noqa: SLF001  # pylint: disable=protected-access
 
         if enable_annex:
             annex_panel = AnnexVerisureOwaAlarmPanel(
@@ -110,7 +110,7 @@ async def async_setup_entry(
                 coordinator=coordinator,
             )
             all_entities.append(annex_panel)
-            axis_panels[annex_panel._AXIS] = annex_panel  # noqa: SLF001
+            axis_panels[annex_panel._AXIS] = annex_panel  # noqa: SLF001  # pylint: disable=protected-access
 
         if enable_interior:
             interior_panel = InteriorVerisureOwaAlarmPanel(
@@ -120,7 +120,7 @@ async def async_setup_entry(
                 coordinator=coordinator,
             )
             all_entities.append(interior_panel)
-            axis_panels[interior_panel._AXIS] = interior_panel  # noqa: SLF001
+            axis_panels[interior_panel._AXIS] = interior_panel  # noqa: SLF001  # pylint: disable=protected-access
 
     async_add_entities(all_entities, False)
     hass.data[DOMAIN]["alarm_entities"] = {a.installation.number: a for a in alarms}

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -33,6 +33,7 @@ from .. import (
     VerisureHub,
     _notify,
 )
+from ..const import CIRCUIT_ANNEX, CIRCUIT_INTERIOR, CIRCUIT_PERIMETER
 from ..coordinators import AlarmCoordinator, AlarmStatusData
 from ..entity import VerisureEntity
 from ..events import (
@@ -55,10 +56,13 @@ from ..verisure_owa_api import (
 )
 from ..verisure_owa_api.__version__ import __url__ as _PROJECT_URL
 from ..verisure_owa_api.command_resolver import (
+    AlarmState,
+    AnnexMode,
     CommandResolver,
     CommandStep,
+    InteriorMode,
+    PerimeterMode,
     PROTO_TO_ALARM_STATE,
-    AlarmState,
 )
 from ..verisure_owa_api.models import ActivityCategory, ActivityException
 
@@ -72,6 +76,27 @@ HA_STATE_TO_CONF_KEY: dict[str, str] = {
 }
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def build_partial_disarm_target(
+    current: AlarmState, circuits: list[str]
+) -> AlarmState:
+    """Build an AlarmState that disarms ``circuits`` and keeps the rest.
+
+    Unknown circuit names are silently ignored — the caller validates
+    against ``LOCK_CIRCUITS``.
+    """
+    return AlarmState(
+        interior=(
+            InteriorMode.OFF if CIRCUIT_INTERIOR in circuits else current.interior
+        ),
+        perimeter=(
+            PerimeterMode.OFF if CIRCUIT_PERIMETER in circuits else current.perimeter
+        ),
+        annex=(
+            AnnexMode.OFF if CIRCUIT_ANNEX in circuits else current.annex
+        ),
+    )
 
 
 class BaseVerisureOwaAlarmPanel(  # type: ignore[override]

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -78,9 +78,7 @@ HA_STATE_TO_CONF_KEY: dict[str, str] = {
 _LOGGER = logging.getLogger(__name__)
 
 
-def build_partial_disarm_target(
-    current: AlarmState, circuits: list[str]
-) -> AlarmState:
+def build_partial_disarm_target(current: AlarmState, circuits: list[str]) -> AlarmState:
     """Build an AlarmState that disarms ``circuits`` and keeps the rest.
 
     Unknown circuit names are silently ignored — the caller validates
@@ -93,9 +91,7 @@ def build_partial_disarm_target(
         perimeter=(
             PerimeterMode.OFF if CIRCUIT_PERIMETER in circuits else current.perimeter
         ),
-        annex=(
-            AnnexMode.OFF if CIRCUIT_ANNEX in circuits else current.annex
-        ),
+        annex=(AnnexMode.OFF if CIRCUIT_ANNEX in circuits else current.annex),
     )
 
 

--- a/custom_components/verisure_owa/alarm_control_panel/_panels.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_panels.py
@@ -91,15 +91,15 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
 
         affected = [self, *self._affected_axis_subpanels(circuits)]
         for entity in affected:
-            entity._operation_in_progress = True  # noqa: SLF001
-            entity._operation_epoch += 1  # noqa: SLF001
-            entity._force_state(AlarmControlPanelState.DISARMING)  # noqa: SLF001
+            entity._operation_in_progress = True  # noqa: SLF001  # pylint: disable=protected-access
+            entity._operation_epoch += 1  # noqa: SLF001  # pylint: disable=protected-access
+            entity._force_state(AlarmControlPanelState.DISARMING)  # noqa: SLF001  # pylint: disable=protected-access
         try:
             result = await self._execute_transition(target)
         except VerisureOwaError as err:
             for entity in affected:
-                entity._state = entity._last_state  # noqa: SLF001
-                entity._operation_in_progress = False  # noqa: SLF001
+                entity._state = entity._last_state  # noqa: SLF001  # pylint: disable=protected-access
+                entity._operation_in_progress = False  # noqa: SLF001  # pylint: disable=protected-access
                 entity.async_write_ha_state()
             _LOGGER.error(
                 "Partial disarm failed for %s circuits %s: %s",
@@ -110,7 +110,7 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
             return False
         for entity in affected:
             entity.update_status_alarm(result)
-            entity._operation_in_progress = False  # noqa: SLF001
+            entity._operation_in_progress = False  # noqa: SLF001  # pylint: disable=protected-access
             entity.async_write_ha_state()
         await self.coordinator.async_request_refresh()
         return True

--- a/custom_components/verisure_owa/alarm_control_panel/_panels.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_panels.py
@@ -16,6 +16,12 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.components.alarm_control_panel.const import AlarmControlPanelState
 
+from ..const import (
+    CIRCUIT_ANNEX,
+    CIRCUIT_INTERIOR,
+    CIRCUIT_PERIMETER,
+    DOMAIN,
+)
 from ..coordinators import AlarmStatusData
 from ..verisure_owa_api import (
     OperationStatus,
@@ -68,6 +74,13 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
 
         Returns True on success, False on VerisureOwaError. Empty
         ``circuits`` is a no-op success.
+
+        Drives the same optimistic-state lifecycle as a user-initiated disarm
+        on each affected entity (this combined panel + any registered axis
+        sub-panel for the listed circuits): DISARMING during the transition,
+        post-result state on success, rollback on failure. Concludes with a
+        coordinator refresh so other observers don't have to wait for the
+        next poll to see the change.
         """
         if not circuits:
             return True
@@ -75,10 +88,19 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
         target = build_partial_disarm_target(current, circuits)
         if target == current:
             return True
+
+        affected = [self, *self._affected_axis_subpanels(circuits)]
+        for entity in affected:
+            entity._operation_in_progress = True  # noqa: SLF001
+            entity._operation_epoch += 1  # noqa: SLF001
+            entity._force_state(AlarmControlPanelState.DISARMING)  # noqa: SLF001
         try:
-            await self._execute_transition(target)
-            return True
+            result = await self._execute_transition(target)
         except VerisureOwaError as err:
+            for entity in affected:
+                entity._state = entity._last_state  # noqa: SLF001
+                entity._operation_in_progress = False  # noqa: SLF001
+                entity.async_write_ha_state()
             _LOGGER.error(
                 "Partial disarm failed for %s circuits %s: %s",
                 self._installation.number,
@@ -86,6 +108,35 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
                 err.log_detail(),
             )
             return False
+        for entity in affected:
+            entity.update_status_alarm(result)
+            entity._operation_in_progress = False  # noqa: SLF001
+            entity.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+        return True
+
+    def _affected_axis_subpanels(
+        self, circuits: list[str]
+    ) -> list[BaseVerisureOwaAlarmPanel]:
+        """Look up registered sub-panel entities matching the given circuits.
+
+        Returns an empty list when there is no entry_data registration (test
+        contexts) or when the circuits don't map to any active sub-panel.
+        """
+        if self.hass is None:
+            return []
+        config_entry = getattr(self._client, "config_entry", None)
+        entry_id = getattr(config_entry, "entry_id", None)
+        if entry_id is None:
+            return []
+        domain_data = self.hass.data.get(DOMAIN, {})
+        entry_data = domain_data.get(entry_id)
+        if not isinstance(entry_data, dict):
+            return []
+        axis_panels = entry_data.get("axis_alarm_panels", {}).get(
+            self._installation.number, {}
+        )
+        return [axis_panels[c] for c in circuits if c in axis_panels]
 
 
 class _AxisSubPanelMixin:
@@ -150,6 +201,7 @@ class InteriorVerisureOwaAlarmPanel(_AxisSubPanelMixin, BaseVerisureOwaAlarmPane
     """
 
     _SUFFIX = "_interior"
+    _AXIS = CIRCUIT_INTERIOR
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -214,6 +266,7 @@ class PerimeterVerisureOwaAlarmPanel(_AxisSubPanelMixin, BaseVerisureOwaAlarmPan
     """
 
     _SUFFIX = "_perimeter"
+    _AXIS = CIRCUIT_PERIMETER
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -259,6 +312,7 @@ class AnnexVerisureOwaAlarmPanel(_AxisSubPanelMixin, BaseVerisureOwaAlarmPanel):
     """
 
     _SUFFIX = "_annex"
+    _AXIS = CIRCUIT_ANNEX
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/custom_components/verisure_owa/alarm_control_panel/_panels.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_panels.py
@@ -8,6 +8,7 @@ preserve the others when computing target states.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.components.alarm_control_panel import (
@@ -30,7 +31,9 @@ from ..verisure_owa_api.command_resolver import (
     PROTO_TO_ALARM_STATE,
     VERISURE_OWA_STATE_TO_ALARM_STATE,
 )
-from ._base import BaseVerisureOwaAlarmPanel
+from ._base import BaseVerisureOwaAlarmPanel, build_partial_disarm_target
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
@@ -59,6 +62,30 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
                 except ValueError:
                     return None
         return None
+
+    async def execute_partial_disarm(self, circuits: list[str]) -> bool:
+        """Disarm the specified circuits, leaving others unchanged.
+
+        Returns True on success, False on VerisureOwaError. Empty
+        ``circuits`` is a no-op success.
+        """
+        if not circuits:
+            return True
+        current = self.coordinator.alarm_state
+        target = build_partial_disarm_target(current, circuits)
+        if target == current:
+            return True
+        try:
+            await self._execute_transition(target)
+            return True
+        except VerisureOwaError as err:
+            _LOGGER.error(
+                "Partial disarm failed for %s circuits %s: %s",
+                self._installation.number,
+                circuits,
+                err.log_detail(),
+            )
+            return False
 
 
 class _AxisSubPanelMixin:

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -953,11 +953,15 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
         return list(domain_entry.get("registered_locks", []))
 
     def _get_enabled_circuits(self) -> set[str]:
-        """Return the set of circuit labels enabled on this installation."""
+        """Return the set of circuit labels enabled on this installation.
+
+        Interior is always available — every installation has interior alarm.
+        The CONF_ENABLE_INTERIOR_PANEL flag controls whether a separate
+        sub-panel entity is exposed, not whether the circuit exists.
+        Perimeter and annex are gated on their explicit toggles.
+        """
         opts = self.config_entry.options
-        enabled: set[str] = set()
-        if opts.get(CONF_ENABLE_INTERIOR_PANEL, True):
-            enabled.add(CIRCUIT_INTERIOR)
+        enabled: set[str] = {CIRCUIT_INTERIOR}
         if opts.get(CONF_ENABLE_PERIMETER_PANEL, False):
             enabled.add(CIRCUIT_PERIMETER)
         if opts.get(CONF_ENABLE_ANNEX_PANEL, False):

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import section
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     CountrySelector,
@@ -898,22 +897,38 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_lock_automations(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
-        """Step 3: Per-lock automation settings (lock-on-arm / disarm-on-unlock)."""
+        """Step 3: Per-lock automation settings (lock-on-arm / disarm-on-unlock).
+
+        Renders one collapsible section per registered lock, each containing
+        per-circuit boolean checkboxes for the two automations. The persisted
+        shape (CONF_LOCK_AUTOMATIONS = {device_id: {lock_on_arm: [...],
+        unlock_disarms: [...]}}) is unchanged — the handler converts between
+        per-circuit booleans (UI) and circuit-name lists (storage).
+        """
         registered_locks = self._get_registered_locks()
         if not registered_locks:
             return self.async_create_entry(title="", data=self._general_data)
 
         enabled_circuits = self._get_enabled_circuits()
+        # Preserve LOCK_CIRCUITS ordering so the UI is consistent.
+        enabled_circuit_list = [c for c in LOCK_CIRCUITS if c in enabled_circuits]
 
         if user_input is not None:
             new_map: dict[str, dict[str, list[str]]] = {}
             for lk in registered_locks:
                 did = lk["device_id"]
+                section_data = user_input.get(f"lock__{did}", {}) or {}
                 new_map[did] = {
-                    "lock_on_arm": list(user_input.get(f"{did}__lock_on_arm", [])),
-                    "unlock_disarms": list(
-                        user_input.get(f"{did}__unlock_disarms", [])
-                    ),
+                    "lock_on_arm": [
+                        c
+                        for c in enabled_circuit_list
+                        if section_data.get(f"lock_on_arm__{c}", False)
+                    ],
+                    "unlock_disarms": [
+                        c
+                        for c in enabled_circuit_list
+                        if section_data.get(f"unlock_disarms__{c}", False)
+                    ],
                 }
             return self.async_create_entry(
                 title="",
@@ -921,28 +936,35 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
             )
 
         existing = self.config_entry.options.get(CONF_LOCK_AUTOMATIONS, {})
-        circuit_options = {c: c.title() for c in LOCK_CIRCUITS if c in enabled_circuits}
 
-        fields: dict[Any, Any] = {}
+        schema_dict: dict[Any, Any] = {}
+        placeholders: dict[str, str] = {}
         for lk in registered_locks:
             did = lk["device_id"]
             saved = existing.get(did, {})
-            fields[
-                vol.Optional(
-                    f"{did}__lock_on_arm",
-                    default=saved.get("lock_on_arm", []),
-                )
-            ] = cv.multi_select(circuit_options)
-            fields[
-                vol.Optional(
-                    f"{did}__unlock_disarms",
-                    default=saved.get("unlock_disarms", []),
-                )
-            ] = cv.multi_select(circuit_options)
+            saved_arm = set(saved.get("lock_on_arm", []))
+            saved_unlock = set(saved.get("unlock_disarms", []))
+
+            section_fields: dict[Any, Any] = {}
+            for c in enabled_circuit_list:
+                section_fields[
+                    vol.Optional(f"lock_on_arm__{c}", default=c in saved_arm)
+                ] = bool
+            for c in enabled_circuit_list:
+                section_fields[
+                    vol.Optional(f"unlock_disarms__{c}", default=c in saved_unlock)
+                ] = bool
+
+            schema_dict[vol.Required(f"lock__{did}")] = section(
+                vol.Schema(section_fields),
+                {"collapsed": False},
+            )
+            placeholders[f"lock_alias_{did}"] = lk.get("alias") or did
 
         return self.async_show_form(
             step_id="lock_automations",
-            data_schema=vol.Schema(fields),
+            data_schema=vol.Schema(schema_dict),
+            description_placeholders=placeholders,
         )
 
     def _get_registered_locks(self) -> list[dict[str, str]]:

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import section
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     CountrySelector,
@@ -53,10 +54,15 @@ from . import (
     generate_uuid,
 )
 from .const import (
+    CIRCUIT_ANNEX,
+    CIRCUIT_INTERIOR,
+    CIRCUIT_PERIMETER,
     CONF_ENABLE_ANNEX_PANEL,
     CONF_ENABLE_INTERIOR_PANEL,
     CONF_ENABLE_PERIMETER_PANEL,
+    CONF_LOCK_AUTOMATIONS,
     CONF_REFRESH_TOKEN,
+    LOCK_CIRCUITS,
 )
 from .api_queue import ApiQueue
 from .verisure_owa_api import (
@@ -846,8 +852,8 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> config_entries.ConfigFlowResult:
         """Step 2: Alarm state mappings."""
         if user_input is not None:
-            data = {**self._general_data, **user_input}
-            return self.async_create_entry(title="", data=data)
+            self._general_data = {**self._general_data, **user_input}
+            return await self.async_step_lock_automations()
 
         # Resolve via the helper so we read coordinator → published cache →
         # False, matching the init step. Avoids the race where the user
@@ -888,3 +894,72 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
             }
         )
         return self.async_show_form(step_id="mappings", data_schema=schema)
+
+    async def async_step_lock_automations(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Step 3: Per-lock automation settings (lock-on-arm / disarm-on-unlock)."""
+        registered_locks = self._get_registered_locks()
+        if not registered_locks:
+            return self.async_create_entry(title="", data=self._general_data)
+
+        enabled_circuits = self._get_enabled_circuits()
+
+        if user_input is not None:
+            new_map: dict[str, dict[str, list[str]]] = {}
+            for lk in registered_locks:
+                did = lk["device_id"]
+                new_map[did] = {
+                    "lock_on_arm": list(user_input.get(f"{did}__lock_on_arm", [])),
+                    "unlock_disarms": list(
+                        user_input.get(f"{did}__unlock_disarms", [])
+                    ),
+                }
+            return self.async_create_entry(
+                title="",
+                data={**self._general_data, CONF_LOCK_AUTOMATIONS: new_map},
+            )
+
+        existing = self.config_entry.options.get(CONF_LOCK_AUTOMATIONS, {})
+        circuit_options = {c: c.title() for c in LOCK_CIRCUITS if c in enabled_circuits}
+
+        fields: dict[Any, Any] = {}
+        for lk in registered_locks:
+            did = lk["device_id"]
+            saved = existing.get(did, {})
+            fields[
+                vol.Optional(
+                    f"{did}__lock_on_arm",
+                    default=saved.get("lock_on_arm", []),
+                )
+            ] = cv.multi_select(circuit_options)
+            fields[
+                vol.Optional(
+                    f"{did}__unlock_disarms",
+                    default=saved.get("unlock_disarms", []),
+                )
+            ] = cv.multi_select(circuit_options)
+
+        return self.async_show_form(
+            step_id="lock_automations",
+            data_schema=vol.Schema(fields),
+        )
+
+    def _get_registered_locks(self) -> list[dict[str, str]]:
+        """Return [{device_id, alias}] for each lock registered for this entry."""
+        domain_entry = self.hass.data.get(DOMAIN, {}).get(
+            self.config_entry.entry_id, {}
+        )
+        return list(domain_entry.get("registered_locks", []))
+
+    def _get_enabled_circuits(self) -> set[str]:
+        """Return the set of circuit labels enabled on this installation."""
+        opts = self.config_entry.options
+        enabled: set[str] = set()
+        if opts.get(CONF_ENABLE_INTERIOR_PANEL, True):
+            enabled.add(CIRCUIT_INTERIOR)
+        if opts.get(CONF_ENABLE_PERIMETER_PANEL, False):
+            enabled.add(CIRCUIT_PERIMETER)
+        if opts.get(CONF_ENABLE_ANNEX_PANEL, False):
+            enabled.add(CIRCUIT_ANNEX)
+        return enabled

--- a/custom_components/verisure_owa/const.py
+++ b/custom_components/verisure_owa/const.py
@@ -65,3 +65,11 @@ PLATFORMS = [
 ]
 
 SENTINEL_SERVICE_NAMES: frozenset[str] = frozenset({"CONFORT", "COMFORTO", "COMFORT"})
+
+# Lock automations (issue #449) — per-lock auto-lock-on-arm and
+# auto-disarm-on-unlock configuration.
+CONF_LOCK_AUTOMATIONS = "lock_automations"
+CIRCUIT_INTERIOR = "interior"
+CIRCUIT_PERIMETER = "perimeter"
+CIRCUIT_ANNEX = "annex"
+LOCK_CIRCUITS: tuple[str, ...] = (CIRCUIT_INTERIOR, CIRCUIT_PERIMETER, CIRCUIT_ANNEX)

--- a/custom_components/verisure_owa/coordinators.py
+++ b/custom_components/verisure_owa/coordinators.py
@@ -323,7 +323,15 @@ class SentinelCoordinator(DataUpdateCoordinator[SentinelData]):
         self._zone = zone
 
     async def _fetch_data(self) -> SentinelData:
-        """Fetch sentinel and air quality data concurrently."""
+        """Fetch sentinel and air quality data via the API queue.
+
+        Both submits are dispatched together via ``asyncio.gather`` so the
+        second is queued the moment the first frees the queue, but the
+        ``ApiQueue`` itself serialises the actual API calls (single shared
+        lock). End result: back-to-back rather than truly concurrent —
+        this still saves the round-trip latency between sequential awaits
+        in the coordinator.
+        """
         sentinel, air_quality = await asyncio.gather(
             self._queue.submit(
                 self._client.get_sentinel_data,

--- a/custom_components/verisure_owa/discovery.py
+++ b/custom_components/verisure_owa/discovery.py
@@ -234,6 +234,13 @@ async def _discover_locks(
             if entry is not None:
                 new_lock._entry_id = entry.entry_id
             locks.append(new_lock)
+            # Register the lock so the options flow can discover it.
+            entry_data.setdefault("registered_locks", []).append(
+                {
+                    "device_id": device_id,
+                    "alias": new_lock._attr_name or device_id,
+                }
+            )
         lock_add(locks, False)
 
         # Schedule deferred config retry for locks without config.

--- a/custom_components/verisure_owa/discovery.py
+++ b/custom_components/verisure_owa/discovery.py
@@ -172,6 +172,7 @@ async def _discover_locks(
     hub: VerisureHub,
     installation: Installation,
     entry_data: dict[str, Any],
+    entry: ConfigEntry | None = None,
 ) -> None:
     """Discover lock devices for an installation and add entities."""
     from .lock import (
@@ -222,16 +223,17 @@ async def _discover_locks(
                     installation.number,
                     device_id,
                 )
-            locks.append(
-                VerisureLock(
-                    coordinator=lock_coordinator,
-                    installation=installation,
-                    client=hub,
-                    device_id=device_id,
-                    initial_status=mode.lock_status,
-                    lock_config=lock_config,
-                )
+            new_lock = VerisureLock(
+                coordinator=lock_coordinator,
+                installation=installation,
+                client=hub,
+                device_id=device_id,
+                initial_status=mode.lock_status,
+                lock_config=lock_config,
             )
+            if entry is not None:
+                new_lock._entry_id = entry.entry_id
+            locks.append(new_lock)
         lock_add(locks, False)
 
         # Schedule deferred config retry for locks without config.
@@ -252,4 +254,4 @@ async def _async_discover_devices(hass: HomeAssistant, entry: ConfigEntry) -> No
     for device in devices:
         installation = device.installation
         await _discover_cameras(hass, client, installation, entry_data, entry)
-        await _discover_locks(hass, client, installation, entry_data)
+        await _discover_locks(hass, client, installation, entry_data, entry)

--- a/custom_components/verisure_owa/discovery.py
+++ b/custom_components/verisure_owa/discovery.py
@@ -232,13 +232,13 @@ async def _discover_locks(
                 lock_config=lock_config,
             )
             if entry is not None:
-                new_lock._entry_id = entry.entry_id
+                new_lock._entry_id = entry.entry_id  # noqa: SLF001  # pylint: disable=protected-access
             locks.append(new_lock)
             # Register the lock so the options flow can discover it.
             entry_data.setdefault("registered_locks", []).append(
                 {
                     "device_id": device_id,
-                    "alias": new_lock._attr_name or device_id,
+                    "alias": new_lock._attr_name or device_id,  # noqa: SLF001  # pylint: disable=protected-access
                 }
             )
         lock_add(locks, False)

--- a/custom_components/verisure_owa/hub.py
+++ b/custom_components/verisure_owa/hub.py
@@ -359,14 +359,15 @@ class VerisureHub:
             # the shared task that other awaiters still depend on.
             return await asyncio.shield(inflight)
 
-        task = asyncio.create_task(
+        task = self.hass.async_create_task(
             self._api_queue.submit(
                 self.client.get_full_image,
                 installation,
                 id_signal,
                 signal_type,
                 priority=priority,
-            )
+            ),
+            name=f"verisure_owa_full_image_{key}",
         )
         self._full_image_inflight[key] = task
         task.add_done_callback(lambda _t: self._full_image_inflight.pop(key, None))

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -19,7 +19,6 @@ from .const import (
     CIRCUIT_INTERIOR,
     CIRCUIT_PERIMETER,
     CIRCUIT_ANNEX,
-    LOCK_CIRCUITS,
 )
 from .coordinators import LockCoordinator
 from .entity import VerisureEntity
@@ -53,6 +52,7 @@ def _armed_circuits(state: AlarmState) -> set[str]:
     if state.annex != AnnexMode.OFF:
         armed.add(CIRCUIT_ANNEX)
     return armed
+
 
 # Service request name that identifies a smart-lock capability
 DOORLOCK_SERVICE = "DOORLOCK"
@@ -246,13 +246,9 @@ class VerisureLock(  # type: ignore[override]
             self.hass.async_create_task(self._auto_lock())
 
     def _autolock_notification_id(self) -> str:
-        return (
-            f"verisure_owa_autolock_{self._installation.number}_{self._device_id}"
-        )
+        return f"verisure_owa_autolock_{self._installation.number}_{self._device_id}"
 
-    async def _fire_autolock_notification(
-        self, *, title: str, message: str
-    ) -> None:
+    async def _fire_autolock_notification(self, *, title: str, message: str) -> None:
         """Create / replace a persistent notification for an autolock event."""
         if self.hass is None:
             return
@@ -308,9 +304,7 @@ class VerisureLock(  # type: ignore[override]
         # Establish baseline + subscribe.
         if self._alarm_coordinator is not None:
             # Read the current state to seed the baseline (no firing).
-            self._alarm_baseline = _armed_circuits(
-                self._alarm_coordinator.alarm_state
-            )
+            self._alarm_baseline = _armed_circuits(self._alarm_coordinator.alarm_state)
             self._alarm_listener_unsub = self._alarm_coordinator.async_add_listener(
                 self._handle_alarm_coordinator_update
             )
@@ -452,9 +446,7 @@ class VerisureLock(  # type: ignore[override]
         if self._combined_alarm_panel is None or self._alarm_coordinator is None:
             return None
         currently_armed = _armed_circuits(self._alarm_coordinator.alarm_state)
-        targets = [
-            c for c in self._unlock_disarms_circuits if c in currently_armed
-        ]
+        targets = [c for c in self._unlock_disarms_circuits if c in currently_armed]
         if not targets:
             return None
         ok = await self._combined_alarm_panel.execute_partial_disarm(targets)

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -461,14 +462,24 @@ class VerisureLock(  # type: ignore[override]
         return ok
 
     async def _perform_user_unlock(self, operation: str) -> None:
-        """Disarm-first unlock used by both async_unlock and async_open."""
+        """Concurrent disarm + unlock used by both async_unlock and async_open.
+
+        Both branches each handle their own errors internally (disarm fires an
+        "Auto-disarm failed" notification on failure; unlock rolls back the
+        entity state) so neither raises from gather. Running them in parallel
+        halves the user-perceived latency without changing the semantics:
+        the post-call check still fires "Unlock failed" only when the disarm
+        succeeded but the lock state stayed LOCKED.
+        """
         pre_state = self._state
-        disarm_result = await self._dispatch_unlock_disarm()
-        await self._change_lock_mode(
-            lock_state=False,
-            transitional_state=LOCK_STATUS_UNLOCKING,
-            optimistic_state=LOCK_STATUS_UNLOCKED,
-            operation=operation,
+        disarm_result, _ = await asyncio.gather(
+            self._dispatch_unlock_disarm(),
+            self._change_lock_mode(
+                lock_state=False,
+                transitional_state=LOCK_STATUS_UNLOCKING,
+                optimistic_state=LOCK_STATUS_UNLOCKED,
+                operation=operation,
+            ),
         )
         if (
             disarm_result is True

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -140,6 +140,7 @@ class VerisureLock(  # type: ignore[override]
 
         # Auto-lock state — populated when added to hass.
         self._alarm_coordinator = None  # set by async_added_to_hass
+        self._combined_alarm_panel = None  # set by async_added_to_hass
         self._alarm_listener_unsub: Callable[[], None] | None = None
         self._alarm_baseline: set[str] | None = None  # armed circuits at last update
         self._lock_on_arm_circuits: list[str] = []
@@ -406,6 +407,7 @@ class VerisureLock(  # type: ignore[override]
         )
 
     async def async_unlock(self, **kwargs: Any) -> None:
+        await self._dispatch_unlock_disarm()
         await self._change_lock_mode(
             lock_state=False,
             transitional_state=LOCK_STATUS_UNLOCKING,
@@ -414,12 +416,34 @@ class VerisureLock(  # type: ignore[override]
         )
 
     async def async_open(self, **kwargs: Any) -> None:
+        await self._dispatch_unlock_disarm()
         await self._change_lock_mode(
             lock_state=False,
             transitional_state=LOCK_STATUS_UNLOCKING,
             optimistic_state=LOCK_STATUS_UNLOCKED,
             operation="Open",
         )
+
+    async def _dispatch_unlock_disarm(self) -> None:
+        """Disarm configured circuits before unlocking.
+
+        Skipped when no circuits are configured, when the panel is not
+        registered yet, or when no configured circuit is currently
+        armed. Failure handling lives in Task 9.
+        """
+        if not self._unlock_disarms_circuits:
+            return
+        if self._combined_alarm_panel is None:
+            return
+        if self._alarm_coordinator is None:
+            return
+        currently_armed = _armed_circuits(self._alarm_coordinator.alarm_state)
+        targets = [
+            c for c in self._unlock_disarms_circuits if c in currently_armed
+        ]
+        if not targets:
+            return
+        await self._combined_alarm_panel.execute_partial_disarm(targets)
 
     @property
     def supported_features(self) -> lock.LockEntityFeature:  # type: ignore[override]

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -243,14 +243,48 @@ class VerisureLock(  # type: ignore[override]
         if self.hass is not None:
             self.hass.async_create_task(self._auto_lock())
 
+    def _autolock_notification_id(self) -> str:
+        return (
+            f"verisure_owa_autolock_{self._installation.number}_{self._device_id}"
+        )
+
+    async def _fire_autolock_notification(
+        self, *, title: str, message: str
+    ) -> None:
+        """Create / replace a persistent notification for an autolock event."""
+        if self.hass is None:
+            return
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "notification_id": self._autolock_notification_id(),
+                "title": title,
+                "message": message,
+            },
+            blocking=False,
+        )
+
     async def _auto_lock(self) -> None:
-        """Perform an auto-lock-on-arm action (failure handling: Task 7)."""
+        """Perform an auto-lock-on-arm action.
+
+        On failure (VerisureOwaError or post-call state still unlocked),
+        creates a persistent notification.
+        """
         await self._change_lock_mode(
             lock_state=True,
             transitional_state=LOCK_STATUS_LOCKING,
             optimistic_state=LOCK_STATUS_LOCKED,
             operation="Auto-lock",
         )
+        if self._state != LOCK_STATUS_LOCKED:
+            await self._fire_autolock_notification(
+                title="Auto-lock failed",
+                message=(
+                    f"Could not lock {self._attr_name} when arming. "
+                    f"The alarm is armed but the door is unlocked."
+                ),
+            )
 
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -226,7 +226,31 @@ class VerisureLock(  # type: ignore[override]
         if prev is None:
             # First update — establish baseline only.
             return
-        # Transition detection deferred to Task 6.
+        if not self._lock_on_arm_circuits:
+            return
+        # Circuits that just transitioned disarmed→armed.
+        newly_armed = new_armed - prev
+        triggers = newly_armed.intersection(self._lock_on_arm_circuits)
+        if not triggers:
+            return
+        # Idempotency: skip if already locked / locking / mid-operation.
+        if self._operation_in_progress:
+            return
+        if self._state in (LOCK_STATUS_LOCKED, LOCK_STATUS_LOCKING):
+            return
+        # Schedule the lock as a background task — listeners must not
+        # block the coordinator-update path.
+        if self.hass is not None:
+            self.hass.async_create_task(self._auto_lock())
+
+    async def _auto_lock(self) -> None:
+        """Perform an auto-lock-on-arm action (failure handling: Task 7)."""
+        await self._change_lock_mode(
+            lock_state=True,
+            transitional_state=LOCK_STATUS_LOCKING,
+            optimistic_state=LOCK_STATUS_LOCKED,
+            operation="Auto-lock",
+        )
 
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -139,6 +139,7 @@ class VerisureLock(  # type: ignore[override]
         self._config_retry_unsubs: list[Callable[[], None]] = []
 
         # Auto-lock state — populated when added to hass.
+        self._entry_id: str | None = None  # set externally before async_added_to_hass
         self._alarm_coordinator = None  # set by async_added_to_hass
         self._combined_alarm_panel = None  # set by async_added_to_hass
         self._alarm_listener_unsub: Callable[[], None] | None = None
@@ -287,9 +288,39 @@ class VerisureLock(  # type: ignore[override]
                 ),
             )
 
+    async def async_added_to_hass(self) -> None:
+        """Wire up auto-lock listener and load per-lock options."""
+        await super().async_added_to_hass()
+        if self.hass is None or self._entry_id is None:
+            return
+        entry_data = self.hass.data[DOMAIN].get(self._entry_id)
+        if not entry_data:
+            return
+        self._alarm_coordinator = entry_data.get("alarm_coordinator")
+        panels_by_inst = entry_data.get("combined_alarm_panels", {})
+        self._combined_alarm_panel = panels_by_inst.get(self._installation.number)
+        config_entry = entry_data.get("config_entry")
+        if config_entry is not None:
+            options = config_entry.options.get(CONF_LOCK_AUTOMATIONS, {})
+            per_lock = options.get(self._device_id, {})
+            self._lock_on_arm_circuits = list(per_lock.get("lock_on_arm", []))
+            self._unlock_disarms_circuits = list(per_lock.get("unlock_disarms", []))
+        # Establish baseline + subscribe.
+        if self._alarm_coordinator is not None:
+            # Read the current state to seed the baseline (no firing).
+            self._alarm_baseline = _armed_circuits(
+                self._alarm_coordinator.alarm_state
+            )
+            self._alarm_listener_unsub = self._alarm_coordinator.async_add_listener(
+                self._handle_alarm_coordinator_update
+            )
+
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""
         await super().async_will_remove_from_hass()
+        if self._alarm_listener_unsub is not None:
+            self._alarm_listener_unsub()
+            self._alarm_listener_unsub = None
         for unsub in self._config_retry_unsubs:
             unsub()
         self._config_retry_unsubs.clear()

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -406,44 +406,66 @@ class VerisureLock(  # type: ignore[override]
             operation="Lock",
         )
 
-    async def async_unlock(self, **kwargs: Any) -> None:
-        await self._dispatch_unlock_disarm()
-        await self._change_lock_mode(
-            lock_state=False,
-            transitional_state=LOCK_STATUS_UNLOCKING,
-            optimistic_state=LOCK_STATUS_UNLOCKED,
-            operation="Unlock",
-        )
-
-    async def async_open(self, **kwargs: Any) -> None:
-        await self._dispatch_unlock_disarm()
-        await self._change_lock_mode(
-            lock_state=False,
-            transitional_state=LOCK_STATUS_UNLOCKING,
-            optimistic_state=LOCK_STATUS_UNLOCKED,
-            operation="Open",
-        )
-
-    async def _dispatch_unlock_disarm(self) -> None:
+    async def _dispatch_unlock_disarm(self) -> bool | None:
         """Disarm configured circuits before unlocking.
 
-        Skipped when no circuits are configured, when the panel is not
-        registered yet, or when no configured circuit is currently
-        armed. Failure handling lives in Task 9.
+        Returns:
+            None  — disarm was skipped (nothing to do).
+            True  — disarm was attempted and succeeded.
+            False — disarm was attempted and failed (notification already fired).
+
+        The unlock always proceeds regardless of the return value.
         """
         if not self._unlock_disarms_circuits:
-            return
-        if self._combined_alarm_panel is None:
-            return
-        if self._alarm_coordinator is None:
-            return
+            return None
+        if self._combined_alarm_panel is None or self._alarm_coordinator is None:
+            return None
         currently_armed = _armed_circuits(self._alarm_coordinator.alarm_state)
         targets = [
             c for c in self._unlock_disarms_circuits if c in currently_armed
         ]
         if not targets:
-            return
-        await self._combined_alarm_panel.execute_partial_disarm(targets)
+            return None
+        ok = await self._combined_alarm_panel.execute_partial_disarm(targets)
+        if not ok:
+            await self._fire_autolock_notification(
+                title="Auto-disarm failed",
+                message=(
+                    f"Could not disarm before unlocking {self._attr_name}. "
+                    f"The door will be unlocked but the alarm may still be armed."
+                ),
+            )
+        return ok
+
+    async def _perform_user_unlock(self, operation: str) -> None:
+        """Disarm-first unlock used by both async_unlock and async_open."""
+        pre_state = self._state
+        disarm_result = await self._dispatch_unlock_disarm()
+        await self._change_lock_mode(
+            lock_state=False,
+            transitional_state=LOCK_STATUS_UNLOCKING,
+            optimistic_state=LOCK_STATUS_UNLOCKED,
+            operation=operation,
+        )
+        if (
+            disarm_result is True
+            and self._state == pre_state
+            and self._state == LOCK_STATUS_LOCKED
+        ):
+            # Disarm succeeded but the unlock itself failed — state reverted.
+            await self._fire_autolock_notification(
+                title="Unlock failed",
+                message=(
+                    f"{self._attr_name}: alarm has been disarmed but the door "
+                    f"is still locked."
+                ),
+            )
+
+    async def async_unlock(self, **kwargs: Any) -> None:
+        await self._perform_user_unlock("Unlock")
+
+    async def async_open(self, **kwargs: Any) -> None:
+        await self._perform_user_unlock("Open")
 
     @property
     def supported_features(self) -> lock.LockEntityFeature:  # type: ignore[override]

--- a/custom_components/verisure_owa/lock.py
+++ b/custom_components/verisure_owa/lock.py
@@ -14,6 +14,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DOMAIN, VerisureHub
+from .const import (
+    CONF_LOCK_AUTOMATIONS,
+    CIRCUIT_INTERIOR,
+    CIRCUIT_PERIMETER,
+    CIRCUIT_ANNEX,
+    LOCK_CIRCUITS,
+)
 from .coordinators import LockCoordinator
 from .entity import VerisureEntity
 from .verisure_owa_api import (
@@ -23,11 +30,29 @@ from .verisure_owa_api import (
 )
 from .api_queue import ApiQueue
 from .verisure_owa_api.client import SMARTLOCK_DEVICE_ID
+from .verisure_owa_api.models import (
+    AlarmState,
+    InteriorMode,
+    PerimeterMode,
+    AnnexMode,
+)
 
 if TYPE_CHECKING:
     from .verisure_owa_api import SmartLockMode
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _armed_circuits(state: AlarmState) -> set[str]:
+    """Return the set of circuit labels currently armed (mode != OFF)."""
+    armed: set[str] = set()
+    if state.interior != InteriorMode.OFF:
+        armed.add(CIRCUIT_INTERIOR)
+    if state.perimeter != PerimeterMode.OFF:
+        armed.add(CIRCUIT_PERIMETER)
+    if state.annex != AnnexMode.OFF:
+        armed.add(CIRCUIT_ANNEX)
+    return armed
 
 # Service request name that identifies a smart-lock capability
 DOORLOCK_SERVICE = "DOORLOCK"
@@ -113,6 +138,13 @@ class VerisureLock(  # type: ignore[override]
         self._operation_in_progress: bool = False
         self._config_retry_unsubs: list[Callable[[], None]] = []
 
+        # Auto-lock state — populated when added to hass.
+        self._alarm_coordinator = None  # set by async_added_to_hass
+        self._alarm_listener_unsub: Callable[[], None] | None = None
+        self._alarm_baseline: set[str] | None = None  # armed circuits at last update
+        self._lock_on_arm_circuits: list[str] = []
+        self._unlock_disarms_circuits: list[str] = []
+
     # -- Properties ----------------------------------------------------------
 
     @property
@@ -177,6 +209,24 @@ class VerisureLock(  # type: ignore[override]
             self._state = mode.lock_status
 
         self.async_write_ha_state()
+
+    @callback
+    def _handle_alarm_coordinator_update(self) -> None:
+        """React to alarm-coordinator updates.
+
+        Establishes a baseline on first call (no firing). On subsequent
+        calls, detects disarmed→armed transitions for circuits in
+        ``self._lock_on_arm_circuits`` and fires the lock if needed.
+        """
+        if self._alarm_coordinator is None:
+            return
+        new_armed = _armed_circuits(self._alarm_coordinator.alarm_state)
+        prev = self._alarm_baseline
+        self._alarm_baseline = new_armed
+        if prev is None:
+            # First update — establish baseline only.
+            return
+        # Transition detection deferred to Task 6.
 
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""

--- a/custom_components/verisure_owa/strings.json
+++ b/custom_components/verisure_owa/strings.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Vacation",
                     "map_custom": "Custom"
                 }
+            },
+            "lock_automations": {
+                "title": "Lock automation",
+                "description": "Configure each lock's automatic locking and panel-disarming behaviour.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    }
+                }
             }
         }
     },

--- a/custom_components/verisure_owa/translations/ca.json
+++ b/custom_components/verisure_owa/translations/ca.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Vacances",
                     "map_custom": "Personalitzat"
                 }
+            },
+            "lock_automations": {
+                "title": "Automatització del pany",
+                "description": "Configureu el comportament automàtic de tancament i desarmament per a cada pany.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Tanca automàticament en armar l'alarma Interior",
+                            "lock_on_arm__perimeter": "Tanca automàticament en armar l'alarma Perímetre",
+                            "lock_on_arm__annex": "Tanca automàticament en armar l'alarma Annex",
+                            "unlock_disarms__interior": "Desarma l'alarma Interior abans de tornar a obrir",
+                            "unlock_disarms__perimeter": "Desarma l'alarma Perímetre abans de tornar a obrir",
+                            "unlock_disarms__annex": "Desarma l'alarma Annex abans de tornar a obrir"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Tanca automàticament en armar l'alarma Interior",
+                            "lock_on_arm__perimeter": "Tanca automàticament en armar l'alarma Perímetre",
+                            "lock_on_arm__annex": "Tanca automàticament en armar l'alarma Annex",
+                            "unlock_disarms__interior": "Desarma l'alarma Interior abans de tornar a obrir",
+                            "unlock_disarms__perimeter": "Desarma l'alarma Perímetre abans de tornar a obrir",
+                            "unlock_disarms__annex": "Desarma l'alarma Annex abans de tornar a obrir"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Tanca automàticament en armar l'alarma Interior",
+                            "lock_on_arm__perimeter": "Tanca automàticament en armar l'alarma Perímetre",
+                            "lock_on_arm__annex": "Tanca automàticament en armar l'alarma Annex",
+                            "unlock_disarms__interior": "Desarma l'alarma Interior abans de tornar a obrir",
+                            "unlock_disarms__perimeter": "Desarma l'alarma Perímetre abans de tornar a obrir",
+                            "unlock_disarms__annex": "Desarma l'alarma Annex abans de tornar a obrir"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Tanca automàticament en armar l'alarma Interior",
+                            "lock_on_arm__perimeter": "Tanca automàticament en armar l'alarma Perímetre",
+                            "lock_on_arm__annex": "Tanca automàticament en armar l'alarma Annex",
+                            "unlock_disarms__interior": "Desarma l'alarma Interior abans de tornar a obrir",
+                            "unlock_disarms__perimeter": "Desarma l'alarma Perímetre abans de tornar a obrir",
+                            "unlock_disarms__annex": "Desarma l'alarma Annex abans de tornar a obrir"
+                        }
+                    }
+                }
             }
         }
     },

--- a/custom_components/verisure_owa/translations/en.json
+++ b/custom_components/verisure_owa/translations/en.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Vacation",
                     "map_custom": "Custom"
                 }
+            },
+            "lock_automations": {
+                "title": "Lock automation",
+                "description": "Configure each lock's automatic locking and panel-disarming behaviour.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Lock automatically when arming Interior alarm",
+                            "lock_on_arm__perimeter": "Lock automatically when arming Perimeter alarm",
+                            "lock_on_arm__annex": "Lock automatically when arming Annex alarm",
+                            "unlock_disarms__interior": "Disarm Interior alarm before unlocking",
+                            "unlock_disarms__perimeter": "Disarm Perimeter alarm before unlocking",
+                            "unlock_disarms__annex": "Disarm Annex alarm before unlocking"
+                        }
+                    }
+                }
             }
         }
     },

--- a/custom_components/verisure_owa/translations/es.json
+++ b/custom_components/verisure_owa/translations/es.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Vacaciones",
                     "map_custom": "Personalizado"
                 }
+            },
+            "lock_automations": {
+                "title": "Automatización de cerraduras",
+                "description": "Configure el comportamiento automático de bloqueo y desarmado para cada cerradura.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automáticamente al armar la alarma Interior",
+                            "lock_on_arm__perimeter": "Bloquear automáticamente al armar la alarma Perimetral",
+                            "lock_on_arm__annex": "Bloquear automáticamente al armar la alarma Anexo",
+                            "unlock_disarms__interior": "Desarmar la alarma Interior antes de abrir",
+                            "unlock_disarms__perimeter": "Desarmar la alarma Perimetral antes de abrir",
+                            "unlock_disarms__annex": "Desarmar la alarma Anexo antes de abrir"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automáticamente al armar la alarma Interior",
+                            "lock_on_arm__perimeter": "Bloquear automáticamente al armar la alarma Perimetral",
+                            "lock_on_arm__annex": "Bloquear automáticamente al armar la alarma Anexo",
+                            "unlock_disarms__interior": "Desarmar la alarma Interior antes de abrir",
+                            "unlock_disarms__perimeter": "Desarmar la alarma Perimetral antes de abrir",
+                            "unlock_disarms__annex": "Desarmar la alarma Anexo antes de abrir"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automáticamente al armar la alarma Interior",
+                            "lock_on_arm__perimeter": "Bloquear automáticamente al armar la alarma Perimetral",
+                            "lock_on_arm__annex": "Bloquear automáticamente al armar la alarma Anexo",
+                            "unlock_disarms__interior": "Desarmar la alarma Interior antes de abrir",
+                            "unlock_disarms__perimeter": "Desarmar la alarma Perimetral antes de abrir",
+                            "unlock_disarms__annex": "Desarmar la alarma Anexo antes de abrir"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automáticamente al armar la alarma Interior",
+                            "lock_on_arm__perimeter": "Bloquear automáticamente al armar la alarma Perimetral",
+                            "lock_on_arm__annex": "Bloquear automáticamente al armar la alarma Anexo",
+                            "unlock_disarms__interior": "Desarmar la alarma Interior antes de abrir",
+                            "unlock_disarms__perimeter": "Desarmar la alarma Perimetral antes de abrir",
+                            "unlock_disarms__annex": "Desarmar la alarma Anexo antes de abrir"
+                        }
+                    }
+                }
             }
         }
     },

--- a/custom_components/verisure_owa/translations/fr.json
+++ b/custom_components/verisure_owa/translations/fr.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Vacances",
                     "map_custom": "Personnalisé"
                 }
+            },
+            "lock_automations": {
+                "title": "Automatisation des serrures",
+                "description": "Configurez le comportement automatique de verrouillage et de désarmement pour chaque serrure.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Verrouiller automatiquement lors de l'armement de l'alarme Intérieur",
+                            "lock_on_arm__perimeter": "Verrouiller automatiquement lors de l'armement de l'alarme Périmètre",
+                            "lock_on_arm__annex": "Verrouiller automatiquement lors de l'armement de l'alarme Annexe",
+                            "unlock_disarms__interior": "Désarmer l'alarme Intérieur avant le déverrouillage",
+                            "unlock_disarms__perimeter": "Désarmer l'alarme Périmètre avant le déverrouillage",
+                            "unlock_disarms__annex": "Désarmer l'alarme Annexe avant le déverrouillage"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Verrouiller automatiquement lors de l'armement de l'alarme Intérieur",
+                            "lock_on_arm__perimeter": "Verrouiller automatiquement lors de l'armement de l'alarme Périmètre",
+                            "lock_on_arm__annex": "Verrouiller automatiquement lors de l'armement de l'alarme Annexe",
+                            "unlock_disarms__interior": "Désarmer l'alarme Intérieur avant le déverrouillage",
+                            "unlock_disarms__perimeter": "Désarmer l'alarme Périmètre avant le déverrouillage",
+                            "unlock_disarms__annex": "Désarmer l'alarme Annexe avant le déverrouillage"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Verrouiller automatiquement lors de l'armement de l'alarme Intérieur",
+                            "lock_on_arm__perimeter": "Verrouiller automatiquement lors de l'armement de l'alarme Périmètre",
+                            "lock_on_arm__annex": "Verrouiller automatiquement lors de l'armement de l'alarme Annexe",
+                            "unlock_disarms__interior": "Désarmer l'alarme Intérieur avant le déverrouillage",
+                            "unlock_disarms__perimeter": "Désarmer l'alarme Périmètre avant le déverrouillage",
+                            "unlock_disarms__annex": "Désarmer l'alarme Annexe avant le déverrouillage"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Verrouiller automatiquement lors de l'armement de l'alarme Intérieur",
+                            "lock_on_arm__perimeter": "Verrouiller automatiquement lors de l'armement de l'alarme Périmètre",
+                            "lock_on_arm__annex": "Verrouiller automatiquement lors de l'armement de l'alarme Annexe",
+                            "unlock_disarms__interior": "Désarmer l'alarme Intérieur avant le déverrouillage",
+                            "unlock_disarms__perimeter": "Désarmer l'alarme Périmètre avant le déverrouillage",
+                            "unlock_disarms__annex": "Désarmer l'alarme Annexe avant le déverrouillage"
+                        }
+                    }
+                }
             }
         }
     },

--- a/custom_components/verisure_owa/translations/it.json
+++ b/custom_components/verisure_owa/translations/it.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Vacanza",
                     "map_custom": "Personalizzato"
                 }
+            },
+            "lock_automations": {
+                "title": "Automazione delle serrature",
+                "description": "Configura il comportamento automatico di blocco e disattivazione per ciascuna serratura.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Blocca automaticamente all'attivazione dell'allarme Interno",
+                            "lock_on_arm__perimeter": "Blocca automaticamente all'attivazione dell'allarme Perimetrale",
+                            "lock_on_arm__annex": "Blocca automaticamente all'attivazione dell'allarme Annesso",
+                            "unlock_disarms__interior": "Disattiva l'allarme Interno prima di sbloccare",
+                            "unlock_disarms__perimeter": "Disattiva l'allarme Perimetrale prima di sbloccare",
+                            "unlock_disarms__annex": "Disattiva l'allarme Annesso prima di sbloccare"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Blocca automaticamente all'attivazione dell'allarme Interno",
+                            "lock_on_arm__perimeter": "Blocca automaticamente all'attivazione dell'allarme Perimetrale",
+                            "lock_on_arm__annex": "Blocca automaticamente all'attivazione dell'allarme Annesso",
+                            "unlock_disarms__interior": "Disattiva l'allarme Interno prima di sbloccare",
+                            "unlock_disarms__perimeter": "Disattiva l'allarme Perimetrale prima di sbloccare",
+                            "unlock_disarms__annex": "Disattiva l'allarme Annesso prima di sbloccare"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Blocca automaticamente all'attivazione dell'allarme Interno",
+                            "lock_on_arm__perimeter": "Blocca automaticamente all'attivazione dell'allarme Perimetrale",
+                            "lock_on_arm__annex": "Blocca automaticamente all'attivazione dell'allarme Annesso",
+                            "unlock_disarms__interior": "Disattiva l'allarme Interno prima di sbloccare",
+                            "unlock_disarms__perimeter": "Disattiva l'allarme Perimetrale prima di sbloccare",
+                            "unlock_disarms__annex": "Disattiva l'allarme Annesso prima di sbloccare"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Blocca automaticamente all'attivazione dell'allarme Interno",
+                            "lock_on_arm__perimeter": "Blocca automaticamente all'attivazione dell'allarme Perimetrale",
+                            "lock_on_arm__annex": "Blocca automaticamente all'attivazione dell'allarme Annesso",
+                            "unlock_disarms__interior": "Disattiva l'allarme Interno prima di sbloccare",
+                            "unlock_disarms__perimeter": "Disattiva l'allarme Perimetrale prima di sbloccare",
+                            "unlock_disarms__annex": "Disattiva l'allarme Annesso prima di sbloccare"
+                        }
+                    }
+                }
             }
         }
     },

--- a/custom_components/verisure_owa/translations/pt-BR.json
+++ b/custom_components/verisure_owa/translations/pt-BR.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Férias",
                     "map_custom": "Personalizado"
                 }
+            },
+            "lock_automations": {
+                "title": "Automação de fechaduras",
+                "description": "Configure o comportamento automático de bloqueio e desarmar para cada fechadura.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    }
+                }
             }
         }
     },

--- a/custom_components/verisure_owa/translations/pt.json
+++ b/custom_components/verisure_owa/translations/pt.json
@@ -117,6 +117,56 @@
                     "map_vacation": "Férias",
                     "map_custom": "Personalizado"
                 }
+            },
+            "lock_automations": {
+                "title": "Automatização de fechaduras",
+                "description": "Configure o comportamento automático de bloqueio e desarmar para cada fechadura.",
+                "sections": {
+                    "lock__01": {
+                        "name": "{lock_alias_01}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    },
+                    "lock__02": {
+                        "name": "{lock_alias_02}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    },
+                    "lock__03": {
+                        "name": "{lock_alias_03}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    },
+                    "lock__04": {
+                        "name": "{lock_alias_04}",
+                        "data": {
+                            "lock_on_arm__interior": "Bloquear automaticamente ao armar o alarme Interior",
+                            "lock_on_arm__perimeter": "Bloquear automaticamente ao armar o alarme Perímetro",
+                            "lock_on_arm__annex": "Bloquear automaticamente ao armar o alarme Anexo",
+                            "unlock_disarms__interior": "Desarmar o alarme Interior antes de desbloquear",
+                            "unlock_disarms__perimeter": "Desarmar o alarme Perímetro antes de desbloquear",
+                            "unlock_disarms__annex": "Desarmar o alarme Anexo antes de desbloquear"
+                        }
+                    }
+                }
             }
         }
     },

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -5057,8 +5057,12 @@ class TestBuildPartialDisarmTarget:
             build_partial_disarm_target,
         )
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         current = AlarmState(
             interior=InteriorMode.TOTAL,
             perimeter=PerimeterMode.ON,
@@ -5074,8 +5078,12 @@ class TestBuildPartialDisarmTarget:
             build_partial_disarm_target,
         )
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         current = AlarmState(
             interior=InteriorMode.TOTAL,
             perimeter=PerimeterMode.ON,
@@ -5091,8 +5099,12 @@ class TestBuildPartialDisarmTarget:
             build_partial_disarm_target,
         )
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         current = AlarmState(
             interior=InteriorMode.NIGHT,
             perimeter=PerimeterMode.ON,
@@ -5106,8 +5118,11 @@ class TestBuildPartialDisarmTarget:
             build_partial_disarm_target,
         )
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
         )
+
         current = AlarmState(
             interior=InteriorMode.TOTAL,
             perimeter=PerimeterMode.ON,
@@ -5126,8 +5141,12 @@ class TestExecutePartialDisarm:
 
     async def test_returns_true_on_success_and_calls_execute_transition(self):
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         panel = make_alarm()  # existing helper
         # Pretend alarm is currently TOTAL + perimeter ON + annex ON.
         panel.coordinator.alarm_state = AlarmState(
@@ -5152,17 +5171,19 @@ class TestExecutePartialDisarm:
     async def test_returns_false_on_verisure_error(self):
         from custom_components.verisure_owa.verisure_owa_api import VerisureOwaError
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         panel = make_alarm()
         panel.coordinator.alarm_state = AlarmState(
             interior=InteriorMode.TOTAL,
             perimeter=PerimeterMode.OFF,
             annex=AnnexMode.OFF,
         )
-        panel._execute_transition = AsyncMock(
-            side_effect=VerisureOwaError("boom")
-        )
+        panel._execute_transition = AsyncMock(side_effect=VerisureOwaError("boom"))
         ok = await panel.execute_partial_disarm(["interior"])
         assert ok is False
 
@@ -5240,7 +5261,9 @@ class TestCombinedPanelRegistration:
     async def test_combined_panels_keyed_by_installation_number_multi(self):
         """With two installations, combined_alarm_panels must be a dict with one entry per installation."""
         from unittest.mock import MagicMock
-        from custom_components.verisure_owa.alarm_control_panel import CombinedVerisureOwaAlarmPanel
+        from custom_components.verisure_owa.alarm_control_panel import (
+            CombinedVerisureOwaAlarmPanel,
+        )
         from custom_components.verisure_owa import DOMAIN
         from custom_components.verisure_owa.coordinators import AlarmCoordinator
 
@@ -5287,7 +5310,9 @@ class TestCombinedPanelRegistration:
     async def test_combined_panel_per_installation_with_single_install(self):
         """With one installation, combined_alarm_panels must be a dict with exactly one entry."""
         from unittest.mock import MagicMock
-        from custom_components.verisure_owa.alarm_control_panel import CombinedVerisureOwaAlarmPanel
+        from custom_components.verisure_owa.alarm_control_panel import (
+            CombinedVerisureOwaAlarmPanel,
+        )
         from custom_components.verisure_owa import DOMAIN
         from custom_components.verisure_owa.coordinators import AlarmCoordinator
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -5194,6 +5194,133 @@ class TestExecutePartialDisarm:
         assert ok is True
         panel._execute_transition.assert_not_awaited()
 
+    async def test_combined_panel_shows_disarming_during_transition(self):
+        """Combined panel should briefly enter DISARMING before the API call resolves
+        so the UI reflects an in-flight auto-disarm instead of jumping silently
+        from armed to disarmed when the next coordinator poll arrives.
+        """
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
+        )
+        from homeassistant.components.alarm_control_panel.const import (
+            AlarmControlPanelState,
+        )
+
+        panel = make_alarm()
+        panel.coordinator.alarm_state = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.OFF,
+            annex=AnnexMode.OFF,
+        )
+
+        observed: list[str | None] = []
+
+        async def _slow_transition(*_args, **_kwargs):
+            observed.append(panel._state)  # state during the transition
+            return MagicMock(protom_response="D", message="ok", protom_response_date="")
+
+        panel._execute_transition = AsyncMock(side_effect=_slow_transition)
+
+        ok = await panel.execute_partial_disarm(["interior"])
+
+        assert ok is True
+        assert observed == [AlarmControlPanelState.DISARMING]
+
+    async def test_partial_disarm_refreshes_coordinator(self):
+        """After a successful partial disarm we trigger a coordinator refresh so
+        any other entity (sub-panel, lock) sees the new state immediately
+        rather than waiting for the next poll."""
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
+        )
+
+        panel = make_alarm()
+        panel.coordinator.alarm_state = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.OFF,
+            annex=AnnexMode.OFF,
+        )
+        panel._execute_transition = AsyncMock(
+            return_value=MagicMock(
+                protom_response="D", message="ok", protom_response_date=""
+            )
+        )
+
+        await panel.execute_partial_disarm(["interior"])
+
+        panel.coordinator.async_request_refresh.assert_awaited_once()
+
+    async def test_partial_disarm_drives_affected_axis_subpanels(self):
+        """When a sub-panel for the affected axis is registered in entry_data,
+        execute_partial_disarm should drive its state through DISARMING and into
+        the post-result state too — so users see the same animation as a direct
+        sub-panel disarm."""
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
+        )
+        from custom_components.verisure_owa.const import DOMAIN
+        from homeassistant.components.alarm_control_panel.const import (
+            AlarmControlPanelState,
+        )
+
+        panel = make_alarm()
+        panel.coordinator.alarm_state = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.OFF,
+            annex=AnnexMode.OFF,
+        )
+
+        # A lightweight stand-in for a real Interior sub-panel — verifies the
+        # combined-panel orchestration without dragging in HA's entity loader.
+        interior = MagicMock()
+        interior._state = AlarmControlPanelState.ARMED_AWAY
+        interior._last_state = AlarmControlPanelState.ARMED_AWAY
+        interior._operation_in_progress = False
+        interior._operation_epoch = 0
+
+        def _force_state(state):
+            interior._last_state = interior._state
+            interior._state = state
+
+        interior._force_state.side_effect = _force_state
+
+        # Wire entry_data so the combined panel can find the sub-panel.
+        entry_id = "entry-test"
+        panel._client.config_entry = MagicMock(entry_id=entry_id)
+        panel.hass.data = {
+            DOMAIN: {
+                entry_id: {
+                    "axis_alarm_panels": {
+                        panel._installation.number: {"interior": interior}
+                    }
+                }
+            }
+        }
+
+        observed_interior: list[str | None] = []
+
+        async def _slow_transition(*_args, **_kwargs):
+            observed_interior.append(interior._state)
+            return MagicMock(protom_response="D", message="ok", protom_response_date="")
+
+        panel._execute_transition = AsyncMock(side_effect=_slow_transition)
+
+        await panel.execute_partial_disarm(["interior"])
+
+        assert observed_interior == [AlarmControlPanelState.DISARMING]
+        # Sub-panel was also driven through the post-result update + state write.
+        interior.update_status_alarm.assert_called_once()
+        interior.async_write_ha_state.assert_called()
+
 
 # ===========================================================================
 # TestCombinedPanelRegistration

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -5047,3 +5047,70 @@ async def test_arming_exception_fires_both_legacy_and_new_events(hass):
     assert legacy_events[0].data == new_events[0].data
     # _event_id is present in the payload.
     assert "_event_id" in legacy_events[0].data
+
+
+class TestBuildPartialDisarmTarget:
+    """Tests for the partial-disarm target-state builder."""
+
+    def test_disarm_interior_only_keeps_perimeter_and_annex(self):
+        from custom_components.verisure_owa.alarm_control_panel import (
+            build_partial_disarm_target,
+        )
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        current = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.ON,
+            annex=AnnexMode.ON,
+        )
+        target = build_partial_disarm_target(current, ["interior"])
+        assert target.interior == InteriorMode.OFF
+        assert target.perimeter == PerimeterMode.ON
+        assert target.annex == AnnexMode.ON
+
+    def test_disarm_multiple_circuits(self):
+        from custom_components.verisure_owa.alarm_control_panel import (
+            build_partial_disarm_target,
+        )
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        current = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.ON,
+            annex=AnnexMode.ON,
+        )
+        target = build_partial_disarm_target(current, ["interior", "annex"])
+        assert target.interior == InteriorMode.OFF
+        assert target.perimeter == PerimeterMode.ON
+        assert target.annex == AnnexMode.OFF
+
+    def test_disarm_empty_list_returns_unchanged(self):
+        from custom_components.verisure_owa.alarm_control_panel import (
+            build_partial_disarm_target,
+        )
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        current = AlarmState(
+            interior=InteriorMode.NIGHT,
+            perimeter=PerimeterMode.ON,
+            annex=AnnexMode.OFF,
+        )
+        target = build_partial_disarm_target(current, [])
+        assert target == current
+
+    def test_disarm_unknown_circuit_is_ignored(self):
+        from custom_components.verisure_owa.alarm_control_panel import (
+            build_partial_disarm_target,
+        )
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode,
+        )
+        current = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.ON,
+        )
+        target = build_partial_disarm_target(current, ["bogus"])
+        assert target == current

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -5180,31 +5180,11 @@ class TestExecutePartialDisarm:
 
 
 class TestCombinedPanelRegistration:
-    """Tests that async_setup_entry stores the combined panel in entry_data."""
+    """Tests that async_setup_entry stores combined panels in entry_data keyed by installation number."""
 
-    async def test_combined_panel_stored_in_entry_data(self):
-        """After platform setup, the combined panel must be in entry_data."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from custom_components.verisure_owa.alarm_control_panel import (
-            CombinedVerisureOwaAlarmPanel,
-            async_setup_entry,
-        )
-        from custom_components.verisure_owa.hub import VerisureDevice
-        from custom_components.verisure_owa import DOMAIN
-        from custom_components.verisure_owa.verisure_owa_api.models import Installation
+    def _make_client(self):
+        from unittest.mock import MagicMock
         from custom_components.verisure_owa.verisure_owa_api.const import STD_DEFAULTS
-        from custom_components.verisure_owa.coordinators import AlarmCoordinator
-
-        installation = Installation(
-            number="654321",
-            alias="Test Home",
-            panel="SDVFAST",
-            type="PLUS",
-            address="1 Test St",
-            city="Barcelona",
-        )
-        device = VerisureDevice(installation)
 
         client = MagicMock()
         client.config = {
@@ -5215,30 +5195,28 @@ class TestCombinedPanelRegistration:
             "map_vacation": STD_DEFAULTS["map_vacation"],
             "scan_interval": 120,
         }
+        return client
 
-        coordinator = MagicMock(spec=AlarmCoordinator)
-        coordinator.has_peri = False
-        coordinator.has_annex = False
+    def _make_device(self, number, alias):
+        from custom_components.verisure_owa.hub import VerisureDevice
+        from custom_components.verisure_owa.verisure_owa_api.models import Installation
 
-        entry_data = {
-            "hub": client,
-            "alarm_coordinator": coordinator,
-            "devices": [device],
-        }
+        installation = Installation(
+            number=number,
+            alias=alias,
+            panel="SDVFAST",
+            type="PLUS",
+            address="1 Test St",
+            city="Barcelona",
+        )
+        return VerisureDevice(installation)
 
-        hass = MagicMock()
-        hass.data = {DOMAIN: {"test-entry-id": entry_data}}
-
-        entry = MagicMock()
-        entry.entry_id = "test-entry-id"
-        entry.options = {}
-
-        added_entities = []
-
-        def capture_entities(entities, update_before_add=False):
-            added_entities.extend(entities)
-
-        async_add_entities = MagicMock(side_effect=capture_entities)
+    async def _run_setup(self, hass, entry, async_add_entities):
+        from unittest.mock import MagicMock, patch
+        from custom_components.verisure_owa.alarm_control_panel import (
+            CombinedVerisureOwaAlarmPanel,
+            async_setup_entry,
+        )
 
         with (
             patch.object(
@@ -5259,7 +5237,90 @@ class TestCombinedPanelRegistration:
         ):
             await async_setup_entry(hass, entry, async_add_entities)
 
-        assert "combined_alarm_panel" in entry_data, (
-            "entry_data missing 'combined_alarm_panel' key after async_setup_entry"
+    async def test_combined_panels_keyed_by_installation_number_multi(self):
+        """With two installations, combined_alarm_panels must be a dict with one entry per installation."""
+        from unittest.mock import MagicMock
+        from custom_components.verisure_owa.alarm_control_panel import CombinedVerisureOwaAlarmPanel
+        from custom_components.verisure_owa import DOMAIN
+        from custom_components.verisure_owa.coordinators import AlarmCoordinator
+
+        device_a = self._make_device("111111", "Main Home")
+        device_b = self._make_device("222222", "Annex")
+
+        coordinator = MagicMock(spec=AlarmCoordinator)
+        coordinator.has_peri = False
+        coordinator.has_annex = False
+
+        entry_data = {
+            "hub": self._make_client(),
+            "alarm_coordinator": coordinator,
+            "devices": [device_a, device_b],
+        }
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"test-entry-id": entry_data}}
+
+        entry = MagicMock()
+        entry.entry_id = "test-entry-id"
+        entry.options = {}
+
+        async_add_entities = MagicMock()
+
+        await self._run_setup(hass, entry, async_add_entities)
+
+        assert "combined_alarm_panels" in entry_data, (
+            "entry_data missing 'combined_alarm_panels' key after async_setup_entry"
         )
-        assert isinstance(entry_data["combined_alarm_panel"], CombinedVerisureOwaAlarmPanel)
+        panels = entry_data["combined_alarm_panels"]
+        assert isinstance(panels, dict), "combined_alarm_panels must be a dict"
+        assert set(panels.keys()) == {"111111", "222222"}, (
+            f"Expected keys {{'111111', '222222'}}, got {set(panels.keys())}"
+        )
+        for inst_num, panel in panels.items():
+            assert isinstance(panel, CombinedVerisureOwaAlarmPanel), (
+                f"Panel for {inst_num} is not a CombinedVerisureOwaAlarmPanel"
+            )
+            assert panel.installation.number == inst_num, (
+                f"Panel installation number {panel.installation.number!r} != key {inst_num!r}"
+            )
+
+    async def test_combined_panel_per_installation_with_single_install(self):
+        """With one installation, combined_alarm_panels must be a dict with exactly one entry."""
+        from unittest.mock import MagicMock
+        from custom_components.verisure_owa.alarm_control_panel import CombinedVerisureOwaAlarmPanel
+        from custom_components.verisure_owa import DOMAIN
+        from custom_components.verisure_owa.coordinators import AlarmCoordinator
+
+        device = self._make_device("654321", "Test Home")
+
+        coordinator = MagicMock(spec=AlarmCoordinator)
+        coordinator.has_peri = False
+        coordinator.has_annex = False
+
+        entry_data = {
+            "hub": self._make_client(),
+            "alarm_coordinator": coordinator,
+            "devices": [device],
+        }
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"test-entry-id": entry_data}}
+
+        entry = MagicMock()
+        entry.entry_id = "test-entry-id"
+        entry.options = {}
+
+        async_add_entities = MagicMock()
+
+        await self._run_setup(hass, entry, async_add_entities)
+
+        assert "combined_alarm_panels" in entry_data, (
+            "entry_data missing 'combined_alarm_panels' key after async_setup_entry"
+        )
+        panels = entry_data["combined_alarm_panels"]
+        assert isinstance(panels, dict), "combined_alarm_panels must be a dict"
+        assert len(panels) == 1, f"Expected exactly 1 entry, got {len(panels)}"
+        assert "654321" in panels, f"Expected key '654321', got {set(panels.keys())}"
+        panel = panels["654321"]
+        assert isinstance(panel, CombinedVerisureOwaAlarmPanel)
+        assert panel.installation.number == "654321"

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -5172,3 +5172,94 @@ class TestExecutePartialDisarm:
         ok = await panel.execute_partial_disarm([])
         assert ok is True
         panel._execute_transition.assert_not_awaited()
+
+
+# ===========================================================================
+# TestCombinedPanelRegistration
+# ===========================================================================
+
+
+class TestCombinedPanelRegistration:
+    """Tests that async_setup_entry stores the combined panel in entry_data."""
+
+    async def test_combined_panel_stored_in_entry_data(self):
+        """After platform setup, the combined panel must be in entry_data."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from custom_components.verisure_owa.alarm_control_panel import (
+            CombinedVerisureOwaAlarmPanel,
+            async_setup_entry,
+        )
+        from custom_components.verisure_owa.hub import VerisureDevice
+        from custom_components.verisure_owa import DOMAIN
+        from custom_components.verisure_owa.verisure_owa_api.models import Installation
+        from custom_components.verisure_owa.verisure_owa_api.const import STD_DEFAULTS
+        from custom_components.verisure_owa.coordinators import AlarmCoordinator
+
+        installation = Installation(
+            number="654321",
+            alias="Test Home",
+            panel="SDVFAST",
+            type="PLUS",
+            address="1 Test St",
+            city="Barcelona",
+        )
+        device = VerisureDevice(installation)
+
+        client = MagicMock()
+        client.config = {
+            "map_home": STD_DEFAULTS["map_home"],
+            "map_away": STD_DEFAULTS["map_away"],
+            "map_night": STD_DEFAULTS["map_night"],
+            "map_custom": STD_DEFAULTS["map_custom"],
+            "map_vacation": STD_DEFAULTS["map_vacation"],
+            "scan_interval": 120,
+        }
+
+        coordinator = MagicMock(spec=AlarmCoordinator)
+        coordinator.has_peri = False
+        coordinator.has_annex = False
+
+        entry_data = {
+            "hub": client,
+            "alarm_coordinator": coordinator,
+            "devices": [device],
+        }
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"test-entry-id": entry_data}}
+
+        entry = MagicMock()
+        entry.entry_id = "test-entry-id"
+        entry.options = {}
+
+        added_entities = []
+
+        def capture_entities(entities, update_before_add=False):
+            added_entities.extend(entities)
+
+        async_add_entities = MagicMock(side_effect=capture_entities)
+
+        with (
+            patch.object(
+                CombinedVerisureOwaAlarmPanel,
+                "async_schedule_update_ha_state",
+                MagicMock(),
+            ),
+            patch.object(
+                CombinedVerisureOwaAlarmPanel,
+                "async_write_ha_state",
+                MagicMock(),
+            ),
+            patch(
+                "custom_components.verisure_owa.alarm_control_panel"
+                ".async_get_current_platform",
+                return_value=MagicMock(),
+            ),
+        ):
+            await async_setup_entry(hass, entry, async_add_entities)
+
+        assert "combined_alarm_panel" in entry_data, (
+            "entry_data missing 'combined_alarm_panel' key after async_setup_entry"
+        )
+        assert isinstance(entry_data["combined_alarm_panel"], CombinedVerisureOwaAlarmPanel)

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -5114,3 +5114,61 @@ class TestBuildPartialDisarmTarget:
         )
         target = build_partial_disarm_target(current, ["bogus"])
         assert target == current
+
+
+# ===========================================================================
+# execute_partial_disarm
+# ===========================================================================
+
+
+class TestExecutePartialDisarm:
+    """Tests for CombinedVerisureOwaAlarmPanel.execute_partial_disarm."""
+
+    async def test_returns_true_on_success_and_calls_execute_transition(self):
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        panel = make_alarm()  # existing helper
+        # Pretend alarm is currently TOTAL + perimeter ON + annex ON.
+        panel.coordinator.alarm_state = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.ON,
+            annex=AnnexMode.ON,
+        )
+        panel._execute_transition = AsyncMock(
+            return_value=MagicMock(protom_response="D")
+        )
+
+        ok = await panel.execute_partial_disarm(["interior"])
+
+        assert ok is True
+        panel._execute_transition.assert_awaited_once()
+        # Inspect the target passed to _execute_transition.
+        target = panel._execute_transition.await_args.args[0]
+        assert target.interior == InteriorMode.OFF
+        assert target.perimeter == PerimeterMode.ON
+        assert target.annex == AnnexMode.ON
+
+    async def test_returns_false_on_verisure_error(self):
+        from custom_components.verisure_owa.verisure_owa_api import VerisureOwaError
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        panel = make_alarm()
+        panel.coordinator.alarm_state = AlarmState(
+            interior=InteriorMode.TOTAL,
+            perimeter=PerimeterMode.OFF,
+            annex=AnnexMode.OFF,
+        )
+        panel._execute_transition = AsyncMock(
+            side_effect=VerisureOwaError("boom")
+        )
+        ok = await panel.execute_partial_disarm(["interior"])
+        assert ok is False
+
+    async def test_skips_when_no_circuits_specified(self):
+        panel = make_alarm()
+        panel._execute_transition = AsyncMock()
+        ok = await panel.execute_partial_disarm([])
+        assert ok is True
+        panel._execute_transition.assert_not_awaited()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1898,7 +1898,7 @@ def _make_entry_with_locks(
     )
 
     circuits = enabled_circuits if enabled_circuits is not None else {"interior"}
-    options = entry_options or {}
+    options = dict(entry_options) if entry_options else {}
     # Map circuit names to option keys
     options.setdefault(CONF_ENABLE_INTERIOR_PANEL, "interior" in circuits)
     options.setdefault(CONF_ENABLE_PERIMETER_PANEL, "perimeter" in circuits)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1876,3 +1876,178 @@ async def test_subpanel_all_toggles_visible_with_full_caps(hass):
     assert CONF_ENABLE_PERIMETER_PANEL in keys
     assert CONF_ENABLE_ANNEX_PANEL in keys
     assert CONF_ENABLE_INTERIOR_PANEL in keys
+
+
+# ===================================================================
+# TestLockAutomationsOptionsStep (~5 tests)
+# ===================================================================
+
+
+def _make_entry_with_locks(
+    hass,
+    *,
+    registered_locks: list[dict],
+    enabled_circuits: set[str] | None = None,
+    entry_options: dict | None = None,
+):
+    """Create MockConfigEntry and inject registered_locks + circuit options into hass.data."""
+    from custom_components.verisure_owa.const import (
+        CONF_ENABLE_ANNEX_PANEL,
+        CONF_ENABLE_INTERIOR_PANEL,
+        CONF_ENABLE_PERIMETER_PANEL,
+    )
+
+    circuits = enabled_circuits if enabled_circuits is not None else {"interior"}
+    options = entry_options or {}
+    # Map circuit names to option keys
+    options.setdefault(CONF_ENABLE_INTERIOR_PANEL, "interior" in circuits)
+    options.setdefault(CONF_ENABLE_PERIMETER_PANEL, "perimeter" in circuits)
+    options.setdefault(CONF_ENABLE_ANNEX_PANEL, "annex" in circuits)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=make_config_entry_data(),
+        options=options,
+    )
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "registered_locks": registered_locks,
+    }
+    return entry
+
+
+async def _advance_to_lock_automations(hass, entry):
+    """Navigate init -> mappings -> lock_automations and return flow_id."""
+    flow_id = await _advance_to_mappings(hass, entry)
+    result = await hass.config_entries.options.async_configure(
+        flow_id,
+        user_input={
+            CONF_MAP_HOME: STD_DEFAULTS[CONF_MAP_HOME],
+            CONF_MAP_AWAY: STD_DEFAULTS[CONF_MAP_AWAY],
+            CONF_MAP_NIGHT: STD_DEFAULTS[CONF_MAP_NIGHT],
+            CONF_MAP_CUSTOM: STD_DEFAULTS[CONF_MAP_CUSTOM],
+            CONF_MAP_VACATION: STD_DEFAULTS[CONF_MAP_VACATION],
+        },
+    )
+    assert result["step_id"] == "lock_automations", (
+        f"Expected lock_automations step, got {result['step_id']}"
+    )
+    return result["flow_id"]
+
+
+async def test_lock_automations_renders_one_section_per_lock(hass):
+    """Form should have two fields per registered lock (lock_on_arm, unlock_disarms)."""
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[
+            {"device_id": "lockA", "alias": "Front Door"},
+            {"device_id": "lockB", "alias": "Back Door"},
+        ],
+        enabled_circuits={"interior", "perimeter", "annex"},
+    )
+    flow_id = await _advance_to_lock_automations(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(flow_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_automations"
+    keys = {str(k) for k in result["data_schema"].schema.keys()}
+    assert any("lockA" in k for k in keys)
+    assert any("lockB" in k for k in keys)
+
+
+async def test_lock_automations_disabled_circuits_excluded(hass):
+    """Circuits not enabled on this installation should not appear as options."""
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[{"device_id": "lockA", "alias": "Front Door"}],
+        enabled_circuits={"interior"},
+    )
+    flow_id = await _advance_to_lock_automations(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(flow_id)
+
+    schema_str = str(result["data_schema"])
+    assert "perimeter" not in schema_str
+    assert "annex" not in schema_str
+
+
+async def test_lock_automations_submission_persists_per_lock_config(hass):
+    """Submitting the form should save per-lock config in CONF_LOCK_AUTOMATIONS."""
+    from custom_components.verisure_owa.const import CONF_LOCK_AUTOMATIONS
+
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[{"device_id": "lockA", "alias": "Front Door"}],
+        enabled_circuits={"interior", "perimeter", "annex"},
+    )
+    flow_id = await _advance_to_lock_automations(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(
+        flow_id,
+        user_input={
+            "lockA__lock_on_arm": ["interior", "perimeter"],
+            "lockA__unlock_disarms": ["interior"],
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_LOCK_AUTOMATIONS in result["data"]
+    assert result["data"][CONF_LOCK_AUTOMATIONS]["lockA"] == {
+        "lock_on_arm": ["interior", "perimeter"],
+        "unlock_disarms": ["interior"],
+    }
+
+
+async def test_lock_automations_re_edit_prefills_existing_values(hass):
+    """Re-opening options flow should prefill previously saved lock automation values."""
+    from custom_components.verisure_owa.const import CONF_LOCK_AUTOMATIONS
+
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[{"device_id": "lockA", "alias": "Front Door"}],
+        enabled_circuits={"interior", "perimeter", "annex"},
+        entry_options={
+            CONF_LOCK_AUTOMATIONS: {
+                "lockA": {
+                    "lock_on_arm": ["perimeter"],
+                    "unlock_disarms": ["interior", "annex"],
+                }
+            }
+        },
+    )
+    flow_id = await _advance_to_lock_automations(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(flow_id)
+
+    assert result["type"] == FlowResultType.FORM
+    schema = result["data_schema"].schema
+    for k, _v in schema.items():
+        key_str = str(k)
+        if "lockA__lock_on_arm" in key_str:
+            assert k.default() == ["perimeter"]
+        if "lockA__unlock_disarms" in key_str:
+            assert k.default() == ["interior", "annex"]
+
+
+async def test_lock_automations_skipped_when_no_locks_discovered(hass):
+    """When no locks are registered, the step should be skipped (CREATE_ENTRY)."""
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[],
+        enabled_circuits={"interior"},
+    )
+    flow_id = await _advance_to_mappings(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(
+        flow_id,
+        user_input={
+            CONF_MAP_HOME: STD_DEFAULTS[CONF_MAP_HOME],
+            CONF_MAP_AWAY: STD_DEFAULTS[CONF_MAP_AWAY],
+            CONF_MAP_NIGHT: STD_DEFAULTS[CONF_MAP_NIGHT],
+            CONF_MAP_CUSTOM: STD_DEFAULTS[CONF_MAP_CUSTOM],
+            CONF_MAP_VACATION: STD_DEFAULTS[CONF_MAP_VACATION],
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1956,6 +1956,15 @@ async def test_lock_automations_renders_one_section_per_lock(hass):
     assert any("lockB" in k for k in keys)
 
 
+def _circuit_options_from_schema(schema) -> set[str]:
+    """Extract circuit labels from all multi_select values in a lock-automations schema."""
+    circuits: set[str] = set()
+    for v in schema.schema.values():
+        if hasattr(v, "options"):
+            circuits.update(v.options.keys())
+    return circuits
+
+
 async def test_lock_automations_disabled_circuits_excluded(hass):
     """Circuits not enabled on this installation should not appear as options."""
     entry = _make_entry_with_locks(
@@ -1967,9 +1976,30 @@ async def test_lock_automations_disabled_circuits_excluded(hass):
 
     result = await hass.config_entries.options.async_configure(flow_id)
 
-    schema_str = str(result["data_schema"])
-    assert "perimeter" not in schema_str
-    assert "annex" not in schema_str
+    circuits = _circuit_options_from_schema(result["data_schema"])
+    assert "interior" in circuits
+    assert "perimeter" not in circuits
+    assert "annex" not in circuits
+
+
+async def test_lock_automations_interior_always_present_even_when_panel_disabled(hass):
+    """Interior is always available on the combined panel; the lock-automations
+    UI should always offer it as a circuit option, regardless of whether the
+    interior sub-panel entity is enabled."""
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[{"device_id": "lockA", "alias": "Front Door"}],
+        # Explicitly disable all sub-panels including interior.
+        enabled_circuits=set(),
+    )
+    flow_id = await _advance_to_lock_automations(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(flow_id)
+
+    circuits = _circuit_options_from_schema(result["data_schema"])
+    assert "interior" in circuits
+    assert "perimeter" not in circuits
+    assert "annex" not in circuits
 
 
 async def test_lock_automations_submission_persists_per_lock_config(hass):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1935,8 +1935,45 @@ async def _advance_to_lock_automations(hass, entry):
     return result["flow_id"]
 
 
+def _section_keys(data_schema) -> set[str]:
+    """Return the set of section names in a sectioned schema."""
+    from homeassistant.data_entry_flow import section
+
+    return {
+        getattr(marker, "schema", marker)
+        for marker, value in data_schema.schema.items()
+        if isinstance(value, section)
+    }
+
+
+def _section_inner_keys(data_schema, section_key: str) -> set[str]:
+    """Return the field keys inside the named section() of a schema."""
+    from homeassistant.data_entry_flow import section
+
+    for marker, value in data_schema.schema.items():
+        name = getattr(marker, "schema", marker)
+        if name != section_key or not isinstance(value, section):
+            continue
+        return {getattr(m, "schema", m) for m in value.schema.schema}
+    return set()
+
+
+def _section_inner_marker(data_schema, section_key: str, field_key: str):
+    """Return the voluptuous marker for a field inside a named section."""
+    from homeassistant.data_entry_flow import section
+
+    for marker, value in data_schema.schema.items():
+        name = getattr(marker, "schema", marker)
+        if name != section_key or not isinstance(value, section):
+            continue
+        for inner_marker in value.schema.schema:
+            if getattr(inner_marker, "schema", inner_marker) == field_key:
+                return inner_marker
+    return None
+
+
 async def test_lock_automations_renders_one_section_per_lock(hass):
-    """Form should have two fields per registered lock (lock_on_arm, unlock_disarms)."""
+    """Form should have one section per registered lock with per-circuit bools inside."""
     entry = _make_entry_with_locks(
         hass,
         registered_locks=[
@@ -1951,17 +1988,19 @@ async def test_lock_automations_renders_one_section_per_lock(hass):
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "lock_automations"
-    keys = {str(k) for k in result["data_schema"].schema.keys()}
-    assert any("lockA" in k for k in keys)
-    assert any("lockB" in k for k in keys)
+    sections = _section_keys(result["data_schema"])
+    assert "lock__lockA" in sections
+    assert "lock__lockB" in sections
 
 
-def _circuit_options_from_schema(schema) -> set[str]:
-    """Extract circuit labels from all multi_select values in a lock-automations schema."""
+def _circuit_options_from_schema(schema, lock_id: str = "lockA") -> set[str]:
+    """Extract circuit labels offered for a lock by inspecting its section's bool fields."""
+    inner = _section_inner_keys(schema, f"lock__{lock_id}")
     circuits: set[str] = set()
-    for v in schema.schema.values():
-        if hasattr(v, "options"):
-            circuits.update(v.options.keys())
+    for key in inner:
+        for prefix in ("lock_on_arm__", "unlock_disarms__"):
+            if key.startswith(prefix):
+                circuits.add(key[len(prefix) :])
     return circuits
 
 
@@ -2016,17 +2055,22 @@ async def test_lock_automations_submission_persists_per_lock_config(hass):
     result = await hass.config_entries.options.async_configure(
         flow_id,
         user_input={
-            "lockA__lock_on_arm": ["interior", "perimeter"],
-            "lockA__unlock_disarms": ["interior"],
+            "lock__lockA": {
+                "lock_on_arm__interior": True,
+                "lock_on_arm__perimeter": True,
+                "lock_on_arm__annex": False,
+                "unlock_disarms__interior": True,
+                "unlock_disarms__perimeter": False,
+                "unlock_disarms__annex": False,
+            },
         },
     )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert CONF_LOCK_AUTOMATIONS in result["data"]
-    assert result["data"][CONF_LOCK_AUTOMATIONS]["lockA"] == {
-        "lock_on_arm": ["interior", "perimeter"],
-        "unlock_disarms": ["interior"],
-    }
+    saved = result["data"][CONF_LOCK_AUTOMATIONS]["lockA"]
+    assert sorted(saved["lock_on_arm"]) == ["interior", "perimeter"]
+    assert saved["unlock_disarms"] == ["interior"]
 
 
 async def test_lock_automations_re_edit_prefills_existing_values(hass):
@@ -2051,13 +2095,19 @@ async def test_lock_automations_re_edit_prefills_existing_values(hass):
     result = await hass.config_entries.options.async_configure(flow_id)
 
     assert result["type"] == FlowResultType.FORM
-    schema = result["data_schema"].schema
-    for k, _v in schema.items():
-        key_str = str(k)
-        if "lockA__lock_on_arm" in key_str:
-            assert k.default() == ["perimeter"]
-        if "lockA__unlock_disarms" in key_str:
-            assert k.default() == ["interior", "annex"]
+    schema = result["data_schema"]
+
+    def _bool_default(field_key: str) -> bool:
+        marker = _section_inner_marker(schema, "lock__lockA", field_key)
+        assert marker is not None, f"missing field {field_key}"
+        return marker.default()
+
+    assert _bool_default("lock_on_arm__interior") is False
+    assert _bool_default("lock_on_arm__perimeter") is True
+    assert _bool_default("lock_on_arm__annex") is False
+    assert _bool_default("unlock_disarms__interior") is True
+    assert _bool_default("unlock_disarms__perimeter") is False
+    assert _bool_default("unlock_disarms__annex") is True
 
 
 async def test_lock_automations_skipped_when_no_locks_discovered(hass):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -384,6 +384,7 @@ def test_lock_automations_constants_exist():
         CIRCUIT_ANNEX,
         LOCK_CIRCUITS,
     )
+
     assert CONF_LOCK_AUTOMATIONS == "lock_automations"
     assert CIRCUIT_INTERIOR == "interior"
     assert CIRCUIT_PERIMETER == "perimeter"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -371,3 +371,21 @@ class TestCountryCodes:
         # The HA config-flow's CountrySelector consumes the list and renders it
         # as a dropdown — it must be a list, not a set/frozenset/tuple.
         assert isinstance(COUNTRY_CODES, list)
+
+
+# ── Lock Automations ─────────────────────────────────────────────────────────
+
+
+def test_lock_automations_constants_exist():
+    from custom_components.verisure_owa.const import (
+        CONF_LOCK_AUTOMATIONS,
+        CIRCUIT_INTERIOR,
+        CIRCUIT_PERIMETER,
+        CIRCUIT_ANNEX,
+        LOCK_CIRCUITS,
+    )
+    assert CONF_LOCK_AUTOMATIONS == "lock_automations"
+    assert CIRCUIT_INTERIOR == "interior"
+    assert CIRCUIT_PERIMETER == "perimeter"
+    assert CIRCUIT_ANNEX == "annex"
+    assert LOCK_CIRCUITS == ("interior", "perimeter", "annex")

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1262,3 +1262,58 @@ class TestHassNoneGuards:
 
         assert lock._state == "1"
         lock.async_schedule_update_ha_state.assert_not_called()  # type: ignore[attr-defined]
+
+
+class TestVerisureLockAlarmListener:
+    """Tests for the alarm-coordinator transition listener."""
+
+    def _make_alarm_coord(self, state):
+        coord = MagicMock()
+        coord.alarm_state = state
+        coord.async_add_listener = MagicMock(return_value=lambda: None)
+        return coord
+
+    def _state(self, *, i="OFF", p="OFF", a="OFF"):
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        return AlarmState(
+            interior=getattr(InteriorMode, i),
+            perimeter=getattr(PerimeterMode, p),
+            annex=getattr(AnnexMode, a),
+        )
+
+    async def test_baseline_recorded_on_first_update_and_no_action_taken(self):
+        # Lock starts up with alarm already armed; no auto-lock should fire.
+        lock = make_lock(initial_status="1")  # currently unlocked
+        alarm_coord = self._make_alarm_coord(self._state(i="TOTAL"))
+        lock._alarm_coordinator = alarm_coord
+        lock._alarm_baseline = None  # explicit
+        lock._lock_on_arm_circuits = ["interior"]
+
+        # Trigger first update.
+        lock._handle_alarm_coordinator_update()
+
+        # Baseline must be recorded as currently TOTAL.
+        from custom_components.verisure_owa.const import CIRCUIT_INTERIOR
+        assert CIRCUIT_INTERIOR in (lock._alarm_baseline or set())
+        # And no lock action was attempted.
+        # (verified more thoroughly in Task 6; here we just check no crash and
+        # state unchanged.)
+        assert lock._state == "1"
+
+    def test_armed_circuits_helper_excludes_off_modes(self):
+        from custom_components.verisure_owa.lock import _armed_circuits
+        from custom_components.verisure_owa.const import (
+            CIRCUIT_INTERIOR, CIRCUIT_PERIMETER, CIRCUIT_ANNEX,
+        )
+        s = self._state(i="OFF", p="ON", a="OFF")
+        assert _armed_circuits(s) == {CIRCUIT_PERIMETER}
+        s = self._state(i="DAY", p="OFF", a="ON")
+        assert _armed_circuits(s) == {CIRCUIT_INTERIOR, CIRCUIT_ANNEX}
+        s = self._state(i="TOTAL", p="ON", a="ON")
+        assert _armed_circuits(s) == {
+            CIRCUIT_INTERIOR, CIRCUIT_PERIMETER, CIRCUIT_ANNEX
+        }
+        s = self._state()  # all OFF
+        assert _armed_circuits(s) == set()

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -141,6 +141,19 @@ def make_lock(
     return lock_entity
 
 
+async def _drain_lock_tasks(lock):
+    """Run all coroutines scheduled via the mocked ``hass.async_create_task``.
+
+    The mocked hass collects scheduled coroutines as MagicMock call args;
+    we await each one in turn so test assertions can observe the side effects.
+    """
+    calls = lock.hass.async_create_task.call_args_list
+    for call in calls:
+        coro = call.args[0]
+        await coro
+    lock.hass.async_create_task.reset_mock()
+
+
 # ===========================================================================
 # Sentinel sensor helper — mock coordinator
 # ===========================================================================
@@ -1317,3 +1330,124 @@ class TestVerisureLockAlarmListener:
         }
         s = self._state()  # all OFF
         assert _armed_circuits(s) == set()
+
+
+# ===========================================================================
+# Auto-lock-on-arm tests (Task 6)
+# ===========================================================================
+
+
+class TestVerisureLockAutoLockOnArm:
+    """Tests for auto-lock-on-arm behavior."""
+
+    def _make_alarm_coord(self, state):
+        coord = MagicMock()
+        coord.alarm_state = state
+        coord.async_add_listener = MagicMock(return_value=lambda: None)
+        return coord
+
+    def _state(self, *, i="OFF", p="OFF", a="OFF"):
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        return AlarmState(
+            interior=getattr(InteriorMode, i),
+            perimeter=getattr(PerimeterMode, p),
+            annex=getattr(AnnexMode, a),
+        )
+
+    async def test_locks_when_configured_circuit_transitions_to_armed(self):
+        # Lock currently unlocked. Auto-lock configured for [interior].
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._lock_on_arm_circuits = ["interior"]
+        # Establish baseline = all OFF.
+        coord = self._make_alarm_coord(self._state())
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()  # baseline
+        # Now interior arms.
+        coord.alarm_state = self._state(i="TOTAL")
+        lock._handle_alarm_coordinator_update()
+        # Drain pending tasks.
+        await _drain_lock_tasks(lock)
+        lock._client.change_lock_mode.assert_awaited_once()
+        # Was a lock command (state=True).
+        call = lock._client.change_lock_mode.await_args
+        assert call.args[1] is True
+
+    async def test_does_not_lock_when_already_locked(self):
+        lock = make_lock(initial_status="2", poll_status="2")  # already locked
+        lock._client.change_lock_mode = AsyncMock()
+        lock._lock_on_arm_circuits = ["interior"]
+        coord = self._make_alarm_coord(self._state())
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()
+        coord.alarm_state = self._state(i="TOTAL")
+        lock._handle_alarm_coordinator_update()
+        await _drain_lock_tasks(lock)
+        lock._client.change_lock_mode.assert_not_awaited()
+
+    async def test_does_not_lock_when_unconfigured_circuit_arms(self):
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock()
+        lock._lock_on_arm_circuits = ["interior"]  # only interior
+        coord = self._make_alarm_coord(self._state())
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()
+        coord.alarm_state = self._state(p="ON")  # perimeter, not interior
+        lock._handle_alarm_coordinator_update()
+        await _drain_lock_tasks(lock)
+        lock._client.change_lock_mode.assert_not_awaited()
+
+    async def test_or_semantics_any_configured_circuit_fires(self):
+        # Configured for [interior, perimeter]; only perimeter arms.
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._lock_on_arm_circuits = ["interior", "perimeter"]
+        coord = self._make_alarm_coord(self._state())
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()
+        coord.alarm_state = self._state(p="ON")
+        lock._handle_alarm_coordinator_update()
+        await _drain_lock_tasks(lock)
+        lock._client.change_lock_mode.assert_awaited_once()
+
+    async def test_dedupe_when_multiple_circuits_arm_simultaneously(self):
+        # Combined-panel arm flips interior + perimeter together.
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._lock_on_arm_circuits = ["interior", "perimeter"]
+        coord = self._make_alarm_coord(self._state())
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()
+        coord.alarm_state = self._state(i="TOTAL", p="ON")
+        lock._handle_alarm_coordinator_update()
+        await _drain_lock_tasks(lock)
+        # Only one lock command, not two.
+        assert lock._client.change_lock_mode.await_count == 1
+
+    async def test_no_lock_on_disarm_transition(self):
+        # Going armed→disarmed should NEVER trigger a lock.
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock()
+        lock._lock_on_arm_circuits = ["interior"]
+        coord = self._make_alarm_coord(self._state(i="TOTAL"))
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()  # baseline = armed
+        coord.alarm_state = self._state()
+        lock._handle_alarm_coordinator_update()  # now disarmed
+        await _drain_lock_tasks(lock)
+        lock._client.change_lock_mode.assert_not_awaited()
+
+    async def test_no_lock_when_operation_in_progress(self):
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock()
+        lock._lock_on_arm_circuits = ["interior"]
+        lock._operation_in_progress = True  # simulate ongoing manual lock
+        coord = self._make_alarm_coord(self._state())
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()
+        coord.alarm_state = self._state(i="TOTAL")
+        lock._handle_alarm_coordinator_update()
+        await _drain_lock_tasks(lock)
+        lock._client.change_lock_mode.assert_not_awaited()

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1556,22 +1556,31 @@ class TestVerisureLockUnlockDisarm:
         coord.alarm_state = state
         return coord
 
-    async def test_disarm_runs_before_unlock_when_configured(self):
+    async def test_disarm_and_unlock_run_in_parallel(self):
+        """Disarm and unlock dispatch concurrently — neither blocks on the other.
+
+        Verified via cross-coupled events: each fake awaits the other's "started"
+        event before completing. Sequential execution (in either order) would
+        deadlock; parallel execution lets both progress and the test completes.
+        """
+        import asyncio
+
         lock = make_lock(initial_status="2", poll_status="1")
-        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
         lock._unlock_disarms_circuits = ["interior"]
         lock._combined_alarm_panel = self._make_alarm_panel(success=True)
         lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
 
-        # Capture call order.
-        order: list[str] = []
+        disarm_started = asyncio.Event()
+        unlock_started = asyncio.Event()
 
-        async def fake_disarm(circuits):
-            order.append("disarm")
+        async def fake_disarm(_circuits):
+            disarm_started.set()
+            await asyncio.wait_for(unlock_started.wait(), timeout=1.0)
             return True
 
-        async def fake_change(installation, lock_state, device_id=None):
-            order.append("unlock")
+        async def fake_change(_installation, _lock_state, _device_id=None):
+            unlock_started.set()
+            await asyncio.wait_for(disarm_started.wait(), timeout=1.0)
             return MagicMock()
 
         lock._combined_alarm_panel.execute_partial_disarm = AsyncMock(
@@ -1581,10 +1590,12 @@ class TestVerisureLockUnlockDisarm:
 
         await lock.async_unlock()
 
-        assert order == ["disarm", "unlock"]
+        assert disarm_started.is_set()
+        assert unlock_started.is_set()
         lock._combined_alarm_panel.execute_partial_disarm.assert_awaited_once_with(
             ["interior"]
         )
+        lock._client.change_lock_mode.assert_awaited_once()
 
     async def test_disarm_skipped_when_alarm_already_disarmed(self):
         lock = make_lock(initial_status="2", poll_status="1")

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1599,3 +1599,90 @@ class TestVerisureLockUnlockDisarm:
         lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
         await lock.async_unlock()  # must not raise
         lock._client.change_lock_mode.assert_awaited_once()
+
+
+# ===========================================================================
+# Unlock-disarm failure notification tests (Task 9)
+# ===========================================================================
+
+
+class TestVerisureLockUnlockDisarmFailure:
+    """Tests for unlock-disarm failure surfaces."""
+
+    def _state(self, *, i="OFF", p="OFF", a="OFF"):
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        return AlarmState(
+            interior=getattr(InteriorMode, i),
+            perimeter=getattr(PerimeterMode, p),
+            annex=getattr(AnnexMode, a),
+        )
+
+    def _make_alarm_coord(self, state):
+        coord = MagicMock()
+        coord.alarm_state = state
+        return coord
+
+    async def test_pre_unlock_disarm_failure_notifies_and_proceeds(self):
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._unlock_disarms_circuits = ["interior"]
+        lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
+        panel = MagicMock()
+        panel.execute_partial_disarm = AsyncMock(return_value=False)
+        lock._combined_alarm_panel = panel
+        lock.hass.services.async_call = AsyncMock()
+
+        await lock.async_unlock()
+
+        # Notification fired with "Auto-disarm failed" wording.
+        notif_calls = [
+            c for c in lock.hass.services.async_call.await_args_list
+            if c.args[:2] == ("persistent_notification", "create")
+        ]
+        assert len(notif_calls) == 1
+        assert "Auto-disarm failed" in notif_calls[0].args[2]["title"]
+        # Unlock still happened.
+        lock._client.change_lock_mode.assert_awaited_once()
+
+    async def test_unlock_failure_after_successful_disarm_notifies(self):
+        from custom_components.verisure_owa.verisure_owa_api import VerisureOwaError
+        lock = make_lock(initial_status="2", poll_status="2")  # stays locked
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("nope")
+        )
+        lock._unlock_disarms_circuits = ["interior"]
+        lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
+        panel = MagicMock()
+        panel.execute_partial_disarm = AsyncMock(return_value=True)
+        lock._combined_alarm_panel = panel
+        lock.hass.services.async_call = AsyncMock()
+
+        await lock.async_unlock()
+
+        # The unlock failed — notification with "Unlock failed" wording.
+        notif_calls = [
+            c for c in lock.hass.services.async_call.await_args_list
+            if c.args[:2] == ("persistent_notification", "create")
+        ]
+        assert len(notif_calls) == 1
+        assert "Unlock failed" in notif_calls[0].args[2]["title"]
+
+    async def test_no_notification_on_full_success(self):
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._unlock_disarms_circuits = ["interior"]
+        lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
+        panel = MagicMock()
+        panel.execute_partial_disarm = AsyncMock(return_value=True)
+        lock._combined_alarm_panel = panel
+        lock.hass.services.async_call = AsyncMock()
+
+        await lock.async_unlock()
+
+        notif_calls = [
+            c for c in lock.hass.services.async_call.await_args_list
+            if c.args[:2] == ("persistent_notification", "create")
+        ]
+        assert notif_calls == []

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1493,3 +1493,109 @@ class TestVerisureLockAutoLockFailure:
             if c.args[:2] == ("persistent_notification", "create")
         ]
         assert notification_calls == []
+
+
+# ===========================================================================
+# Unlock→disarm flow tests (Task 8)
+# ===========================================================================
+
+
+class TestVerisureLockUnlockDisarm:
+    """Tests for unlock→disarm flow (success paths)."""
+
+    def _state(self, *, i="OFF", p="OFF", a="OFF"):
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+        )
+        return AlarmState(
+            interior=getattr(InteriorMode, i),
+            perimeter=getattr(PerimeterMode, p),
+            annex=getattr(AnnexMode, a),
+        )
+
+    def _make_alarm_panel(self, *, success=True):
+        panel = MagicMock()
+        panel.execute_partial_disarm = AsyncMock(return_value=success)
+        return panel
+
+    def _make_alarm_coord(self, state):
+        coord = MagicMock()
+        coord.alarm_state = state
+        return coord
+
+    async def test_disarm_runs_before_unlock_when_configured(self):
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._unlock_disarms_circuits = ["interior"]
+        lock._combined_alarm_panel = self._make_alarm_panel(success=True)
+        lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
+
+        # Capture call order.
+        order: list[str] = []
+        async def fake_disarm(circuits):
+            order.append("disarm")
+            return True
+        async def fake_change(installation, lock_state, device_id=None):
+            order.append("unlock")
+            return MagicMock()
+        lock._combined_alarm_panel.execute_partial_disarm = AsyncMock(
+            side_effect=fake_disarm
+        )
+        lock._client.change_lock_mode = AsyncMock(side_effect=fake_change)
+
+        await lock.async_unlock()
+
+        assert order == ["disarm", "unlock"]
+        lock._combined_alarm_panel.execute_partial_disarm.assert_awaited_once_with(
+            ["interior"]
+        )
+
+    async def test_disarm_skipped_when_alarm_already_disarmed(self):
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._unlock_disarms_circuits = ["interior"]
+        lock._combined_alarm_panel = self._make_alarm_panel(success=True)
+        # Alarm already fully disarmed.
+        lock._alarm_coordinator = self._make_alarm_coord(self._state())
+
+        await lock.async_unlock()
+
+        lock._combined_alarm_panel.execute_partial_disarm.assert_not_awaited()
+        # Unlock still proceeds.
+        lock._client.change_lock_mode.assert_awaited_once()
+
+    async def test_disarm_skipped_when_no_circuits_configured(self):
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._unlock_disarms_circuits = []  # no automation
+        lock._combined_alarm_panel = self._make_alarm_panel(success=True)
+        lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
+
+        await lock.async_unlock()
+
+        lock._combined_alarm_panel.execute_partial_disarm.assert_not_awaited()
+        lock._client.change_lock_mode.assert_awaited_once()
+
+    async def test_async_open_follows_same_disarm_first_flow(self):
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._unlock_disarms_circuits = ["interior"]
+        lock._combined_alarm_panel = self._make_alarm_panel(success=True)
+        lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
+
+        await lock.async_open()
+
+        lock._combined_alarm_panel.execute_partial_disarm.assert_awaited_once_with(
+            ["interior"]
+        )
+        lock._client.change_lock_mode.assert_awaited_once()
+
+    async def test_no_disarm_dispatched_when_panel_unavailable(self):
+        # Defensive: missing panel reference (e.g., setup race) → skip disarm.
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._unlock_disarms_circuits = ["interior"]
+        lock._combined_alarm_panel = None
+        lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
+        await lock.async_unlock()  # must not raise
+        lock._client.change_lock_mode.assert_awaited_once()

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1686,3 +1686,101 @@ class TestVerisureLockUnlockDisarmFailure:
             if c.args[:2] == ("persistent_notification", "create")
         ]
         assert notif_calls == []
+
+
+# ===========================================================================
+# TestVerisureLockSetupAndTeardown
+# ===========================================================================
+
+
+class TestVerisureLockSetupAndTeardown:
+    """Tests for async_added_to_hass / async_will_remove_from_hass wiring."""
+
+    async def test_loads_per_lock_options_and_subscribes(self):
+        from custom_components.verisure_owa.const import (
+            CONF_LOCK_AUTOMATIONS,
+        )
+        lock = make_lock(initial_status="2")
+        # Stand in for hass-managed plumbing.
+        unsub = MagicMock()
+        alarm_coord = MagicMock()
+        alarm_coord.async_add_listener = MagicMock(return_value=unsub)
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode,
+        )
+        alarm_coord.alarm_state = AlarmState(
+            interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF
+        )
+        panel = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.options = {
+            CONF_LOCK_AUTOMATIONS: {
+                lock._device_id: {
+                    "lock_on_arm": ["interior", "perimeter"],
+                    "unlock_disarms": ["interior"],
+                }
+            }
+        }
+        from custom_components.verisure_owa import DOMAIN
+        lock.hass.data = {
+            DOMAIN: {
+                "entry-1": {
+                    "alarm_coordinator": alarm_coord,
+                    "combined_alarm_panels": {
+                        lock.installation.number: panel,
+                    },
+                    "config_entry": entry,
+                }
+            }
+        }
+        lock._entry_id = "entry-1"  # set by setup helper
+
+        await lock.async_added_to_hass()
+
+        assert lock._lock_on_arm_circuits == ["interior", "perimeter"]
+        assert lock._unlock_disarms_circuits == ["interior"]
+        assert lock._alarm_coordinator is alarm_coord
+        assert lock._combined_alarm_panel is panel
+        alarm_coord.async_add_listener.assert_called_once()
+        # Baseline established (no firing on first call).
+        assert lock._alarm_baseline is not None
+
+    async def test_defaults_to_empty_when_no_options(self):
+        lock = make_lock()
+        alarm_coord = MagicMock()
+        alarm_coord.async_add_listener = MagicMock(return_value=lambda: None)
+        from custom_components.verisure_owa.verisure_owa_api.models import (
+            AlarmState, InteriorMode, PerimeterMode,
+        )
+        alarm_coord.alarm_state = AlarmState(
+            interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF
+        )
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.options = {}
+        from custom_components.verisure_owa import DOMAIN
+        lock.hass.data = {
+            DOMAIN: {
+                "entry-1": {
+                    "alarm_coordinator": alarm_coord,
+                    "combined_alarm_panels": {
+                        lock.installation.number: MagicMock(),
+                    },
+                    "config_entry": entry,
+                }
+            }
+        }
+        lock._entry_id = "entry-1"
+
+        await lock.async_added_to_hass()
+
+        assert lock._lock_on_arm_circuits == []
+        assert lock._unlock_disarms_circuits == []
+
+    async def test_unsubscribe_called_on_removal(self):
+        lock = make_lock()
+        unsub = MagicMock()
+        lock._alarm_listener_unsub = unsub
+        await lock.async_will_remove_from_hass()
+        unsub.assert_called_once()

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1387,6 +1387,20 @@ class TestVerisureLockAutoLockOnArm:
         await _drain_lock_tasks(lock)
         lock._client.change_lock_mode.assert_not_awaited()
 
+    async def test_does_not_lock_when_already_locking(self):
+        # Lock currently mid-lock-operation (status=4); a new arm transition
+        # should not enqueue another auto-lock.
+        lock = make_lock(initial_status="4", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock()
+        lock._lock_on_arm_circuits = ["interior"]
+        coord = self._make_alarm_coord(self._state())
+        lock._alarm_coordinator = coord
+        lock._handle_alarm_coordinator_update()  # baseline = OFF
+        coord.alarm_state = self._state(i="TOTAL")
+        lock._handle_alarm_coordinator_update()
+        await _drain_lock_tasks(lock)
+        lock._client.change_lock_mode.assert_not_awaited()
+
     async def test_does_not_lock_when_unconfigured_circuit_arms(self):
         lock = make_lock(initial_status="1", poll_status="2")
         lock._client.change_lock_mode = AsyncMock()

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1451,3 +1451,45 @@ class TestVerisureLockAutoLockOnArm:
         lock._handle_alarm_coordinator_update()
         await _drain_lock_tasks(lock)
         lock._client.change_lock_mode.assert_not_awaited()
+
+
+# ===========================================================================
+# Auto-lock failure notification tests (Task 7)
+# ===========================================================================
+
+
+class TestVerisureLockAutoLockFailure:
+    """Tests for the persistent-notification surface on auto-lock failure."""
+
+    async def test_persistent_notification_created_on_lock_failure(self):
+        from custom_components.verisure_owa.verisure_owa_api import VerisureOwaError
+        lock = make_lock(initial_status="1", poll_status="1")  # stays unlocked
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("network down")
+        )
+        # Patch services so we can capture persistent_notification.create.
+        lock.hass.services.async_call = AsyncMock()
+
+        await lock._auto_lock()
+
+        # Look for a persistent_notification.create call.
+        calls = lock.hass.services.async_call.await_args_list
+        notification_calls = [
+            c for c in calls
+            if c.args[:2] == ("persistent_notification", "create")
+        ]
+        assert len(notification_calls) == 1
+        payload = notification_calls[0].args[2]
+        assert payload["notification_id"].startswith("verisure_owa_autolock_")
+        assert "Auto-lock failed" in payload["title"]
+
+    async def test_no_notification_on_successful_auto_lock(self):
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock.hass.services.async_call = AsyncMock()
+        await lock._auto_lock()
+        notification_calls = [
+            c for c in lock.hass.services.async_call.await_args_list
+            if c.args[:2] == ("persistent_notification", "create")
+        ]
+        assert notification_calls == []

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1288,8 +1288,12 @@ class TestVerisureLockAlarmListener:
 
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         return AlarmState(
             interior=getattr(InteriorMode, i),
             perimeter=getattr(PerimeterMode, p),
@@ -1309,6 +1313,7 @@ class TestVerisureLockAlarmListener:
 
         # Baseline must be recorded as currently TOTAL.
         from custom_components.verisure_owa.const import CIRCUIT_INTERIOR
+
         assert CIRCUIT_INTERIOR in (lock._alarm_baseline or set())
         # And no lock action was attempted.
         # (verified more thoroughly in Task 6; here we just check no crash and
@@ -1318,15 +1323,20 @@ class TestVerisureLockAlarmListener:
     def test_armed_circuits_helper_excludes_off_modes(self):
         from custom_components.verisure_owa.lock import _armed_circuits
         from custom_components.verisure_owa.const import (
-            CIRCUIT_INTERIOR, CIRCUIT_PERIMETER, CIRCUIT_ANNEX,
+            CIRCUIT_INTERIOR,
+            CIRCUIT_PERIMETER,
+            CIRCUIT_ANNEX,
         )
+
         s = self._state(i="OFF", p="ON", a="OFF")
         assert _armed_circuits(s) == {CIRCUIT_PERIMETER}
         s = self._state(i="DAY", p="OFF", a="ON")
         assert _armed_circuits(s) == {CIRCUIT_INTERIOR, CIRCUIT_ANNEX}
         s = self._state(i="TOTAL", p="ON", a="ON")
         assert _armed_circuits(s) == {
-            CIRCUIT_INTERIOR, CIRCUIT_PERIMETER, CIRCUIT_ANNEX
+            CIRCUIT_INTERIOR,
+            CIRCUIT_PERIMETER,
+            CIRCUIT_ANNEX,
         }
         s = self._state()  # all OFF
         assert _armed_circuits(s) == set()
@@ -1348,8 +1358,12 @@ class TestVerisureLockAutoLockOnArm:
 
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         return AlarmState(
             interior=getattr(InteriorMode, i),
             perimeter=getattr(PerimeterMode, p),
@@ -1477,6 +1491,7 @@ class TestVerisureLockAutoLockFailure:
 
     async def test_persistent_notification_created_on_lock_failure(self):
         from custom_components.verisure_owa.verisure_owa_api import VerisureOwaError
+
         lock = make_lock(initial_status="1", poll_status="1")  # stays unlocked
         lock._client.change_lock_mode = AsyncMock(
             side_effect=VerisureOwaError("network down")
@@ -1489,8 +1504,7 @@ class TestVerisureLockAutoLockFailure:
         # Look for a persistent_notification.create call.
         calls = lock.hass.services.async_call.await_args_list
         notification_calls = [
-            c for c in calls
-            if c.args[:2] == ("persistent_notification", "create")
+            c for c in calls if c.args[:2] == ("persistent_notification", "create")
         ]
         assert len(notification_calls) == 1
         payload = notification_calls[0].args[2]
@@ -1503,7 +1517,8 @@ class TestVerisureLockAutoLockFailure:
         lock.hass.services.async_call = AsyncMock()
         await lock._auto_lock()
         notification_calls = [
-            c for c in lock.hass.services.async_call.await_args_list
+            c
+            for c in lock.hass.services.async_call.await_args_list
             if c.args[:2] == ("persistent_notification", "create")
         ]
         assert notification_calls == []
@@ -1519,8 +1534,12 @@ class TestVerisureLockUnlockDisarm:
 
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         return AlarmState(
             interior=getattr(InteriorMode, i),
             perimeter=getattr(PerimeterMode, p),
@@ -1546,12 +1565,15 @@ class TestVerisureLockUnlockDisarm:
 
         # Capture call order.
         order: list[str] = []
+
         async def fake_disarm(circuits):
             order.append("disarm")
             return True
+
         async def fake_change(installation, lock_state, device_id=None):
             order.append("unlock")
             return MagicMock()
+
         lock._combined_alarm_panel.execute_partial_disarm = AsyncMock(
             side_effect=fake_disarm
         )
@@ -1625,8 +1647,12 @@ class TestVerisureLockUnlockDisarmFailure:
 
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode, AnnexMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
+            AnnexMode,
         )
+
         return AlarmState(
             interior=getattr(InteriorMode, i),
             perimeter=getattr(PerimeterMode, p),
@@ -1652,7 +1678,8 @@ class TestVerisureLockUnlockDisarmFailure:
 
         # Notification fired with "Auto-disarm failed" wording.
         notif_calls = [
-            c for c in lock.hass.services.async_call.await_args_list
+            c
+            for c in lock.hass.services.async_call.await_args_list
             if c.args[:2] == ("persistent_notification", "create")
         ]
         assert len(notif_calls) == 1
@@ -1662,10 +1689,9 @@ class TestVerisureLockUnlockDisarmFailure:
 
     async def test_unlock_failure_after_successful_disarm_notifies(self):
         from custom_components.verisure_owa.verisure_owa_api import VerisureOwaError
+
         lock = make_lock(initial_status="2", poll_status="2")  # stays locked
-        lock._client.change_lock_mode = AsyncMock(
-            side_effect=VerisureOwaError("nope")
-        )
+        lock._client.change_lock_mode = AsyncMock(side_effect=VerisureOwaError("nope"))
         lock._unlock_disarms_circuits = ["interior"]
         lock._alarm_coordinator = self._make_alarm_coord(self._state(i="TOTAL"))
         panel = MagicMock()
@@ -1677,7 +1703,8 @@ class TestVerisureLockUnlockDisarmFailure:
 
         # The unlock failed — notification with "Unlock failed" wording.
         notif_calls = [
-            c for c in lock.hass.services.async_call.await_args_list
+            c
+            for c in lock.hass.services.async_call.await_args_list
             if c.args[:2] == ("persistent_notification", "create")
         ]
         assert len(notif_calls) == 1
@@ -1696,7 +1723,8 @@ class TestVerisureLockUnlockDisarmFailure:
         await lock.async_unlock()
 
         notif_calls = [
-            c for c in lock.hass.services.async_call.await_args_list
+            c
+            for c in lock.hass.services.async_call.await_args_list
             if c.args[:2] == ("persistent_notification", "create")
         ]
         assert notif_calls == []
@@ -1714,14 +1742,18 @@ class TestVerisureLockSetupAndTeardown:
         from custom_components.verisure_owa.const import (
             CONF_LOCK_AUTOMATIONS,
         )
+
         lock = make_lock(initial_status="2")
         # Stand in for hass-managed plumbing.
         unsub = MagicMock()
         alarm_coord = MagicMock()
         alarm_coord.async_add_listener = MagicMock(return_value=unsub)
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
         )
+
         alarm_coord.alarm_state = AlarmState(
             interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF
         )
@@ -1737,6 +1769,7 @@ class TestVerisureLockSetupAndTeardown:
             }
         }
         from custom_components.verisure_owa import DOMAIN
+
         lock.hass.data = {
             DOMAIN: {
                 "entry-1": {
@@ -1765,8 +1798,11 @@ class TestVerisureLockSetupAndTeardown:
         alarm_coord = MagicMock()
         alarm_coord.async_add_listener = MagicMock(return_value=lambda: None)
         from custom_components.verisure_owa.verisure_owa_api.models import (
-            AlarmState, InteriorMode, PerimeterMode,
+            AlarmState,
+            InteriorMode,
+            PerimeterMode,
         )
+
         alarm_coord.alarm_state = AlarmState(
             interior=InteriorMode.OFF, perimeter=PerimeterMode.OFF
         )
@@ -1774,6 +1810,7 @@ class TestVerisureLockSetupAndTeardown:
         entry.entry_id = "entry-1"
         entry.options = {}
         from custom_components.verisure_owa import DOMAIN
+
         lock.hass.data = {
             DOMAIN: {
                 "entry-1": {

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -594,7 +594,9 @@ class TestFullImageCapture:
         hub.hass.data = {DOMAIN: {"test_entry": {"camera_coordinator": mock_coord}}}
 
         _tasks = []
-        hub.hass.async_create_task = lambda coro, **_: _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
+        hub.hass.async_create_task = lambda coro, **_: (
+            _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
+        )
 
         with patch(
             "custom_components.verisure_owa.hub.async_dispatcher_send",
@@ -651,7 +653,9 @@ class TestFullImageCapture:
         hub._update_camera_coordinator_full_image = MagicMock()
 
         _tasks = []
-        hub.hass.async_create_task = lambda coro, **_: _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
+        hub.hass.async_create_task = lambda coro, **_: (
+            _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
+        )
 
         with patch(
             "custom_components.verisure_owa.hub.async_dispatcher_send",
@@ -680,7 +684,9 @@ class TestFullImageCapture:
         hub._update_camera_coordinator_full_image = MagicMock()
 
         _tasks = []
-        hub.hass.async_create_task = lambda coro, **_: _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
+        hub.hass.async_create_task = lambda coro, **_: (
+            _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
+        )
 
         with patch(
             "custom_components.verisure_owa.hub.async_dispatcher_send",

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -36,6 +36,10 @@ def make_hub(*, mock_client: bool = True, **config_overrides) -> VerisureHub:
     """
     hass = MagicMock()
     hass.data = {}
+    # Forward async_create_task to asyncio.create_task so coroutines actually
+    # run inside the loop (the production hub uses hass.async_create_task for
+    # tracked task lifecycles).
+    hass.async_create_task = lambda coro, **_kwargs: asyncio.create_task(coro)
     config = {
         "username": "test@example.com",
         "password": "pass",
@@ -590,7 +594,7 @@ class TestFullImageCapture:
         hub.hass.data = {DOMAIN: {"test_entry": {"camera_coordinator": mock_coord}}}
 
         _tasks = []
-        hub.hass.async_create_task = lambda coro: _tasks.append(coro)
+        hub.hass.async_create_task = lambda coro, **_: _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
 
         with patch(
             "custom_components.verisure_owa.hub.async_dispatcher_send",
@@ -647,7 +651,7 @@ class TestFullImageCapture:
         hub._update_camera_coordinator_full_image = MagicMock()
 
         _tasks = []
-        hub.hass.async_create_task = lambda coro: _tasks.append(coro)
+        hub.hass.async_create_task = lambda coro, **_: _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
 
         with patch(
             "custom_components.verisure_owa.hub.async_dispatcher_send",
@@ -676,7 +680,7 @@ class TestFullImageCapture:
         hub._update_camera_coordinator_full_image = MagicMock()
 
         _tasks = []
-        hub.hass.async_create_task = lambda coro: _tasks.append(coro)
+        hub.hass.async_create_task = lambda coro, **_: _tasks.append(asyncio.create_task(coro)) or _tasks[-1]
 
         with patch(
             "custom_components.verisure_owa.hub.async_dispatcher_send",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1065,6 +1065,45 @@ class TestAsyncUpdateOptions:
             await async_update_options(hass, entry)
             mock_reload.assert_awaited_once_with(entry.entry_id)
 
+    async def test_reload_when_lock_automations_changes(self, hass):
+        """Adding per-lock automation config (with all other settings matching)
+        must trigger a config-entry reload so the lock entity's
+        async_added_to_hass re-reads CONF_LOCK_AUTOMATIONS. Without the reload,
+        the auto-lock listener keeps its stale empty circuit lists from the
+        original load and never fires.
+        """
+        from custom_components.verisure_owa.const import CONF_LOCK_AUTOMATIONS
+
+        data = make_config_entry_data()
+        # All non-lock options match data so the existing trigger keys don't
+        # spuriously cause a reload — isolating CONF_LOCK_AUTOMATIONS as the
+        # only differing setting.
+        options = {
+            CONF_CODE: data[CONF_CODE],
+            CONF_CODE_ARM_REQUIRED: data[CONF_CODE_ARM_REQUIRED],
+            CONF_SCAN_INTERVAL: data[CONF_SCAN_INTERVAL],
+            CONF_MAP_HOME: data[CONF_MAP_HOME],
+            CONF_MAP_AWAY: data[CONF_MAP_AWAY],
+            CONF_MAP_NIGHT: data[CONF_MAP_NIGHT],
+            CONF_MAP_CUSTOM: data[CONF_MAP_CUSTOM],
+            CONF_MAP_VACATION: data[CONF_MAP_VACATION],
+            CONF_NOTIFY_GROUP: "",
+            CONF_FORCE_ARM_NOTIFICATIONS: data[CONF_FORCE_ARM_NOTIFICATIONS],
+            CONF_LOCK_AUTOMATIONS: {
+                "01": {"lock_on_arm": ["interior"], "unlock_disarms": ["interior"]}
+            },
+        }
+        entry = MockConfigEntry(domain=DOMAIN, data=data, options=options)
+        entry.add_to_hass(hass)
+
+        with patch.object(
+            hass.config_entries,
+            "async_reload",
+            new_callable=AsyncMock,
+        ) as mock_reload:
+            await async_update_options(hass, entry)
+            mock_reload.assert_awaited_once_with(entry.entry_id)
+
     @pytest.mark.parametrize(
         "toggle_key",
         [


### PR DESCRIPTION
## Summary

Implements issue #449 — optional auto-lock when an alarm circuit is armed, and auto-disarm of configured circuits when the user unlocks via Home Assistant. Per-lock multi-select configuration over `[interior, perimeter, annex]`.

> **⚠️ Stacked on #461.** This PR is rebased on top of `clintongormley:decomposition` (PR #461). The diff currently includes #461's changes; once #461 merges, this PR's diff will reduce to just the autolocking commits (14 commits, prefixed `feat(autolock)` / `fix(autolock)` / `test(autolock)`).

## Behaviour

- **Auto-lock on arm.** Each `VerisureLock` subscribes to its installation's `AlarmCoordinator`. When any configured circuit transitions disarmed → armed (regardless of source — HA, Verisure app, key fob, scripts), the lock fires. OR semantics across the configured circuit list, idempotent against an already-locked state.
- **Disarm-first unlock.** An HA-initiated `async_unlock` / `async_open` first dispatches a single combined disarm covering the configured circuits, then performs the unlock. Door is never open with armed alarm.
- **Failure surfaces.** Persistent notifications for: auto-lock failure (alarm armed, door unlocked), pre-unlock disarm failure (proceeds with unlock), and unlock-after-successful-disarm failure. Stable per-lock notification IDs replace prior failure rather than piling up.
- **Multi-installation.** Combined panels are now stored in `entry_data["combined_alarm_panels"]` keyed by installation number, supporting main + annex setups.

## Configuration

Per-lock options under a new `entry.options[CONF_LOCK_AUTOMATIONS]` key, configured via a new options-flow sub-step (`async_step_lock_automations`). Two multi-select fields per discovered lock:

- **Lock when arming** — circuits whose disarmed→armed transition triggers the lock (OR semantics)
- **Disarm when unlocking** — circuits to disarm before/during the unlock (AND semantics)

## Test plan

- [x] Unit tests added across `tests/test_alarm_panel.py`, `tests/test_ha_platforms.py`, `tests/test_constants.py`, `tests/test_config_flow.py` — full coverage of OR/AND semantics, idempotency, baseline establishment, multi-circuit dedup, all four failure scenarios, options flow rendering and persistence
- [x] Full test suite: `1417 passed, 0 failed`
- [ ] Manual verification on Verisure setup with a smartlock + arming

## Closes

Closes #449