### PR TITLE
ci: add manual release workflow to keep manifest version in sync with tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,11 +32,11 @@ jobs:
 
       - name: Validate version input
         run: |
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Version '$VERSION' is not valid semver (X.Y.Z or X.Y.Z-suffix)." >&2
+          if ! [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Version '$VERSION' must be X.Y.Z or X.Y.Z-suffix with no leading zeros (build metadata not supported)." >&2
             exit 1
           fi
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+          if git show-ref --tags --verify --quiet "refs/tags/v$VERSION"; then
             echo "Tag v$VERSION already exists." >&2
             exit 1
           fi
@@ -73,6 +73,11 @@ jobs:
       - name: Commit, tag, push
         run: |
           git add custom_components/verisure_owa/manifest.json custom_components/securitas/manifest.json
+          if git diff --cached --quiet; then
+            echo "Manifests already at $VERSION — refusing to tag without a release commit." >&2
+            echo "Investigate prior state (hand-edited manifest? partial earlier run?) before re-running." >&2
+            exit 1
+          fi
           git commit -m "chore: release $VERSION"
           git tag -a "v$VERSION" -m "Release $VERSION"
           git push origin "HEAD:$BRANCH"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,19 @@ jobs:
       VERSION: ${{ inputs.version }}
       PRERELEASE: ${{ inputs.prerelease }}
       BRANCH: ${{ github.ref_name }}
+      REF_TYPE: ${{ github.ref_type }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dispatch ref
+        run: |
+          if [ "$REF_TYPE" != "branch" ]; then
+            echo "Workflow must be dispatched from a branch (got $REF_TYPE '$BRANCH'). The bump commit needs a branch to land on." >&2
+            exit 1
+          fi
 
       - name: Validate version input
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 5.1.0 — no leading v)"
+        required: true
+        type: string
+      prerelease:
+        description: "Mark as pre-release"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Bump manifests, tag, and release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      PRERELEASE: ${{ inputs.prerelease }}
+      BRANCH: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version input
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Version '$VERSION' is not valid semver (X.Y.Z or X.Y.Z-suffix)." >&2
+            exit 1
+          fi
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists." >&2
+            exit 1
+          fi
+
+      - name: Bump manifest versions
+        run: |
+          python3 <<'PY'
+          import os, re, sys
+          new_version = os.environ["VERSION"]
+          for path in (
+              "custom_components/verisure_owa/manifest.json",
+              "custom_components/securitas/manifest.json",
+          ):
+              with open(path) as f:
+                  content = f.read()
+              updated, n = re.subn(
+                  r'("version"\s*:\s*)"[^"]+"',
+                  lambda m: m.group(1) + f'"{new_version}"',
+                  content,
+              )
+              if n != 1:
+                  sys.exit(f"Expected exactly one version field in {path}, found {n}")
+              with open(path, "w") as f:
+                  f.write(updated)
+          PY
+          git diff --stat
+          git diff
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit, tag, push
+        run: |
+          git add custom_components/verisure_owa/manifest.json custom_components/securitas/manifest.json
+          git commit -m "chore: release $VERSION"
+          git tag -a "v$VERSION" -m "Release $VERSION"
+          git push origin "HEAD:$BRANCH"
+          git push origin "v$VERSION"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prerelease_flag=""
+          if [ "$PRERELEASE" = "true" ]; then
+            prerelease_flag="--prerelease"
+          fi
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --generate-notes \
+            $prerelease_flag


### PR DESCRIPTION
## Summary
Adds a `workflow_dispatch`-triggered release pipeline at `.github/workflows/release.yaml`. The motivation is that historically the `manifest.json` version has drifted from the release tag; this workflow makes the manifest bump part of the release flow itself, so they cannot drift.

The workflow:
1. Validates the `version` input is semver and that `v<version>` doesn't already exist.
2. Bumps both `custom_components/verisure_owa/manifest.json` and `custom_components/securitas/manifest.json` in lockstep (regex update — formatting preserved).
3. Commits the bump as `chore: release <version>`, tags `v<version>`, and pushes both to the branch the workflow was dispatched from.
4. Creates a GitHub Release at the tag with auto-generated notes (`gh release create --generate-notes`). Optional `prerelease` checkbox.

## How to use

From the **Actions** tab → **Release** → **Run workflow**, dispatch from `main` with the version (e.g. `5.1.0`).

## Caveats

- The workflow pushes a commit to the dispatch branch. If `main` has branch protection requiring PR review, the `github-actions[bot]` push will be blocked — either grant the bot a bypass, or move the bump-commit step to a separate PR-based flow.
- Inputs are routed through `env:` to avoid GHA script injection.

## Test plan
- [ ] Dispatch the workflow from a non-`main` test branch with a throwaway version (e.g. `0.0.1-test`) and verify: manifest commit lands on that branch, tag is created, GitHub Release appears.
- [ ] Delete the test tag/release/commit afterwards.
- [ ] Confirm dispatch fails cleanly when the tag already exists.
- [ ] Confirm dispatch fails cleanly when version is malformed (e.g. `5.1`).