### PR TITLE
feat(alarm): clear stale arming-exception notifications + reliable TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,8 @@ notify:
 
 After a restart, `notify.mobiles` shows up in the dropdown. The action buttons in the notification are scoped to the installation, so any household member who taps **Force Arm** or **Cancel** triggers the right action.
 
+**Don't include `notify.persistent_notification` in the notify group.** The integration already creates its own persistent notification directly. Adding `notify.persistent_notification` to your group will produce a second, duplicate persistent card every time arming is blocked — with no action buttons and a generic body. The integration filters `notify.persistent_notification` out of the **Notify service** dropdown for the same reason; if you build the group in YAML, leave it out yourself.
+
 ## Troubleshooting
 
 - **HTTP 403 errors / rate limiting** — Verisure uses a web application firewall (WAF) that blocks requests if you poll too frequently. The integration retries once automatically, but if you see repeated 403 errors in the logs:

--- a/README.md
+++ b/README.md
@@ -468,15 +468,17 @@ Fires when the 180 s force-arm window expires without the user acting on it. Use
 
 ### The `verisure_owa_arming_exception_dismissed` event
 
-Fires when an active force-arm context is cleared by a *different* arm/disarm action — i.e. the user moved on instead of tapping **Force Arm** or **Cancel**. Does NOT fire from the canonical resolutions (`async_force_arm` / `async_force_arm_cancel`). Useful for dismissing your own custom notifications when the user takes a different action.
+Fires when an active force-arm context is cleared by something other than the user tapping **Force Arm** or **Cancel** — either a different arm/disarm action ("user moved on"), or the integration itself being torn down (options change, reauth, reload) while the context was still alive. Does NOT fire from the canonical resolutions (`async_force_arm` / `async_force_arm_cancel`). Useful for dismissing your own custom notifications when the context goes away involuntarily.
 
 | Field | What it tells you |
 | ----- | ----------------- |
 | `entity_id` | The alarm panel entity that HELD the dismissed context (may differ from the panel the user just interacted with — multi-panel installations are scoped per installation). |
-| `reason` | `"user_arm"` or `"user_disarm"`. |
-| `new_mode` | The state the user is moving to (`armed_home`, `armed_away`, …, or `"disarmed"`). |
+| `reason` | `"user_arm"`, `"user_disarm"`, or `"integration_reload"`. |
+| `new_mode` | The state the user is moving to (`armed_home`, `armed_away`, …, or `"disarmed"`). `null` when `reason == "integration_reload"` — no new mode applies. |
 | `details.installation` | The Verisure installation number. |
 | `_event_id` | UUID for deduplication. |
+
+**Watch out:** automations that match `reason in ['user_arm', 'user_disarm']` will miss the reload case. If you want the broader "context lost" signal, match on the event type alone or include `'integration_reload'`. Automations that read `new_mode.startswith(...)` will fail with an `UndefinedError` on the reload case — guard with `new_mode is not none` first.
 
 ### Writing your own automations
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,31 @@ You then have ~180 seconds to either fix the underlying issue and arm normally, 
 | `details.installation` | The Verisure installation number. |
 | `details.exceptions` | Full exception list from the API (`alias`, `zone_id`, `device_type`). |
 
+### The `verisure_owa_force_arm_expired` event
+
+Fires when the 180 s force-arm window expires without the user acting on it. Useful for sending a follow-up message ("alarm was not armed — please retry") that's distinct from the initial "arming blocked" alert. Fires regardless of the notifications toggle.
+
+| Field | What it tells you |
+| ----- | ----------------- |
+| `entity_id` | The alarm panel entity whose force-arm context expired. |
+| `mode` | The HA state that was originally attempted. |
+| `zones` | Open zone names from the original failure. |
+| `details.installation` | The Verisure installation number. |
+| `details.exceptions` | Full exception list captured at the original failure. |
+| `_event_id` | UUID for deduplication. |
+
+### The `verisure_owa_arming_exception_dismissed` event
+
+Fires when an active force-arm context is cleared by a *different* arm/disarm action — i.e. the user moved on instead of tapping **Force Arm** or **Cancel**. Does NOT fire from the canonical resolutions (`async_force_arm` / `async_force_arm_cancel`). Useful for dismissing your own custom notifications when the user takes a different action.
+
+| Field | What it tells you |
+| ----- | ----------------- |
+| `entity_id` | The alarm panel entity that HELD the dismissed context (may differ from the panel the user just interacted with — multi-panel installations are scoped per installation). |
+| `reason` | `"user_arm"` or `"user_disarm"`. |
+| `new_mode` | The state the user is moving to (`armed_home`, `armed_away`, …, or `"disarmed"`). |
+| `details.installation` | The Verisure installation number. |
+| `_event_id` | UUID for deduplication. |
+
 ### Writing your own automations
 
 Disable **Built-in force-arm notifications** in the integration options, then trigger on the event. The most common pattern is to auto-force-arm only when the user picks Away (because at that point they've left the building):

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -957,12 +957,19 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 continue
             # Fire the public event first (panel attribution), then wipe
             # the panel's context. The integration's own dismissed-event
-            # handler (added in Task 9) clears the shared notification.
+            # handler clears the shared notification.
             panel._fire_arming_exception_dismissed_event(  # noqa: SLF001  # pylint: disable=protected-access
                 reason=reason,
                 new_mode=new_mode,
             )
             panel._clear_force_context()  # noqa: SLF001  # pylint: disable=protected-access
+            # Push the wiped `force_arm_available` / `arm_exceptions`
+            # attributes to HA's state machine on every cleared panel.
+            # `self` will be re-written by the caller's downstream
+            # `set_arm_state` / disarm flow, but siblings have no other
+            # path to refresh and would otherwise display stale
+            # attributes until the next coordinator update.
+            panel.async_write_ha_state()
 
     @property
     def _notifications_enabled(self) -> bool:
@@ -981,8 +988,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
           carry the same payload.
         - ``verisure_owa_force_arm_expired`` — replaces the mobile
           notification with a button-less informational card on TTL
-          expiry. The persistent side is updated by `_notify_force_arm_expired`
-          directly from `_clear_force_context`.
+          expiry. The persistent side is updated directly by
+          `_async_handle_force_arm_expiry` (the TTL timer callback),
+          which fires the event AND calls `_notify_force_arm_expired()`
+          in the same tick.
         - ``verisure_owa_arming_exception_dismissed`` — clears the shared
           installation-scoped persistent + mobile notifications when the
           stale force-arm context is dismissed (e.g. by a new arm/disarm

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -38,6 +38,7 @@ from ..coordinators import AlarmCoordinator, AlarmStatusData
 from ..entity import VerisureEntity
 from ..events import (
     ARMING_EXCEPTION_EVENT_TYPE,
+    FORCE_ARM_EXPIRED_EVENT_TYPE,
     LEGACY_ARMING_EXCEPTION_EVENT_TYPE,
     inject_ha_event,
 )
@@ -758,20 +759,46 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         # Deprecated alias — removed in v6.0.0.
         self.hass.bus.async_fire(LEGACY_ARMING_EXCEPTION_EVENT_TYPE, payload)
 
+    def _fire_force_arm_expired_event(self) -> None:
+        """Fire the verisure_owa_force_arm_expired event from the saved context.
+
+        Must be called BEFORE the context is wiped — derives the payload from
+        the still-live _force_context snapshot.
+        """
+        assert self._force_context is not None, (
+            "_fire_force_arm_expired_event called without a force_context"
+        )
+        exceptions = self._force_context.get("exceptions", [])
+        zones = [e.get("alias", "unknown") for e in exceptions]
+        payload = {
+            "entity_id": self.entity_id,
+            "mode": self._force_context["mode"],
+            "zones": zones,
+            "details": {
+                "installation": self.installation.number,
+                "exceptions": exceptions,
+            },
+            "_event_id": str(uuid.uuid4()),
+        }
+        self.hass.bus.async_fire(FORCE_ARM_EXPIRED_EVENT_TYPE, payload)
+
     _FORCE_ARM_TTL = datetime.timedelta(seconds=180)
 
     def _clear_force_context(self, force: bool = False) -> None:
         """Clear stored force-arm context and related attributes.
 
         When called from coordinator updates (force=False), only clears if
-        the context has aged past _FORCE_ARM_TTL (180s).  On expiry, the
-        notification is updated to inform the user the alarm was not armed.
+        the context has aged past _FORCE_ARM_TTL (180s). On expiry, fires
+        the verisure_owa_force_arm_expired event (regardless of the
+        notification toggle — events are the public API) and, if the
+        built-in handler is enabled, updates the persistent notification.
         """
         if not force and self._force_context is not None:
             age = datetime.datetime.now() - self._force_context["created_at"]
             if age < self._FORCE_ARM_TTL:
                 return
-            # Expired — update notification to inform user
+            # Expired — public event first, then built-in side effects.
+            self._fire_force_arm_expired_event()
             if self._notifications_enabled:
                 self._notify_force_arm_expired()
         self._force_context = None

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import datetime
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, Callable
 import uuid
 
 import homeassistant.components.alarm_control_panel as alarm
@@ -22,6 +22,7 @@ from homeassistant.components.alarm_control_panel.const import AlarmControlPanel
 from homeassistant.const import CONF_CODE, CONF_SCAN_INTERVAL
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .. import (
@@ -179,6 +180,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         # exceptions (e.g. open window).  Consumed on the next arm attempt to
         # override the exception.  Cleared on status refresh.
         self._force_context: dict[str, Any] | None = None
+        self._force_arm_expiry_unsub: Callable[[], None] | None = None
         self._mobile_action_unsub = None
         self._arming_event_unsub_new = None
         self._arming_event_unsub_legacy = None
@@ -216,6 +218,16 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister event listeners when removed from HA."""
+        # Reload-path safety net: if context is still alive at teardown,
+        # the new entity created post-reload would start fresh with no
+        # context. Fire dismissed event so user automations see the loss.
+        if self._force_context is not None:
+            self._fire_arming_exception_dismissed_event(
+                reason="integration_reload",
+                new_mode=None,
+            )
+        # Cancel the expiry timer to avoid late callbacks on a torn-down entity.
+        self._cancel_force_arm_expiry()
         if self._arming_event_unsub_new:
             self._arming_event_unsub_new()
         if self._arming_event_unsub_legacy:
@@ -233,7 +245,6 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         """Handle updated data from coordinator."""
         if self._operation_in_progress:
             return  # Skip stale updates during arm/disarm
-        self._clear_force_context()
         if self.coordinator.data is not None:
             self._update_from_coordinator(self.coordinator.data)
         self.async_write_ha_state()
@@ -749,6 +760,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             e.get("alias", "unknown") for e in exc.exceptions
         ]
         self._attr_extra_state_attributes["force_arm_available"] = True
+        self._schedule_force_arm_expiry()
 
     def _fire_arming_exception_event(
         self, exc: ArmingExceptionError, mode: str
@@ -798,13 +810,17 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self.hass.bus.async_fire(FORCE_ARM_EXPIRED_EVENT_TYPE, payload)
 
     def _fire_arming_exception_dismissed_event(
-        self, *, reason: str, new_mode: str
+        self, *, reason: str, new_mode: str | None
     ) -> None:
         """Fire the verisure_owa_arming_exception_dismissed event.
 
         Caller is the panel that HELD the dismissed context (so payload
         entity_id is self.entity_id), even if the action that triggered
         the dismissal originated on a sibling panel.
+
+        ``new_mode`` is None when the dismissal is triggered by entity
+        teardown (reason="integration_reload") — at that point there is
+        no new mode being targeted, the entity is simply being removed.
         """
         payload = {
             "entity_id": self.entity_id,
@@ -817,23 +833,56 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
 
     _FORCE_ARM_TTL = datetime.timedelta(seconds=180)
 
-    def _clear_force_context(self, force: bool = False) -> None:
-        """Clear stored force-arm context and related attributes.
+    def _schedule_force_arm_expiry(self) -> None:
+        """Schedule the TTL-driven expiry callback.
 
-        When called from coordinator updates (force=False), only clears if
-        the context has aged past _FORCE_ARM_TTL (180s). On expiry, fires
-        the verisure_owa_force_arm_expired event (regardless of the
-        notification toggle — events are the public API) and, if the
-        built-in handler is enabled, updates the persistent notification.
+        Replaces the previous coordinator-update-driven TTL check, which
+        was unreliable: HA's DataUpdateCoordinator does not call its
+        listeners on consecutive failures, so a sustained API outage
+        starting before the TTL would miss the expiry event entirely.
         """
-        if not force and self._force_context is not None:
-            age = datetime.datetime.now() - self._force_context["created_at"]
-            if age < self._FORCE_ARM_TTL:
-                return
-            # Expired — public event first, then built-in side effects.
-            self._fire_force_arm_expired_event()
-            if self._notifications_enabled:
-                self._notify_force_arm_expired()
+        self._cancel_force_arm_expiry()
+        self._force_arm_expiry_unsub = async_call_later(
+            self.hass,
+            self._FORCE_ARM_TTL.total_seconds(),
+            self._async_handle_force_arm_expiry,
+        )
+
+    def _cancel_force_arm_expiry(self) -> None:
+        """Cancel any pending expiry timer (no-op if not scheduled)."""
+        if self._force_arm_expiry_unsub is not None:
+            self._force_arm_expiry_unsub()
+            self._force_arm_expiry_unsub = None
+
+    async def _async_handle_force_arm_expiry(self, _now: datetime.datetime) -> None:
+        """Timer callback: fire expired event + side effects if context still alive.
+
+        The timer fires exactly _FORCE_ARM_TTL after _set_force_context,
+        independent of coordinator state. If the context was already cleared
+        by the canonical resolution paths (force_arm, force_arm_cancel,
+        dismissal), this callback no-ops.
+        """
+        self._force_arm_expiry_unsub = None
+        if self._force_context is None:
+            return
+        self._fire_force_arm_expired_event()
+        if self._notifications_enabled:
+            self._notify_force_arm_expired()
+        self._force_context = None
+        self._attr_extra_state_attributes.pop("arm_exceptions", None)
+        self._attr_extra_state_attributes.pop("force_arm_available", None)
+        self.async_write_ha_state()
+
+    def _clear_force_context(self, force: bool = False) -> None:
+        """Cancel any pending TTL timer and wipe force-arm context attributes.
+
+        The ``force`` parameter is retained for backwards-compat with
+        existing call sites but is now a no-op — the wipe is unconditional.
+        TTL-driven expiry is handled by ``_async_handle_force_arm_expiry``
+        scheduled in ``_set_force_context``.
+        """
+        del force  # backwards-compat; wipe is now unconditional
+        self._cancel_force_arm_expiry()
         self._force_context = None
         self._attr_extra_state_attributes.pop("arm_exceptions", None)
         self._attr_extra_state_attributes.pop("force_arm_available", None)

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -879,11 +879,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
 
         Each panel that held a context is attributed in its own dismissed
         event with its own entity_id; typically only zero or one panel
-        holds context at any time. Events are fired via the shared
-        ``hass.bus`` directly (rather than delegating through each panel's
-        ``_fire_arming_exception_dismissed_event``) so that the helper
-        works against sibling panels regardless of how they're wired —
-        the per-panel ``entity_id`` in the payload carries the attribution.
+        holds context at any time.
         """
         for panel in self._siblings_on_installation():
             if panel._force_context is None:  # noqa: SLF001  # pylint: disable=protected-access
@@ -891,14 +887,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             # Fire the public event first (panel attribution), then wipe
             # the panel's context. The integration's own dismissed-event
             # handler (added in Task 9) clears the shared notification.
-            payload = {
-                "entity_id": panel.entity_id,
-                "reason": reason,
-                "new_mode": new_mode,
-                "details": {"installation": panel.installation.number},
-                "_event_id": str(uuid.uuid4()),
-            }
-            panel.hass.bus.async_fire(ARMING_EXCEPTION_DISMISSED_EVENT_TYPE, payload)
+            panel._fire_arming_exception_dismissed_event(  # noqa: SLF001  # pylint: disable=protected-access
+                reason=reason,
+                new_mode=new_mode,
+            )
             panel._clear_force_context(force=True)  # noqa: SLF001  # pylint: disable=protected-access
 
     @property

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -37,6 +37,7 @@ from ..const import CIRCUIT_ANNEX, CIRCUIT_INTERIOR, CIRCUIT_PERIMETER
 from ..coordinators import AlarmCoordinator, AlarmStatusData
 from ..entity import VerisureEntity
 from ..events import (
+    ARMING_EXCEPTION_DISMISSED_EVENT_TYPE,
     ARMING_EXCEPTION_EVENT_TYPE,
     FORCE_ARM_EXPIRED_EVENT_TYPE,
     LEGACY_ARMING_EXCEPTION_EVENT_TYPE,
@@ -785,6 +786,24 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         }
         self.hass.bus.async_fire(FORCE_ARM_EXPIRED_EVENT_TYPE, payload)
 
+    def _fire_arming_exception_dismissed_event(
+        self, *, reason: str, new_mode: str
+    ) -> None:
+        """Fire the verisure_owa_arming_exception_dismissed event.
+
+        Caller is the panel that HELD the dismissed context (so payload
+        entity_id is self.entity_id), even if the action that triggered
+        the dismissal originated on a sibling panel.
+        """
+        payload = {
+            "entity_id": self.entity_id,
+            "reason": reason,
+            "new_mode": new_mode,
+            "details": {"installation": self.installation.number},
+            "_event_id": str(uuid.uuid4()),
+        }
+        self.hass.bus.async_fire(ARMING_EXCEPTION_DISMISSED_EVENT_TYPE, payload)
+
     _FORCE_ARM_TTL = datetime.timedelta(seconds=180)
 
     def _clear_force_context(self, force: bool = False) -> None:
@@ -846,6 +865,41 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         if self not in siblings:
             siblings.append(self)
         return siblings
+
+    async def _dismiss_pending_force_context_on_siblings(
+        self, *, reason: str, new_mode: str
+    ) -> None:
+        """For every panel on this installation that has an active force-arm
+        context, fire the dismissed event and clear the context.
+
+        Called from the regular arm/disarm entry points (`_async_arm`,
+        `async_alarm_disarm`) BEFORE the new operation dispatches, so the
+        user sees stale notifications vanish immediately even if the new
+        operation fails.
+
+        Each panel that held a context is attributed in its own dismissed
+        event with its own entity_id; typically only zero or one panel
+        holds context at any time. Events are fired via the shared
+        ``hass.bus`` directly (rather than delegating through each panel's
+        ``_fire_arming_exception_dismissed_event``) so that the helper
+        works against sibling panels regardless of how they're wired —
+        the per-panel ``entity_id`` in the payload carries the attribution.
+        """
+        for panel in self._siblings_on_installation():
+            if panel._force_context is None:  # noqa: SLF001  # pylint: disable=protected-access
+                continue
+            # Fire the public event first (panel attribution), then wipe
+            # the panel's context. The integration's own dismissed-event
+            # handler (added in Task 9) clears the shared notification.
+            payload = {
+                "entity_id": panel.entity_id,
+                "reason": reason,
+                "new_mode": new_mode,
+                "details": {"installation": panel.installation.number},
+                "_event_id": str(uuid.uuid4()),
+            }
+            panel.hass.bus.async_fire(ARMING_EXCEPTION_DISMISSED_EVENT_TYPE, payload)
+            panel._clear_force_context(force=True)  # noqa: SLF001  # pylint: disable=protected-access
 
     @property
     def _notifications_enabled(self) -> bool:

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -41,8 +41,12 @@ from ..entity import VerisureEntity
 from ..events import (
     ARMING_EXCEPTION_DISMISSED_EVENT_TYPE,
     ARMING_EXCEPTION_EVENT_TYPE,
+    DISMISSAL_REASON_INTEGRATION_RELOAD,
+    DISMISSAL_REASON_USER_ARM,
+    DISMISSAL_REASON_USER_DISARM,
     FORCE_ARM_EXPIRED_EVENT_TYPE,
     LEGACY_ARMING_EXCEPTION_EVENT_TYPE,
+    DismissalReason,
     inject_ha_event,
 )
 from ..notification_translations import get_notification_strings
@@ -224,7 +228,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         # context. Fire dismissed event so user automations see the loss.
         if self._force_context is not None:
             self._fire_arming_exception_dismissed_event(
-                reason="integration_reload",
+                reason=DISMISSAL_REASON_INTEGRATION_RELOAD,
                 new_mode=None,
             )
         # Cancel the expiry timer to avoid late callbacks on a torn-down entity.
@@ -413,7 +417,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         """Arm the alarm in the specified mode."""
         if self._check_code_for_arm_if_required(code):
             await self._dismiss_pending_force_context_on_siblings(
-                reason="user_arm",
+                reason=DISMISSAL_REASON_USER_ARM,
                 new_mode=state,
             )
             self._force_state(AlarmControlPanelState.ARMING)
@@ -611,7 +615,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         if not self._check_code(code):
             return
         await self._dismiss_pending_force_context_on_siblings(
-            reason="user_disarm",
+            reason=DISMISSAL_REASON_USER_DISARM,
             new_mode="disarmed",
         )
         # Capture the calling user's context up-front — HA expires
@@ -811,7 +815,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self.hass.bus.async_fire(FORCE_ARM_EXPIRED_EVENT_TYPE, payload)
 
     def _fire_arming_exception_dismissed_event(
-        self, *, reason: str, new_mode: str | None
+        self, *, reason: DismissalReason, new_mode: str | None
     ) -> None:
         """Fire the verisure_owa_arming_exception_dismissed event.
 
@@ -869,9 +873,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._fire_force_arm_expired_event()
         if self._notifications_enabled:
             self._notify_force_arm_expired()
-        self._force_context = None
-        self._attr_extra_state_attributes.pop("arm_exceptions", None)
-        self._attr_extra_state_attributes.pop("force_arm_available", None)
+        self._wipe_force_arm_state()
         self.async_write_ha_state()
 
     def _clear_force_context(self) -> None:
@@ -883,6 +885,15 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         (force_arm, force_arm_cancel, sibling dismissal).
         """
         self._cancel_force_arm_expiry()
+        self._wipe_force_arm_state()
+
+    def _wipe_force_arm_state(self) -> None:
+        """Clear the in-memory force-arm context dict and its public attributes.
+
+        Shared by the timer expiry path and the canonical-resolution clear
+        path so both stay in lock-step when new force-arm-related entity
+        attributes get added.
+        """
         self._force_context = None
         self._attr_extra_state_attributes.pop("arm_exceptions", None)
         self._attr_extra_state_attributes.pop("force_arm_available", None)
@@ -927,7 +938,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         return siblings
 
     async def _dismiss_pending_force_context_on_siblings(
-        self, *, reason: str, new_mode: str
+        self, *, reason: DismissalReason, new_mode: str
     ) -> None:
         """For every panel on this installation that has an active force-arm
         context, fire the dismissed event and clear the context.

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -181,6 +181,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._mobile_action_unsub = None
         self._arming_event_unsub_new = None
         self._arming_event_unsub_legacy = None
+        self._force_arm_expired_event_unsub = None
         self._last_handled_event_id: str | None = None
 
     async def async_added_to_hass(self) -> None:
@@ -217,6 +218,8 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._arming_event_unsub_new()
         if self._arming_event_unsub_legacy:
             self._arming_event_unsub_legacy()
+        if self._force_arm_expired_event_unsub:
+            self._force_arm_expired_event_unsub()
         if self._mobile_action_unsub:
             self._mobile_action_unsub()
         await super().async_will_remove_from_hass()
@@ -826,10 +829,17 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
     def _register_arming_exception_handler(self) -> None:
         """Register event listeners for built-in arming exception notifications.
 
-        Listens to both the new verisure_owa_arming_exception and the legacy
-        securitas_arming_exception events. Deduplicates via _event_id so the
-        handler fires at most once per arming exception even though both events
-        carry the same payload.
+        Listens to:
+        - ``verisure_owa_arming_exception`` (canonical) — sends initial
+          persistent + mobile notifications with action buttons.
+        - ``securitas_arming_exception`` — deprecated alias of the above,
+          removed in v6.0.0. Deduplicated via _event_id so the handler
+          fires at most once per arming exception even though both events
+          carry the same payload.
+        - ``verisure_owa_force_arm_expired`` — replaces the mobile
+          notification with a button-less informational card on TTL
+          expiry. The persistent side is updated by `_notify_force_arm_expired`
+          directly from `_clear_force_context`.
         """
 
         @callback
@@ -843,6 +853,20 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._last_handled_event_id = eid
             self._notify_arm_exceptions_from_event(event)
 
+        @callback
+        def _handle_force_arm_expired_event(event: Event) -> None:
+            """Handle force-arm-expired event for this entity."""
+            if event.data.get("entity_id") != self.entity_id:
+                return
+            eid = event.data.get("_event_id")
+            # Reuse the same dedup slot — the same event_id can only ever
+            # describe one transition, never both an arming exception AND
+            # an expiry, so collisions are not possible in practice.
+            if eid is not None and eid == self._last_handled_event_id:
+                return
+            self._last_handled_event_id = eid
+            self._notify_force_arm_expired_mobile_from_event(event)
+
         self._arming_event_unsub_new = self.hass.bus.async_listen(
             ARMING_EXCEPTION_EVENT_TYPE,
             _handle_arming_exception_event,
@@ -850,6 +874,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._arming_event_unsub_legacy = self.hass.bus.async_listen(
             LEGACY_ARMING_EXCEPTION_EVENT_TYPE,
             _handle_arming_exception_event,
+        )
+        self._force_arm_expired_event_unsub = self.hass.bus.async_listen(
+            FORCE_ARM_EXPIRED_EVENT_TYPE,
+            _handle_force_arm_expired_event,
         )
 
     def _notify_arm_exceptions_from_event(self, event: Event) -> None:
@@ -915,6 +943,48 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                     },
                 },
             )
+
+    async def _async_notify_force_arm_expired_mobile(self, event: Event) -> None:
+        """Replace the mobile arming-exception notification with a button-less
+        informational card when the force-arm window expires.
+
+        Same `tag` as the original notification (so iOS/Android updates the
+        existing card in place rather than stacking a new one). No `actions`
+        array — the buttons are removed.
+
+        No-ops when notifications are disabled or no notify_group is configured.
+        Per-entity scoped: ignores events whose entity_id is not ours.
+        """
+        if event.data.get("entity_id") != self.entity_id:
+            return
+        if not self._notifications_enabled:
+            return
+        notify_group = self.client.config.get(CONF_NOTIFY_GROUP)
+        if not notify_group:
+            return
+
+        entry = get_notification_strings(self.hass, "force_arm_expired")
+        title = entry.get("title", "")
+        # Fall back to message if mobile_message is missing — defensive against
+        # partial translation data; existing tests assert mobile_message is
+        # present in every locale we ship, but a future locale might lag.
+        mobile_message = entry.get("mobile_message") or entry.get("message", "")
+
+        await self.hass.services.async_call(
+            domain="notify",
+            service=notify_group,
+            service_data={
+                "title": title,
+                "message": mobile_message,
+                "data": {
+                    "tag": self._arming_exception_notification_id,
+                },
+            },
+        )
+
+    def _notify_force_arm_expired_mobile_from_event(self, event: Event) -> None:
+        """Schedule the async expiry-mobile-notify on the HA loop."""
+        self.hass.async_create_task(self._async_notify_force_arm_expired_mobile(event))
 
     def _dismiss_arming_exception_notification(self) -> None:
         """Dismiss the persistent and mobile arming-exception notifications."""

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -397,6 +397,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
     ) -> None:
         """Arm the alarm in the specified mode."""
         if self._check_code_for_arm_if_required(code):
+            await self._dismiss_pending_force_context_on_siblings(
+                reason="user_arm",
+                new_mode=state,
+            )
             self._force_state(AlarmControlPanelState.ARMING)
             await self.set_arm_state(state)
 
@@ -591,6 +595,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         """Send disarm command."""
         if not self._check_code(code):
             return
+        await self._dismiss_pending_force_context_on_siblings(
+            reason="user_disarm",
+            new_mode="disarmed",
+        )
         # Capture the calling user's context up-front — HA expires
         # `self._context` ~1 s after async_set_context, and the disarm
         # transition + state writes below take longer than that.

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -7,10 +7,11 @@ inherit the bulk of their behaviour from BaseVerisureOwaAlarmPanel here.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import datetime
 from datetime import timedelta
 import logging
-from typing import Any, Callable
+from typing import Any
 import uuid
 
 import homeassistant.components.alarm_control_panel as alarm
@@ -844,7 +845,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._cancel_force_arm_expiry()
         self._force_arm_expiry_unsub = async_call_later(
             self.hass,
-            self._FORCE_ARM_TTL.total_seconds(),
+            self._FORCE_ARM_TTL,
             self._async_handle_force_arm_expiry,
         )
 
@@ -873,15 +874,14 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._attr_extra_state_attributes.pop("force_arm_available", None)
         self.async_write_ha_state()
 
-    def _clear_force_context(self, force: bool = False) -> None:
+    def _clear_force_context(self) -> None:
         """Cancel any pending TTL timer and wipe force-arm context attributes.
 
-        The ``force`` parameter is retained for backwards-compat with
-        existing call sites but is now a no-op — the wipe is unconditional.
         TTL-driven expiry is handled by ``_async_handle_force_arm_expiry``
-        scheduled in ``_set_force_context``.
+        scheduled in ``_set_force_context``; this method just performs the
+        unconditional wipe used by the canonical resolution paths
+        (force_arm, force_arm_cancel, sibling dismissal).
         """
-        del force  # backwards-compat; wipe is now unconditional
         self._cancel_force_arm_expiry()
         self._force_context = None
         self._attr_extra_state_attributes.pop("arm_exceptions", None)
@@ -951,7 +951,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 reason=reason,
                 new_mode=new_mode,
             )
-            panel._clear_force_context(force=True)  # noqa: SLF001  # pylint: disable=protected-access
+            panel._clear_force_context()  # noqa: SLF001  # pylint: disable=protected-access
 
     @property
     def _notifications_enabled(self) -> bool:
@@ -1182,7 +1182,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             )
             return
         _LOGGER.info("Force-arm cancelled by user")
-        self._clear_force_context(force=True)
+        self._clear_force_context()
         if self._notifications_enabled:
             self._dismiss_arming_exception_notification()
         self.async_write_ha_state()
@@ -1223,7 +1223,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             "Force-arming: overriding previous exceptions %s",
             [e.get("alias") for e in bypassed],
         )
-        self._clear_force_context(force=True)
+        self._clear_force_context()
         if self._notifications_enabled:
             self._dismiss_arming_exception_notification()
         self._force_state(AlarmControlPanelState.ARMING)

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -821,6 +821,32 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         """Return a per-installation persistent-notification ID."""
         return f"{DOMAIN}.arming_exception_{self.installation.number}"
 
+    def _siblings_on_installation(self) -> list[BaseVerisureOwaAlarmPanel]:
+        """Return all alarm panels (combined + sub-panels) for this installation.
+
+        Walks ``hass.data[DOMAIN]`` config-entry buckets — each entry's
+        ``combined_alarm_panels`` and ``axis_alarm_panels`` are populated by
+        ``alarm_control_panel.__init__.async_setup_entry``.
+
+        Always includes ``self``. Returns ``[self]`` if entry data is missing
+        (defensive — early registration paths or test scaffolding may not
+        have populated the buckets yet).
+        """
+        inst_num = self.installation.number
+        siblings: list[BaseVerisureOwaAlarmPanel] = []
+        domain_data = self.hass.data.get(DOMAIN, {})
+        for entry_data in domain_data.values():
+            if not isinstance(entry_data, dict):
+                continue
+            combined = entry_data.get("combined_alarm_panels", {}).get(inst_num)
+            if combined is not None:
+                siblings.append(combined)
+            axis_panels = entry_data.get("axis_alarm_panels", {}).get(inst_num, {})
+            siblings.extend(axis_panels.values())
+        if self not in siblings:
+            siblings.append(self)
+        return siblings
+
     @property
     def _notifications_enabled(self) -> bool:
         """Return True if the built-in force-arm notification handler is active."""

--- a/custom_components/verisure_owa/alarm_control_panel/_base.py
+++ b/custom_components/verisure_owa/alarm_control_panel/_base.py
@@ -183,6 +183,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._arming_event_unsub_new = None
         self._arming_event_unsub_legacy = None
         self._force_arm_expired_event_unsub = None
+        self._arming_exception_dismissed_event_unsub = None
         self._last_handled_event_id: str | None = None
 
     async def async_added_to_hass(self) -> None:
@@ -221,6 +222,8 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._arming_event_unsub_legacy()
         if self._force_arm_expired_event_unsub:
             self._force_arm_expired_event_unsub()
+        if self._arming_exception_dismissed_event_unsub:
+            self._arming_exception_dismissed_event_unsub()
         if self._mobile_action_unsub:
             self._mobile_action_unsub()
         await super().async_will_remove_from_hass()
@@ -920,6 +923,13 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
           notification with a button-less informational card on TTL
           expiry. The persistent side is updated by `_notify_force_arm_expired`
           directly from `_clear_force_context`.
+        - ``verisure_owa_arming_exception_dismissed`` — clears the shared
+          installation-scoped persistent + mobile notifications when the
+          stale force-arm context is dismissed (e.g. by a new arm/disarm
+          on this or a sibling panel). Does NOT use the `_last_handled_event_id`
+          dedup slot — dismissed events have unique `_event_id`s by
+          construction and must not clobber the dedup slot used by
+          arming-exception/expiry events.
         """
 
         @callback
@@ -947,6 +957,19 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._last_handled_event_id = eid
             self._notify_force_arm_expired_mobile_from_event(event)
 
+        @callback
+        def _handle_arming_exception_dismissed_event(event: Event) -> None:
+            """Handle dismissed event for this entity by clearing notifications."""
+            if event.data.get("entity_id") != self.entity_id:
+                return
+            # The notifications-enabled gate lives in async_added_to_hass at
+            # registration time; if we got here, the toggle was True. But the
+            # config can change at runtime via the options flow, so re-check
+            # before doing the dismiss work.
+            if not self._notifications_enabled:
+                return
+            self._dismiss_arming_exception_notification()
+
         self._arming_event_unsub_new = self.hass.bus.async_listen(
             ARMING_EXCEPTION_EVENT_TYPE,
             _handle_arming_exception_event,
@@ -958,6 +981,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._force_arm_expired_event_unsub = self.hass.bus.async_listen(
             FORCE_ARM_EXPIRED_EVENT_TYPE,
             _handle_force_arm_expired_event,
+        )
+        self._arming_exception_dismissed_event_unsub = self.hass.bus.async_listen(
+            ARMING_EXCEPTION_DISMISSED_EVENT_TYPE,
+            _handle_arming_exception_dismissed_event,
         )
 
     def _notify_arm_exceptions_from_event(self, event: Event) -> None:

--- a/custom_components/verisure_owa/config_flow.py
+++ b/custom_components/verisure_owa/config_flow.py
@@ -82,7 +82,14 @@ VERSION = 4
 
 _LOGGER = logging.getLogger(__name__)
 
-_NOTIFY_EXCLUDE = {"notify", "send_message"}
+# Services that should not appear in the Notify-service dropdown.
+# - `notify` / `send_message`: aliases of the legacy generic notify service;
+#   not useful as a routing target.
+# - `persistent_notification`: the integration already creates its own
+#   persistent notification directly via the `persistent_notification` domain.
+#   Routing via `notify.persistent_notification` would produce a duplicate
+#   card with no actions and no useful body and never reach a real device.
+_NOTIFY_EXCLUDE = {"notify", "send_message", "persistent_notification"}
 
 PANEL_OPTION_KEYS = (
     CONF_ENABLE_PERIMETER_PANEL,

--- a/custom_components/verisure_owa/events.py
+++ b/custom_components/verisure_owa/events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Callable
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from homeassistant.core import Context, HomeAssistant
 
@@ -37,6 +37,14 @@ FORCE_ARM_EXPIRED_EVENT_TYPE = "verisure_owa_force_arm_expired"
 # those are the canonical resolutions). Built-in handler dismisses the
 # persistent + mobile notifications.
 ARMING_EXCEPTION_DISMISSED_EVENT_TYPE = "verisure_owa_arming_exception_dismissed"
+
+# Closed set of `reason` values for the dismissed event. Kept as
+# constants so callers can't typo a string and silently break user
+# automations that match the documented values.
+DISMISSAL_REASON_USER_ARM = "user_arm"
+DISMISSAL_REASON_USER_DISARM = "user_disarm"
+DISMISSAL_REASON_INTEGRATION_RELOAD = "integration_reload"
+DismissalReason = Literal["user_arm", "user_disarm", "integration_reload"]
 
 # Display name attributed to synthetic events when the triggering HA call
 # carries no user_id (automation/script-driven actions).

--- a/custom_components/verisure_owa/events.py
+++ b/custom_components/verisure_owa/events.py
@@ -27,6 +27,17 @@ ARMING_EXCEPTION_EVENT_TYPE = "verisure_owa_arming_exception"
 # Deprecated alias — fires alongside the canonical event, removed in v6.0.0.
 LEGACY_ARMING_EXCEPTION_EVENT_TYPE = "securitas_arming_exception"
 
+# Fired when the force-arm context times out (180 s) without the user
+# acting on the action buttons. Built-in handler updates the mobile
+# notification to remove its action buttons.
+FORCE_ARM_EXPIRED_EVENT_TYPE = "verisure_owa_force_arm_expired"
+
+# Fired when an active force-arm context is cleared by a different
+# arm/disarm action (NOT by force_arm or force_arm_cancel themselves —
+# those are the canonical resolutions). Built-in handler dismisses the
+# persistent + mobile notifications.
+ARMING_EXCEPTION_DISMISSED_EVENT_TYPE = "verisure_owa_arming_exception_dismissed"
+
 # Display name attributed to synthetic events when the triggering HA call
 # carries no user_id (automation/script-driven actions).
 _HA_USER = "Home Assistant"

--- a/custom_components/verisure_owa/notification_translations.py
+++ b/custom_components/verisure_owa/notification_translations.py
@@ -59,8 +59,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
             "message": (
                 "Arming was blocked because the following sensor(s) are open:\n"
                 "{sensor_list}\n\n"
-                "To arm anyway, tap **Force Arm** on the alarm card "
-                "or on your mobile notification."
+                "To arm anyway, tap **Force Arm** on the alarm card."
             ),
             "mobile_message": (
                 "Arm blocked — open sensor(s): {sensor_list}. Arm anyway?"
@@ -128,7 +127,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "El armado se bloqueó porque los siguientes sensores están "
                 "abiertos:\n{sensor_list}\n\n"
                 "Para armar de todos modos, pulsa **Armar de todos modos** en "
-                "la tarjeta de la alarma o en tu notificación móvil."
+                "la tarjeta de la alarma."
             ),
             "mobile_message": (
                 "Armado bloqueado — sensor(es) abierto(s): {sensor_list}. "
@@ -197,7 +196,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "L'armement a été bloqué car les capteurs suivants sont "
                 "ouverts :\n{sensor_list}\n\n"
                 "Pour armer quand même, appuyez sur **Armer quand même** sur "
-                "la carte d'alarme ou sur votre notification mobile."
+                "la carte d'alarme."
             ),
             "mobile_message": (
                 "Armement bloqué — capteur(s) ouvert(s) : {sensor_list}. "
@@ -266,7 +265,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "L'attivazione è stata bloccata perché i seguenti sensori "
                 "sono aperti:\n{sensor_list}\n\n"
                 "Per attivare comunque, tocca **Attiva comunque** sulla card "
-                "dell'allarme o sulla tua notifica mobile."
+                "dell'allarme."
             ),
             "mobile_message": (
                 "Attivazione bloccata — sensore(i) aperto(i): {sensor_list}. "
@@ -335,7 +334,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "O armar foi bloqueado porque os seguintes sensores estão "
                 "abertos:\n{sensor_list}\n\n"
                 "Para armar na mesma, toque em **Armar na mesma** no cartão "
-                "do alarme ou na sua notificação móvel."
+                "do alarme."
             ),
             "mobile_message": (
                 "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. Armar na mesma?"
@@ -403,7 +402,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "Armar foi bloqueado porque os seguintes sensores estão "
                 "abertos:\n{sensor_list}\n\n"
                 "Para armar mesmo assim, toque em **Forçar armado** no cartão "
-                "do alarme ou na sua notificação móvel."
+                "do alarme."
             ),
             "mobile_message": (
                 "Armar bloqueado — sensor(es) aberto(s): {sensor_list}. "
@@ -472,7 +471,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "L'armat s'ha bloquejat perquè els següents sensors estan "
                 "oberts:\n{sensor_list}\n\n"
                 "Per armar igualment, toca **Forçar armat** a la targeta de "
-                "l'alarma o a la teva notificació mòbil."
+                "l'alarma."
             ),
             "mobile_message": (
                 "Armat bloquejat — sensor(s) obert(s): {sensor_list}. Armar igualment?"

--- a/custom_components/verisure_owa/notification_translations.py
+++ b/custom_components/verisure_owa/notification_translations.py
@@ -53,6 +53,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "The force-arm option has expired. The alarm was **not armed**. "
                 "Please try arming again."
             ),
+            "mobile_message": ("Force-arm window expired. The alarm was not armed."),
         },
         "arm_blocked_open_sensors": {
             "title": "Verisure: Arm blocked — open sensor(s)",
@@ -120,6 +121,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "La opción de armado forzado ha expirado. La alarma **no** se "
                 "armó. Por favor, intenta armar de nuevo."
             ),
+            "mobile_message": ("El armado forzado ha expirado. La alarma no se armó."),
         },
         "arm_blocked_open_sensors": {
             "title": "Verisure: Armado bloqueado — sensor(es) abierto(s)",
@@ -188,6 +190,9 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
             "message": (
                 "L'option d'armement forcé a expiré. "
                 "L'alarme **n'a pas** été armée. Veuillez réessayer."
+            ),
+            "mobile_message": (
+                "L'armement forcé a expiré. L'alarme n'a pas été armée."
             ),
         },
         "arm_blocked_open_sensors": {
@@ -258,6 +263,9 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "L'opzione di attivazione forzata è scaduta. "
                 "L'allarme **non** è stato attivato. Riprova ad attivarlo."
             ),
+            "mobile_message": (
+                "L'attivazione forzata è scaduta. L'allarme non è stato attivato."
+            ),
         },
         "arm_blocked_open_sensors": {
             "title": "Verisure: Attivazione bloccata — sensore(i) aperto(i)",
@@ -327,6 +335,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "A opção de armar à força expirou. "
                 "O alarme **não** foi armado. Tente armar novamente."
             ),
+            "mobile_message": ("Armar à força expirou. O alarme não foi armado."),
         },
         "arm_blocked_open_sensors": {
             "title": "Verisure: Armar bloqueado — sensor(es) aberto(s)",
@@ -395,6 +404,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "A opção de forçar armado expirou. "
                 "O alarme **não** foi armado. Tente armar novamente."
             ),
+            "mobile_message": ("Forçar armado expirou. O alarme não foi armado."),
         },
         "arm_blocked_open_sensors": {
             "title": "Verisure: Armar bloqueado — sensor(es) aberto(s)",
@@ -464,6 +474,7 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
                 "L'opció d'armat forçat ha expirat. "
                 "L'alarma **no** s'ha armat. Si us plau, torna a provar a armar."
             ),
+            "mobile_message": ("L'armat forçat ha expirat. L'alarma no s'ha armat."),
         },
         "arm_blocked_open_sensors": {
             "title": "Verisure: Armat bloquejat — sensor(s) obert(s)",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -453,13 +453,13 @@ On `async_setup_entry`, the combined panel is stored in `entry_data["combined_al
 ```
 force_arm:
   1. Read stored reference_id, suid, mode from _force_context
-  2. _clear_force_context(force=True)
+  2. _clear_force_context()  — cancels TTL timer + wipes context dict + attrs
   3. _dismiss_arming_exception_notification() (if notifications enabled)
   4. set_arm_state(mode, force_arming_remote_id=ref_id, suid=suid)
      → API accepts force params and overrides the open-sensor exceptions
 
 force_arm_cancel:
-  1. _clear_force_context(force=True)
+  1. _clear_force_context()
   2. _dismiss_arming_exception_notification() (if notifications enabled)
   3. async_write_ha_state()
 
@@ -468,7 +468,7 @@ Mobile notification actions (when built-in handler enabled):
   - SECURITAS_CANCEL_FORCE_ARM_<num> → _clear_force_context() + write state
 ```
 
-**Force-arm context expiry:** The force-arm context has a 180-second TTL (`_FORCE_ARM_TTL`). When `_clear_force_context()` is called by a coordinator update and the context has aged past the TTL, it is cleared. If the built-in notification handler is enabled, a persistent notification is shown explaining the force-arm option has expired. This prevents stale force-arm contexts from being used after the panel has moved on.
+**Force-arm context expiry:** The force-arm context has a 180-second TTL (`_FORCE_ARM_TTL`). Expiry is driven by an independent `async_call_later` timer scheduled in `_set_force_context` (`_base.py:_schedule_force_arm_expiry`); when it fires, `_async_handle_force_arm_expiry` fires the public `verisure_owa_force_arm_expired` event, runs the built-in notification side effects (if enabled), and wipes the context. The timer runs independent of coordinator state — this matters because HA's `DataUpdateCoordinator` does NOT call its listeners on consecutive failed refreshes, so the previous coordinator-driven check would silently skip the expiry during a sustained API outage that started before the TTL boundary. `_clear_force_context()` is now a pure wipe (cancels the timer + drops the context dict + drops the entity attributes); it does no TTL bookkeeping itself and is used by the canonical resolution paths (force_arm, force_arm_cancel, sibling dismissal).
 
 The `_get_exceptions()` API call uses the same polling pattern as arm/disarm — the server returns `WAIT` on the first poll while the panel reports the open sensors, then `OK` with the full exception list on a subsequent poll.
 
@@ -494,6 +494,7 @@ When arming is blocked by open sensors (the API returns a `NON_BLOCKING` error),
 
 **Event payload:**
 ```python
+# verisure_owa_arming_exception
 {
     "entity_id": "alarm_control_panel.verisure_owa_my_home",
     "mode": "armed_away",
@@ -504,8 +505,64 @@ When arming is blocked by open sensors (the API returns a `NON_BLOCKING` error),
             {"alias": "Kitchen window", "zone_id": "3", "device_type": "MAG"},
         ],
     },
+    "_event_id": "<uuid4>",
 }
 ```
+
+**Lifecycle events** (`events.py:33,39`):
+
+Two follow-on events fire for every active force-arm context, regardless of the
+`force_arm_notifications` toggle. The toggle gates the built-in side effects only —
+the events themselves are the public contract for user automations.
+
+```python
+# verisure_owa_force_arm_expired — fires when the 180 s TTL elapses without
+# the user pressing Force Arm or Cancel.
+{
+    "entity_id": "alarm_control_panel.verisure_owa_my_home",
+    "mode": "armed_away",
+    "zones": ["Front door", "Garage"],
+    "details": {
+        "installation": "12345",
+        "exceptions": [{"alias": "Front door", "zone_id": "1", ...}],
+    },
+    "_event_id": "<uuid4>",
+}
+
+# verisure_owa_arming_exception_dismissed — fires when an active force-arm
+# context is cleared by something OTHER than force_arm / force_arm_cancel
+# (those are the canonical resolutions and do not fire dismissed).
+{
+    "entity_id": "alarm_control_panel.verisure_owa_my_home",
+    "reason": "user_arm" | "user_disarm" | "integration_reload",
+    "new_mode": "armed_home" | "armed_away" | "disarmed" | None,
+    "details": {"installation": "12345"},
+    "_event_id": "<uuid4>",
+}
+```
+
+`reason` is one of the constants in `events.py:43-46` (`DISMISSAL_REASON_USER_ARM`,
+`DISMISSAL_REASON_USER_DISARM`, `DISMISSAL_REASON_INTEGRATION_RELOAD`); `new_mode`
+is `None` only when `reason="integration_reload"` (entity teardown — there is no
+new mode being targeted).
+
+**Cross-panel coordination:** the Combined and per-axis sub-panels (Interior /
+Perimeter / Annex) for an installation share notification state. `_async_arm`
+and `async_alarm_disarm` call `_dismiss_pending_force_context_on_siblings`
+BEFORE dispatching the new operation: it walks every panel returned by
+`_siblings_on_installation` (which reads `entry_data["combined_alarm_panels"]`
+and `entry_data["axis_alarm_panels"]`), fires the dismissed event attributed to
+the panel that HELD the context (its own `entity_id`), then clears that panel's
+context. So if the user triggers an arming exception on Combined and then arms
+via the Interior sub-panel, Combined's persistent + mobile notifications vanish
+immediately even if the new arm operation later fails.
+
+**Reload safety net:** `async_will_remove_from_hass` checks for a still-live
+`_force_context` at teardown and fires the dismissed event with
+`reason="integration_reload"` and `new_mode=None`. This covers options-flow
+edits, reauth, and any other path that re-creates the entity, so user
+automations see the loss instead of silently inheriting a fresh entity with no
+context.
 
 **Built-in handler (enabled by default):**
 
@@ -513,7 +570,8 @@ When the built-in handler is active it:
 - Creates a persistent notification listing open zones with instructions for how to force-arm.
 - Sends a mobile notification (if `notify_group` is configured) with **Force Arm** / **Cancel** action buttons.
 - Listens for `mobile_app_notification_action` events to handle button taps (`SECURITAS_FORCE_ARM_<num>` → `async_force_arm()`, `SECURITAS_CANCEL_FORCE_ARM_<num>` → cancel). The action names retain the `SECURITAS_` prefix through the v5 deprecation window: the integration both sends the action (in the mobile notification payload) and listens for the resulting press event, so renaming would silently break any user automation hooked to `mobile_app_notification_action` events that match the action string. Renamed in v6 with explicit release-note guidance.
-- When force-arm context expires (180 s), updates the notification to inform the user the alarm was not armed.
+- When the force-arm context expires (180 s), fires `verisure_owa_force_arm_expired` (regardless of toggle) and — when notifications are enabled — updates the persistent notification, then replaces the mobile notification *in place* with a button-less informational card (same `tag` as the original so iOS/Android updates the existing card rather than stacking a new one; `actions` array omitted so no buttons render).
+- Listens for `verisure_owa_arming_exception_dismissed` and clears the shared persistent + mobile notifications when fired (so a sibling-panel arm/disarm or an integration reload cleans up the user-visible state).
 
 **Disabling the built-in handler:**
 

--- a/docs/before-release-todo.md
+++ b/docs/before-release-todo.md
@@ -388,6 +388,42 @@ on actual API responses, multi-axis state, or hardware configuration.
       Cancel buttons fires when arming with an open sensor; Force Arm
       bypasses the exception. Confirmed working on the user's install.
 
+- [x] **`verisure_owa_force_arm_expired` fires during a sustained API
+      outage.** Triggered an arming exception, then killed DNS / network
+      on the HA host. Waited 3+ minutes. Confirmed in Developer Tools →
+      Events that the event fired at exactly the TTL boundary,
+      independent of coordinator state (the previous coordinator-driven
+      check would have silently skipped expiry because HA's
+      `DataUpdateCoordinator` does not call its listeners on consecutive
+      failed refreshes).
+
+- [x] **`verisure_owa_arming_exception_dismissed` fires on integration
+      reload.** Triggered an arming exception, then changed an
+      integration option that forces a reload while the force-arm
+      context was still alive. Confirmed the event payload includes
+      `reason="integration_reload"` and `new_mode=null`.
+
+- [x] **Mobile notification on TTL expiry replaces in place (Android).**
+      Verified on the Android Companion app: the arm-blocked card with
+      Force Arm / Cancel buttons is updated in place to a button-less
+      informational card after 180 s (same `tag`, no `actions` array),
+      not stacked as a new notification.
+
+- [x] **Mobile notification on TTL expiry replaces in place (iOS).**
+      Same behaviour verified on the iOS Companion app: the existing
+      card is updated in place to the button-less informational version.
+
+- [x] **Cross-panel dismissal.** Triggered an arming exception on the
+      Combined panel, then armed via the Interior sub-panel. The
+      Combined panel's persistent + mobile notifications cleared
+      immediately and the dismissed event fired attributed to Combined's
+      `entity_id`.
+
+- [x] **Notify-service dropdown excludes
+      `notify.persistent_notification`.** Verified in the options flow
+      that the persistent-notification service does not appear in the
+      dropdown (config_flow.py `_NOTIFY_EXCLUDE`).
+
 - [x] **Backwards compatibility.** Existing users keep their
       `entity_id`, mappings, and PIN configuration. `CONF_HAS_PERI` is
       dropped from stored data and recomputed at load time.

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -46,6 +46,24 @@ from custom_components.verisure_owa.const import (
     CONF_FORCE_ARM_NOTIFICATIONS,
     DEFAULT_FORCE_ARM_NOTIFICATIONS,
 )
+from custom_components.verisure_owa.events import (
+    ARMING_EXCEPTION_DISMISSED_EVENT_TYPE,
+    FORCE_ARM_EXPIRED_EVENT_TYPE,
+)
+
+
+class TestNewArmingExceptionEventConstants:
+    """Tests that the two new event-type constants are defined with the
+    canonical verisure_owa_* names."""
+
+    def test_force_arm_expired_event_type(self):
+        assert FORCE_ARM_EXPIRED_EVENT_TYPE == "verisure_owa_force_arm_expired"
+
+    def test_arming_exception_dismissed_event_type(self):
+        assert (
+            ARMING_EXCEPTION_DISMISSED_EVENT_TYPE
+            == "verisure_owa_arming_exception_dismissed"
+        )
 
 
 class TestForceArmNotificationsConfig:

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -66,6 +66,64 @@ class TestNewArmingExceptionEventConstants:
         )
 
 
+class TestNotificationTranslationsPersistentMessageTrim:
+    """The persistent-notification arm_blocked_open_sensors.message must
+    not direct users to a mobile notification — anyone reading the
+    persistent notification is already in the HA UI."""
+
+    LOCALES = ("en", "es", "fr", "it", "pt", "pt-BR", "ca")
+
+    # Substrings (case-insensitive) that would indicate a leftover
+    # "or on your mobile notification" clause per locale. We only check
+    # for words that *uniquely* appear in the mobile clause, not in the
+    # ambient text — "mobile" / "móvil" / "móvel" / "phone".
+    FORBIDDEN_BY_LOCALE = {
+        "en": ["mobile notification"],
+        "es": ["notificación móvil"],
+        "fr": ["notification mobile"],
+        "it": ["notifica mobile"],
+        "pt": ["notificação móvel"],
+        "pt-BR": ["notificação móvel"],
+        "ca": ["notificació mòbil"],
+    }
+
+    def test_message_does_not_mention_mobile_notification(self):
+        from custom_components.verisure_owa.notification_translations import (
+            NOTIFICATION_TRANSLATIONS,
+        )
+
+        for locale in self.LOCALES:
+            entry = NOTIFICATION_TRANSLATIONS[locale]["arm_blocked_open_sensors"]
+            msg = entry["message"].lower()
+            for forbidden in self.FORBIDDEN_BY_LOCALE[locale]:
+                assert forbidden.lower() not in msg, (
+                    f"Locale {locale!r} arm_blocked_open_sensors.message "
+                    f"still contains forbidden substring {forbidden!r}: {entry['message']!r}"
+                )
+
+    def test_message_still_mentions_alarm_card(self):
+        """Sanity: the alarm-card guidance must still be present per locale."""
+        from custom_components.verisure_owa.notification_translations import (
+            NOTIFICATION_TRANSLATIONS,
+        )
+
+        # Translation hint per locale that should remain.
+        keepers = {
+            "en": "alarm card",
+            "es": "tarjeta de la alarma",
+            "fr": "carte d'alarme",
+            "it": "card dell'allarme",
+            "pt": "cartão do alarme",
+            "pt-BR": "cartão do alarme",
+            "ca": "targeta de l'alarma",
+        }
+        for locale in self.LOCALES:
+            entry = NOTIFICATION_TRANSLATIONS[locale]["arm_blocked_open_sensors"]
+            assert keepers[locale].lower() in entry["message"].lower(), (
+                f"Locale {locale!r} no longer mentions {keepers[locale]!r}"
+            )
+
+
 class TestForceArmNotificationsConfig:
     """Tests for the force_arm_notifications config toggle."""
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2240,12 +2240,13 @@ class TestForceArmExpiredEventFire:
         ]
         assert "_event_id" in payload
 
-    def test_event_does_not_fire_on_force_clear(self):
-        """force=True clear (cancel/confirm path) must NOT fire the event."""
+    def test_event_does_not_fire_on_direct_clear(self):
+        """Direct _clear_force_context (cancel/confirm/sibling-dismiss path) must
+        not fire the expired event — that is the timer callback's job alone."""
         alarm = make_alarm()
         alarm._force_context = self._expired_context()  # even when expired
 
-        alarm._clear_force_context(force=True)
+        alarm._clear_force_context()
 
         fire_calls = alarm.hass.bus.async_fire.call_args_list
         force_expired = [
@@ -2271,9 +2272,12 @@ class TestForceArmExpiredEventFire:
             alarm._set_force_context(exc, AlarmControlPanelState.ARMED_HOME)
 
         mock_call_later.assert_called_once()
-        delay_seconds = mock_call_later.call_args[0][1]
-        assert delay_seconds == alarm._FORCE_ARM_TTL.total_seconds()
-        assert delay_seconds == 180
+        delay = mock_call_later.call_args[0][1]
+        # async_call_later accepts a timedelta directly — we pass the field
+        # itself rather than .total_seconds() so the unit lives at the
+        # declaration site.
+        assert delay == alarm._FORCE_ARM_TTL
+        assert delay.total_seconds() == 180
 
     async def test_event_fires_even_when_notifications_disabled(self):
         """Events are the public API and fire regardless of the notification toggle."""
@@ -2320,8 +2324,8 @@ class TestForceArmExpiryTimer:
         mock_call_later.assert_called_once()
         args = mock_call_later.call_args[0]
         assert args[0] is alarm.hass
-        # Delay must be the TTL in seconds (not a raw 180).
-        assert args[1] == alarm._FORCE_ARM_TTL.total_seconds()
+        # Delay is the TTL — async_call_later accepts a timedelta directly.
+        assert args[1] == alarm._FORCE_ARM_TTL
         # Callback is the expiry handler.
         assert args[2] == alarm._async_handle_force_arm_expiry
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -279,8 +279,12 @@ class TestForceArmNotificationsConfig:
         assert alarm._force_context is not None
         assert alarm._attr_extra_state_attributes["force_arm_available"] is True
 
-    def test_force_context_expiry_silent_when_disabled(self):
-        """When notifications disabled, force context expiry does not notify."""
+    async def test_force_context_expiry_silent_when_disabled(self):
+        """When notifications disabled, force context expiry does not notify.
+
+        The expiry timer callback now drives this — the coordinator-update
+        path no longer touches force context (see TestForceArmExpiryTimer).
+        """
         alarm = make_alarm()
         alarm.client.config["force_arm_notifications"] = False
         alarm._force_context = {
@@ -293,16 +297,14 @@ class TestForceArmNotificationsConfig:
         alarm._attr_extra_state_attributes["force_arm_available"] = True
         alarm._attr_extra_state_attributes["arm_exceptions"] = ["Door"]
 
-        alarm.coordinator.data = AlarmStatusData(
-            status=SStatus(status="D"), protom_response="D"
-        )
-
-        alarm._handle_coordinator_update()
+        # Invoke the timer callback directly — same semantics as the
+        # async_call_later-driven flow that production runs.
+        await alarm._async_handle_force_arm_expiry(datetime.now())
 
         # Force context cleared
         assert alarm._force_context is None
         assert "force_arm_available" not in alarm._attr_extra_state_attributes
-        # No notification calls
+        # No notification calls (notifications disabled)
         alarm.hass.async_create_task.assert_not_called()
 
     async def test_force_arm_no_dismiss_when_disabled(self):
@@ -1921,24 +1923,27 @@ class TestForceArmContext:
             "force_arm_expired",
         )
 
-    async def test_force_context_cleared_on_expired_coordinator_update(self):
-        """Coordinator update clears force context after scan interval expires."""
+    async def test_force_context_cleared_on_expiry_timer(self):
+        """Expiry timer callback clears force context + attributes.
+
+        Previously this exercised the coordinator-update-driven TTL check,
+        which has been removed (HA's coordinator does not call listeners
+        on consecutive failures, so the TTL would be missed during a
+        sustained outage). The expiry is now driven by an independent
+        async_call_later timer scheduled in _set_force_context.
+        """
         alarm = make_alarm()
         alarm._force_context = {
             "reference_id": "ref-123",
             "suid": "suid-123",
             "mode": AlarmControlPanelState.ARMED_HOME,
             "exceptions": [],
-            "created_at": datetime.now() - timedelta(seconds=300),  # Old
+            "created_at": datetime.now() - timedelta(seconds=300),
         }
         alarm._attr_extra_state_attributes["force_arm_available"] = True
         alarm._attr_extra_state_attributes["arm_exceptions"] = ["Door"]
 
-        alarm.coordinator.data = AlarmStatusData(
-            status=SStatus(status="D"), protom_response="D"
-        )
-
-        alarm._handle_coordinator_update()
+        await alarm._async_handle_force_arm_expiry(datetime.now())
 
         assert alarm._force_context is None
         assert "force_arm_available" not in alarm._attr_extra_state_attributes
@@ -2205,19 +2210,20 @@ class TestForceArmExpiredEventFire:
             "created_at": datetime.now() - timedelta(seconds=300),
         }
 
-    def test_event_fires_on_expiry_via_coordinator_update(self):
+    async def test_event_fires_on_expiry_timer_callback(self):
+        """Expiry timer callback fires verisure_owa_force_arm_expired with the
+        original mode + zones derived from the saved exceptions.
+
+        Previously this exercised the coordinator-update-driven TTL check;
+        the TTL is now timer-driven (see TestForceArmExpiryTimer).
+        """
         alarm = make_alarm()
         alarm._force_context = self._expired_context()
         alarm._attr_extra_state_attributes["force_arm_available"] = True
         alarm._attr_extra_state_attributes["arm_exceptions"] = ["Front door", "Garage"]
-        alarm.coordinator.data = AlarmStatusData(
-            status=SStatus(status="D"), protom_response="D"
-        )
 
-        alarm._handle_coordinator_update()
+        await alarm._async_handle_force_arm_expiry(datetime.now())
 
-        # Expiry path fires verisure_owa_force_arm_expired with the original
-        # mode + zones derived from the saved exceptions.
         fire_calls = alarm.hass.bus.async_fire.call_args_list
         force_expired = [
             c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
@@ -2247,39 +2253,280 @@ class TestForceArmExpiredEventFire:
         ]
         assert force_expired == []
 
-    def test_event_does_not_fire_when_context_still_fresh(self):
+    def test_timer_scheduled_with_correct_delay(self):
+        """_set_force_context schedules the timer at exactly _FORCE_ARM_TTL.
+
+        Previously the "still fresh" test asserted that _clear_force_context
+        early-returned within the TTL — but that semantic is gone: the timer
+        fires exactly at TTL and the canonical clear path is unconditional.
+        What's worth asserting now is that the timer is scheduled with the
+        right delay; the rest is HA's scheduler.
+        """
         alarm = make_alarm()
-        alarm._force_context = {
-            "reference_id": "ref-fresh",
-            "suid": "suid-fresh",
-            "mode": AlarmControlPanelState.ARMED_HOME,
-            "exceptions": [{"alias": "Door"}],
-            "created_at": datetime.now(),  # fresh
-        }
+        exc = ArmingExceptionError("ref-x", "suid-x", [{"alias": "Door"}])
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later"
+        ) as mock_call_later:
+            mock_call_later.return_value = MagicMock()
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_HOME)
 
-        alarm._clear_force_context(force=False)
+        mock_call_later.assert_called_once()
+        delay_seconds = mock_call_later.call_args[0][1]
+        assert delay_seconds == alarm._FORCE_ARM_TTL.total_seconds()
+        assert delay_seconds == 180
 
-        fire_calls = alarm.hass.bus.async_fire.call_args_list
-        force_expired = [
-            c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
-        ]
-        assert force_expired == []
-        # Context remains because TTL not exceeded
-        assert alarm._force_context is not None
-
-    def test_event_fires_even_when_notifications_disabled(self):
+    async def test_event_fires_even_when_notifications_disabled(self):
         """Events are the public API and fire regardless of the notification toggle."""
         alarm = make_alarm()
         alarm.client.config["force_arm_notifications"] = False
         alarm._force_context = self._expired_context()
 
-        alarm._clear_force_context(force=False)
+        await alarm._async_handle_force_arm_expiry(datetime.now())
 
         fire_calls = alarm.hass.bus.async_fire.call_args_list
         force_expired = [
             c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
         ]
         assert len(force_expired) == 1
+
+
+class TestForceArmExpiryTimer:
+    """Tests for the independent timer driving force-arm TTL expiry.
+
+    Replaces the previous coordinator-update-driven TTL check, which
+    missed the expiry event entirely during sustained API outages
+    (HA's DataUpdateCoordinator does not call listeners on consecutive
+    failures).
+    """
+
+    @staticmethod
+    def _make_exception():
+        return ArmingExceptionError(
+            "ref-timer",
+            "suid-timer",
+            [{"alias": "Front door", "deviceType": "MG", "zone_id": "1"}],
+        )
+
+    def test_set_force_context_schedules_timer(self):
+        """_set_force_context schedules async_call_later with the TTL."""
+        alarm = make_alarm()
+        exc = self._make_exception()
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later"
+        ) as mock_call_later:
+            mock_call_later.return_value = MagicMock()
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_AWAY)
+
+        mock_call_later.assert_called_once()
+        args = mock_call_later.call_args[0]
+        assert args[0] is alarm.hass
+        # Delay must be the TTL in seconds (not a raw 180).
+        assert args[1] == alarm._FORCE_ARM_TTL.total_seconds()
+        # Callback is the expiry handler.
+        assert args[2] == alarm._async_handle_force_arm_expiry
+
+    def test_clear_force_context_cancels_timer(self):
+        """_clear_force_context cancels the pending expiry timer."""
+        alarm = make_alarm()
+        exc = self._make_exception()
+        unsub_mock = MagicMock()
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later",
+            return_value=unsub_mock,
+        ):
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_AWAY)
+
+        alarm._clear_force_context()
+
+        unsub_mock.assert_called_once()
+        assert alarm._force_arm_expiry_unsub is None
+
+    async def test_timer_callback_fires_expired_event_when_context_alive(self):
+        """The captured timer callback fires the expired event + wipes context."""
+        alarm = make_alarm()
+        exc = self._make_exception()
+        unsub_mock = MagicMock()
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later",
+            return_value=unsub_mock,
+        ) as mock_call_later:
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_AWAY)
+            callback_fn = mock_call_later.call_args[0][2]
+
+        # Reset fire-call tracking to isolate the timer-driven event.
+        alarm.hass.bus.async_fire.reset_mock()
+
+        await callback_fn(datetime.now())
+
+        # Expired event fired.
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        force_expired = [
+            c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        ]
+        assert len(force_expired) == 1
+        payload = force_expired[0][0][1]
+        assert payload["entity_id"] == alarm.entity_id
+        assert payload["mode"] == AlarmControlPanelState.ARMED_AWAY
+        assert payload["zones"] == ["Front door"]
+
+        # Context wiped.
+        assert alarm._force_context is None
+        assert "arm_exceptions" not in alarm._attr_extra_state_attributes
+        assert "force_arm_available" not in alarm._attr_extra_state_attributes
+        # Timer slot cleared so the unsub is never called twice on teardown.
+        assert alarm._force_arm_expiry_unsub is None
+        alarm.async_write_ha_state.assert_called()
+
+    async def test_timer_callback_noops_when_context_already_cleared(self):
+        """If context is cleared between scheduling and firing, callback no-ops."""
+        alarm = make_alarm()
+        exc = self._make_exception()
+        unsub_mock = MagicMock()
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later",
+            return_value=unsub_mock,
+        ) as mock_call_later:
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_AWAY)
+            callback_fn = mock_call_later.call_args[0][2]
+
+        # Wipe context manually as if a canonical resolution path already ran.
+        alarm._force_context = None
+        alarm.hass.bus.async_fire.reset_mock()
+
+        await callback_fn(datetime.now())
+
+        # No event fired.
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        force_expired = [
+            c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        ]
+        assert force_expired == []
+        # Timer slot still cleared.
+        assert alarm._force_arm_expiry_unsub is None
+
+    async def test_force_arm_cancels_timer(self):
+        """async_force_arm cancels the pending expiry timer (force=True path)."""
+        alarm = make_alarm()
+        alarm._state = AlarmControlPanelState.DISARMED
+        exc = self._make_exception()
+        unsub_mock = MagicMock()
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later",
+            return_value=unsub_mock,
+        ):
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_AWAY)
+
+        alarm.client.arm_alarm = AsyncMock(
+            return_value=OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                installation_number="123456",
+                protom_response="T",
+                protom_response_date="",
+            )
+        )
+
+        await alarm.async_force_arm()
+
+        unsub_mock.assert_called_once()
+
+    async def test_dismissed_path_cancels_timer(self):
+        """_dismiss_pending_force_context_on_siblings cancels the timer."""
+        from custom_components.verisure_owa import DOMAIN
+
+        alarm = make_alarm()
+        # Wire up the entry-data shape the dismissal helper walks.
+        alarm.hass.data = {DOMAIN: {}}
+        alarm.hass.data[DOMAIN]["entry-id-1"] = {
+            "combined_alarm_panels": {alarm.installation.number: alarm},
+            "axis_alarm_panels": {alarm.installation.number: {}},
+        }
+        exc = self._make_exception()
+        unsub_mock = MagicMock()
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later",
+            return_value=unsub_mock,
+        ):
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_AWAY)
+
+        await alarm._dismiss_pending_force_context_on_siblings(
+            reason="user_arm",
+            new_mode=AlarmControlPanelState.ARMED_NIGHT,
+        )
+
+        unsub_mock.assert_called_once()
+
+
+class TestArmingExceptionDismissedOnEntityRemoval:
+    """Reload-path safety net: fire the dismissed event when the entity is
+    torn down with a live force-arm context (covers integration-reload
+    scenarios — options change, reauth, etc.)."""
+
+    @staticmethod
+    def _make_exception():
+        return ArmingExceptionError(
+            "ref-reload",
+            "suid-reload",
+            [{"alias": "Window", "deviceType": "MG"}],
+        )
+
+    async def test_will_remove_fires_dismissed_when_context_alive(self):
+        """async_will_remove_from_hass fires the dismissed event with
+        reason='integration_reload' and new_mode=None when context is alive."""
+        alarm = make_alarm()
+        alarm._force_context = {
+            "reference_id": "ref-reload",
+            "suid": "suid-reload",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Window"}],
+            "created_at": datetime.now(),
+        }
+
+        await alarm.async_will_remove_from_hass()
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 1
+        payload = dismissed[0][0][1]
+        assert payload["entity_id"] == alarm.entity_id
+        assert payload["reason"] == "integration_reload"
+        assert payload["new_mode"] is None
+        assert payload["details"] == {"installation": "123456"}
+
+    async def test_will_remove_no_event_when_context_already_cleared(self):
+        """No dismissed event fires when context is already None."""
+        alarm = make_alarm()
+        alarm._force_context = None
+
+        await alarm.async_will_remove_from_hass()
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert dismissed == []
+
+    async def test_will_remove_cancels_timer(self):
+        """async_will_remove_from_hass cancels any pending expiry timer."""
+        alarm = make_alarm()
+        exc = ArmingExceptionError("ref-x", "suid-x", [{"alias": "Door"}])
+        unsub_mock = MagicMock()
+        with patch(
+            "custom_components.verisure_owa.alarm_control_panel._base.async_call_later",
+            return_value=unsub_mock,
+        ):
+            alarm._set_force_context(exc, AlarmControlPanelState.ARMED_AWAY)
+
+        await alarm.async_will_remove_from_hass()
+
+        unsub_mock.assert_called_once()
 
 
 class TestForceArmExpiredMobileNotification:

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2492,6 +2492,40 @@ class TestSiblingPanelLookup:
 
         assert siblings == [alarm]
 
+    def test_lookup_walks_multiple_config_entries(self):
+        """Helper iterates ALL config entries — a panel in entry-2 is found
+        even when self lives in entry-1's registry.
+
+        Real-world scenario: multiple Verisure accounts (one config entry per
+        account), each with its own installation. The helper walks every
+        entry's bucket so cross-installation arm/disarm coordination works.
+        """
+        from custom_components.verisure_owa import DOMAIN
+
+        alarm = make_alarm()
+        # A second installation living in a different config entry.
+        other = MagicMock()
+        other.installation = MagicMock(number="999999")
+        other_sub = MagicMock()
+        other_sub._AXIS = "interior"
+
+        alarm.hass.data = {DOMAIN: {}}
+        alarm.hass.data[DOMAIN]["entry-id-1"] = {
+            "combined_alarm_panels": {alarm.installation.number: alarm},
+            "axis_alarm_panels": {alarm.installation.number: {}},
+        }
+        alarm.hass.data[DOMAIN]["entry-id-2"] = {
+            "combined_alarm_panels": {"999999": other},
+            "axis_alarm_panels": {"999999": {"interior": other_sub}},
+        }
+
+        siblings = alarm._siblings_on_installation()
+
+        # Only this installation's panels, drawn from entry-id-1.
+        assert siblings == [alarm]
+        assert other not in siblings
+        assert other_sub not in siblings
+
 
 # ===========================================================================
 # force_arm_cancel service

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2270,6 +2270,148 @@ class TestForceArmExpiredEventFire:
         assert len(force_expired) == 1
 
 
+class TestForceArmExpiredMobileNotification:
+    """The button-less informational mobile notification sent on expiry."""
+
+    @staticmethod
+    def _make_event(entity_id="alarm_control_panel.home"):
+        """Build a mock event matching the FORCE_ARM_EXPIRED payload."""
+        from uuid import uuid4
+
+        ev = MagicMock()
+        ev.data = {
+            "entity_id": entity_id,
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "zones": ["Front door"],
+            "details": {
+                "installation": "123456",
+                "exceptions": [{"alias": "Front door"}],
+            },
+            "_event_id": str(uuid4()),
+        }
+        return ev
+
+    async def test_handler_sends_buttonless_mobile_with_same_tag(self):
+        """With notify_group + notifications enabled, expiry handler sends a
+        notify call with the same tag and no actions array."""
+        alarm = make_alarm()
+        alarm.hass.services.async_call = AsyncMock()
+        alarm.client.config["force_arm_notifications"] = True
+        alarm.client.config["notify_group"] = "mobile_app_phone"
+        # Make entity_id match the event payload
+        ev = self._make_event(entity_id=alarm.entity_id)
+
+        await alarm._async_notify_force_arm_expired_mobile(ev)
+
+        calls = alarm.hass.services.async_call.call_args_list
+        notify_calls = [c for c in calls if c[1].get("domain") == "notify"]
+        assert len(notify_calls) == 1
+        sd = notify_calls[0][1]["service_data"]
+        # Same tag as the original arming-exception notification (so the
+        # mobile OS replaces the existing card in place).
+        assert (
+            sd["data"]["tag"]
+            == f"verisure_owa.arming_exception_{alarm.installation.number}"
+        )
+        # No actions array — buttons removed.
+        assert "actions" not in sd["data"]
+        # Body is the mobile_message from the force_arm_expired translation.
+        from custom_components.verisure_owa.notification_translations import (
+            get_notification_strings,
+        )
+
+        expected = get_notification_strings(alarm.hass, "force_arm_expired")
+        assert sd["message"] == expected["mobile_message"]
+        assert sd["title"] == expected["title"]
+
+    async def test_handler_no_op_without_notify_group(self):
+        """Without a notify_group configured, no mobile notify call fires."""
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = True
+        # Explicitly no notify_group set
+        ev = self._make_event(entity_id=alarm.entity_id)
+
+        await alarm._async_notify_force_arm_expired_mobile(ev)
+
+        calls = alarm.hass.services.async_call.call_args_list
+        notify_calls = [c for c in calls if c[1].get("domain") == "notify"]
+        assert notify_calls == []
+
+    async def test_handler_no_op_when_notifications_disabled(self):
+        """force_arm_notifications=False suppresses the mobile call."""
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = False
+        alarm.client.config["notify_group"] = "mobile_app_phone"
+        ev = self._make_event(entity_id=alarm.entity_id)
+
+        await alarm._async_notify_force_arm_expired_mobile(ev)
+
+        calls = alarm.hass.services.async_call.call_args_list
+        notify_calls = [c for c in calls if c[1].get("domain") == "notify"]
+        assert notify_calls == []
+
+    async def test_handler_skips_event_for_other_entity(self):
+        """Handler ignores events whose entity_id does not match self."""
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = True
+        alarm.client.config["notify_group"] = "mobile_app_phone"
+        ev = self._make_event(entity_id="alarm_control_panel.different")
+
+        await alarm._async_notify_force_arm_expired_mobile(ev)
+
+        calls = alarm.hass.services.async_call.call_args_list
+        notify_calls = [c for c in calls if c[1].get("domain") == "notify"]
+        assert notify_calls == []
+
+
+class TestForceArmExpiredHandlerRegistration:
+    """The expiry-event handler is registered alongside the arming-exception one."""
+
+    def test_register_subscribes_to_force_arm_expired(self):
+        alarm = make_alarm()
+
+        alarm._register_arming_exception_handler()
+
+        listen_calls = alarm.hass.bus.async_listen.call_args_list
+        expired_calls = [
+            c for c in listen_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        ]
+        assert len(expired_calls) == 1
+
+    async def test_handler_dedupes_via_event_id(self):
+        """A repeated _event_id triggers the handler at most once."""
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = True
+        alarm.client.config["notify_group"] = "mobile_app_phone"
+
+        alarm._register_arming_exception_handler()
+
+        # Capture the registered callback.
+        listen_calls = alarm.hass.bus.async_listen.call_args_list
+        expired_cb = next(
+            c[0][1] for c in listen_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        )
+
+        ev = MagicMock()
+        ev.data = {
+            "entity_id": alarm.entity_id,
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "zones": ["Front door"],
+            "details": {"installation": "123456", "exceptions": []},
+            "_event_id": "same-id",
+        }
+        expired_cb(ev)
+        # Same event id again — must be ignored.
+        expired_cb(ev)
+
+        # Only one async_create_task scheduled across the two calls.
+        first_count = alarm.hass.async_create_task.call_count
+        # second call is idempotent — no growth
+        # But MagicMock keeps the count, so re-invoke to confirm:
+        expired_cb(ev)
+        assert alarm.hass.async_create_task.call_count == first_count
+
+
 # ===========================================================================
 # force_arm_cancel service
 # ===========================================================================

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2873,6 +2873,36 @@ class TestDismissPendingForceContextOnSiblings:
         # Self's context cleared
         assert alarm._force_context is None
         assert "force_arm_available" not in alarm._attr_extra_state_attributes
+        # State was written so HA sees the cleared attributes immediately.
+        alarm.async_write_ha_state.assert_called()
+
+    async def test_writes_ha_state_on_cleared_sibling(self):
+        """When a sibling's force-context is cleared, its async_write_ha_state
+        must fire so HA sees the wiped force_arm_available / arm_exceptions
+        attributes without waiting for the next coordinator update."""
+        combined = make_alarm()
+        sub = _make_interior_panel()
+        sub.entity_id = "alarm_control_panel.home_interior"
+        sub.hass = combined.hass
+        sub._installation = combined.installation
+        sub.async_write_ha_state = MagicMock()
+        sub._force_context = {
+            "reference_id": "ref-sub",
+            "suid": "suid-sub",
+            "mode": AlarmControlPanelState.ARMED_NIGHT,
+            "exceptions": [{"alias": "Window"}],
+            "created_at": datetime.now(),
+        }
+        setup_alarm_entry_data(combined, sub_panels=(sub,))
+
+        await combined._dismiss_pending_force_context_on_siblings(
+            reason="user_arm",
+            new_mode=AlarmControlPanelState.ARMED_AWAY,
+        )
+
+        # The sibling panel got its context cleared AND its state written.
+        assert sub._force_context is None
+        sub.async_write_ha_state.assert_called()
 
     async def test_fires_for_sibling_with_context_attributing_to_sibling(self):
         """If Combined holds context and Interior triggered the dismissal,
@@ -2934,6 +2964,9 @@ class TestDismissPendingForceContextOnSiblings:
         # `installation` is a read-only @property — assign via the underlying
         # attribute used by VerisureEntity.__init__.
         sub._installation = combined.installation
+        # Stub out async_write_ha_state — the real method needs HA's loaded-
+        # integrations cache, which the MagicMock'd hass doesn't have.
+        sub.async_write_ha_state = MagicMock()
         sub._force_context = {
             "reference_id": "ref-sub",
             "suid": "suid-sub",

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2669,10 +2669,15 @@ class TestDismissPendingForceContextOnSiblings:
         """If multiple siblings hold contexts (theoretically possible),
         each gets its own dismissed event."""
         combined = make_alarm()
-        # Build a sibling with its own context.
-        sub = MagicMock()
-        sub._AXIS = "interior"
+        # Build a real sub-panel sibling so the helper's delegation to
+        # panel._fire_arming_exception_dismissed_event actually executes
+        # the production method (a MagicMock auto-attribute would no-op).
+        sub = _make_interior_panel()
         sub.entity_id = "alarm_control_panel.home_interior"
+        sub.hass = combined.hass  # share the bus mock
+        # `installation` is a read-only @property — assign via the underlying
+        # attribute used by VerisureEntity.__init__.
+        sub._installation = combined.installation
         sub._force_context = {
             "reference_id": "ref-sub",
             "suid": "suid-sub",
@@ -2680,9 +2685,6 @@ class TestDismissPendingForceContextOnSiblings:
             "exceptions": [{"alias": "Window"}],
             "created_at": datetime.now(),
         }
-        sub._clear_force_context = MagicMock()
-        sub.installation = combined.installation
-        sub.hass = combined.hass
 
         combined._force_context = {
             "reference_id": "ref-comb",
@@ -2708,9 +2710,9 @@ class TestDismissPendingForceContextOnSiblings:
         assert len(dismissed) == 2
         attributed_ids = {c[0][1]["entity_id"] for c in dismissed}
         assert attributed_ids == {combined.entity_id, sub.entity_id}
-        # Both contexts cleared.
+        # Both contexts cleared via the real _clear_force_context method.
         assert combined._force_context is None
-        sub._clear_force_context.assert_called_once_with(force=True)
+        assert sub._force_context is None
 
 
 # ===========================================================================

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -1978,7 +1978,11 @@ class TestForceArmContext:
 
         # Register handler and capture callback
         alarm._register_arming_exception_handler()
-        handler_cb = alarm.hass.bus.async_listen.call_args[0][1]
+        handler_cb = next(
+            c[0][1]
+            for c in alarm.hass.bus.async_listen.call_args_list
+            if c[0][0] == "verisure_owa_arming_exception"
+        )
 
         await alarm.set_arm_state(AlarmControlPanelState.ARMED_HOME)
 
@@ -2008,7 +2012,11 @@ class TestForceArmContext:
 
         # Register handler and capture callback
         alarm._register_arming_exception_handler()
-        handler_cb = alarm.hass.bus.async_listen.call_args[0][1]
+        handler_cb = next(
+            c[0][1]
+            for c in alarm.hass.bus.async_listen.call_args_list
+            if c[0][0] == "verisure_owa_arming_exception"
+        )
 
         await alarm.set_arm_state(AlarmControlPanelState.ARMED_HOME)
 
@@ -2036,7 +2044,11 @@ class TestForceArmContext:
 
         # Register handler and capture callback
         alarm._register_arming_exception_handler()
-        handler_cb = alarm.hass.bus.async_listen.call_args[0][1]
+        handler_cb = next(
+            c[0][1]
+            for c in alarm.hass.bus.async_listen.call_args_list
+            if c[0][0] == "verisure_owa_arming_exception"
+        )
 
         await alarm.set_arm_state(AlarmControlPanelState.ARMED_HOME)
 
@@ -2913,6 +2925,105 @@ class TestArmDisarmDismissesPendingForceContext:
             if c[0][0] == "verisure_owa_arming_exception_dismissed"
         ]
         assert dismissed == []
+
+
+class TestArmingExceptionDismissedHandler:
+    """The built-in handler that responds to verisure_owa_arming_exception_dismissed."""
+
+    @staticmethod
+    def _make_event(entity_id, reason="user_arm"):
+        ev = MagicMock()
+        ev.data = {
+            "entity_id": entity_id,
+            "reason": reason,
+            "new_mode": AlarmControlPanelState.ARMED_HOME,
+            "details": {"installation": "123456"},
+            "_event_id": "ev-1",
+        }
+        return ev
+
+    def test_register_subscribes_to_dismissed(self):
+        alarm = make_alarm()
+
+        alarm._register_arming_exception_handler()
+
+        listen_calls = alarm.hass.bus.async_listen.call_args_list
+        dismissed_calls = [
+            c
+            for c in listen_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed_calls) == 1
+
+    def test_handler_dismisses_when_enabled(self):
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = True
+        alarm.client.config["notify_group"] = "mobile_app_phone"
+
+        alarm._register_arming_exception_handler()
+
+        # Capture the dismissed callback.
+        listen_calls = alarm.hass.bus.async_listen.call_args_list
+        dismissed_cb = next(
+            c[0][1]
+            for c in listen_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        )
+
+        ev = self._make_event(alarm.entity_id)
+        dismissed_cb(ev)
+
+        # Persistent dismiss + mobile clear_notification both scheduled.
+        # _dismiss_arming_exception_notification creates 2 tasks when
+        # notify_group is set (one per service call).
+        assert alarm.hass.async_create_task.call_count == 2
+
+    def test_handler_skips_when_disabled(self):
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = False
+
+        alarm._register_arming_exception_handler()
+        # No listener even registered when disabled — async_added_to_hass
+        # gates _register_arming_exception_handler on _notifications_enabled.
+        # But the method itself, if called, must still subscribe (the
+        # gate lives at registration time, not in the handler).
+        # However, when the handler is invoked under disabled config,
+        # it must skip the dismiss work.
+        listen_calls = alarm.hass.bus.async_listen.call_args_list
+        dismissed_cb = next(
+            (
+                c[0][1]
+                for c in listen_calls
+                if c[0][0] == "verisure_owa_arming_exception_dismissed"
+            ),
+            None,
+        )
+        # If registered, invoke it; either way, no async_create_task fires.
+        alarm.hass.async_create_task.reset_mock()
+        if dismissed_cb is not None:
+            ev = self._make_event(alarm.entity_id)
+            dismissed_cb(ev)
+        alarm.hass.async_create_task.assert_not_called()
+
+    def test_handler_skips_event_for_other_entity(self):
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = True
+        alarm.client.config["notify_group"] = "mobile_app_phone"
+
+        alarm._register_arming_exception_handler()
+
+        listen_calls = alarm.hass.bus.async_listen.call_args_list
+        dismissed_cb = next(
+            c[0][1]
+            for c in listen_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        )
+
+        ev = self._make_event(entity_id="alarm_control_panel.different")
+        dismissed_cb(ev)
+
+        # No dismiss tasks scheduled for an event targeted at a different entity.
+        alarm.hass.async_create_task.assert_not_called()
 
 
 # ===========================================================================
@@ -4650,7 +4761,11 @@ class TestForceArmWorkflow:
 
         # Register handler (simulates async_added_to_hass)
         alarm._register_arming_exception_handler()
-        handler_cb = alarm.hass.bus.async_listen.call_args[0][1]
+        handler_cb = next(
+            c[0][1]
+            for c in alarm.hass.bus.async_listen.call_args_list
+            if c[0][0] == "verisure_owa_arming_exception"
+        )
 
         # Step 1: initial arm attempt fails
         alarm._state = AlarmControlPanelState.ARMING

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2404,10 +2404,11 @@ class TestForceArmExpiredHandlerRegistration:
         # Same event id again — must be ignored.
         expired_cb(ev)
 
-        # Only one async_create_task scheduled across the two calls.
+        # Only one async_create_task scheduled across the two calls — the
+        # second invocation hit the dedup guard and bailed before scheduling.
         first_count = alarm.hass.async_create_task.call_count
-        # second call is idempotent — no growth
-        # But MagicMock keeps the count, so re-invoke to confirm:
+        assert first_count == 1
+        # Third invocation with the same event id is idempotent — no growth.
         expired_cb(ev)
         assert alarm.hass.async_create_task.call_count == first_count
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2413,6 +2413,86 @@ class TestForceArmExpiredHandlerRegistration:
         assert alarm.hass.async_create_task.call_count == first_count
 
 
+class TestSiblingPanelLookup:
+    """The cross-panel sibling-lookup helper for installation-wide coordination."""
+
+    def _setup_entry_data(self, alarm, *, sub_panels=()):
+        """Populate hass.data[DOMAIN] mirroring alarm_control_panel.__init__'s setup."""
+        from custom_components.verisure_owa import DOMAIN
+
+        # Real dict, not MagicMock, so .get/.setdefault behave correctly.
+        alarm.hass.data = {DOMAIN: {}}
+        entry_data = {
+            "combined_alarm_panels": {alarm.installation.number: alarm},
+            "axis_alarm_panels": {
+                alarm.installation.number: {panel._AXIS: panel for panel in sub_panels}
+            },
+        }
+        # Real entry id is irrelevant — the helper iterates all entries.
+        alarm.hass.data[DOMAIN]["entry-id-1"] = entry_data
+
+    def test_lookup_returns_self_only_when_no_sub_panels(self):
+        alarm = make_alarm()
+        self._setup_entry_data(alarm, sub_panels=())
+
+        siblings = alarm._siblings_on_installation()
+
+        assert siblings == [alarm]
+
+    def test_lookup_returns_combined_plus_sub_panels(self):
+        alarm = make_alarm()
+        sub1 = MagicMock()
+        sub1._AXIS = "interior"
+        sub2 = MagicMock()
+        sub2._AXIS = "perimeter"
+        self._setup_entry_data(alarm, sub_panels=(sub1, sub2))
+
+        siblings = alarm._siblings_on_installation()
+
+        # Combined panel always present; sub-panel order is by axis-key
+        # iteration which we don't promise — assert as a set.
+        assert set(siblings) == {alarm, sub1, sub2}
+
+    def test_lookup_skips_other_installations(self):
+        """Only panels for THIS installation number are returned."""
+        from custom_components.verisure_owa import DOMAIN
+
+        alarm = make_alarm()
+        # Another combined panel for a different installation in the same
+        # hass.data entry block.
+        other = MagicMock()
+        other.installation = MagicMock(number="999999")
+
+        alarm.hass.data = {DOMAIN: {}}
+        alarm.hass.data[DOMAIN]["entry-id-1"] = {
+            "combined_alarm_panels": {
+                alarm.installation.number: alarm,
+                "999999": other,
+            },
+            "axis_alarm_panels": {alarm.installation.number: {}},
+        }
+
+        siblings = alarm._siblings_on_installation()
+
+        assert siblings == [alarm]
+        assert other not in siblings
+
+    def test_lookup_handles_missing_entry_data_gracefully(self):
+        """If hass.data[DOMAIN] is empty, helper returns just self.
+
+        Defensive: setup ordering means the entry data dict could be
+        missing during very early registration paths.
+        """
+        from custom_components.verisure_owa import DOMAIN
+
+        alarm = make_alarm()
+        alarm.hass.data = {DOMAIN: {}}
+
+        siblings = alarm._siblings_on_installation()
+
+        assert siblings == [alarm]
+
+
 # ===========================================================================
 # force_arm_cancel service
 # ===========================================================================

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -429,6 +429,25 @@ def make_alarm(
     return alarm
 
 
+def setup_alarm_entry_data(alarm, *, sub_panels=()):
+    """Populate alarm.hass.data[DOMAIN] mirroring alarm_control_panel.__init__.
+
+    Registers ``alarm`` as the combined panel and any provided ``sub_panels``
+    in the axis-panel registry, keyed by their ``_AXIS`` attribute. Used by
+    tests that exercise `_siblings_on_installation` and the cross-panel
+    dismissal helper, both of which walk these registries.
+    """
+    from custom_components.verisure_owa import DOMAIN
+
+    alarm.hass.data = {DOMAIN: {}}
+    alarm.hass.data[DOMAIN]["entry-id-1"] = {
+        "combined_alarm_panels": {alarm.installation.number: alarm},
+        "axis_alarm_panels": {
+            alarm.installation.number: {p._AXIS: p for p in sub_panels}
+        },
+    }
+
+
 # ===========================================================================
 # update_status_alarm  (STD defaults)
 # ===========================================================================
@@ -2679,24 +2698,9 @@ class TestForceArmExpiredHandlerRegistration:
 class TestSiblingPanelLookup:
     """The cross-panel sibling-lookup helper for installation-wide coordination."""
 
-    def _setup_entry_data(self, alarm, *, sub_panels=()):
-        """Populate hass.data[DOMAIN] mirroring alarm_control_panel.__init__'s setup."""
-        from custom_components.verisure_owa import DOMAIN
-
-        # Real dict, not MagicMock, so .get/.setdefault behave correctly.
-        alarm.hass.data = {DOMAIN: {}}
-        entry_data = {
-            "combined_alarm_panels": {alarm.installation.number: alarm},
-            "axis_alarm_panels": {
-                alarm.installation.number: {panel._AXIS: panel for panel in sub_panels}
-            },
-        }
-        # Real entry id is irrelevant — the helper iterates all entries.
-        alarm.hass.data[DOMAIN]["entry-id-1"] = entry_data
-
     def test_lookup_returns_self_only_when_no_sub_panels(self):
         alarm = make_alarm()
-        self._setup_entry_data(alarm, sub_panels=())
+        setup_alarm_entry_data(alarm)
 
         siblings = alarm._siblings_on_installation()
 
@@ -2708,7 +2712,7 @@ class TestSiblingPanelLookup:
         sub1._AXIS = "interior"
         sub2 = MagicMock()
         sub2._AXIS = "perimeter"
-        self._setup_entry_data(alarm, sub_panels=(sub1, sub2))
+        setup_alarm_entry_data(alarm, sub_panels=(sub1, sub2))
 
         siblings = alarm._siblings_on_installation()
 
@@ -2820,21 +2824,10 @@ class TestFireArmingExceptionDismissedEvent:
 class TestDismissPendingForceContextOnSiblings:
     """The cross-panel dismissal helper called by _async_arm / async_alarm_disarm."""
 
-    def _setup(self, alarm, sub_panels=()):
-        from custom_components.verisure_owa import DOMAIN
-
-        alarm.hass.data = {DOMAIN: {}}
-        alarm.hass.data[DOMAIN]["entry-id-1"] = {
-            "combined_alarm_panels": {alarm.installation.number: alarm},
-            "axis_alarm_panels": {
-                alarm.installation.number: {p._AXIS: p for p in sub_panels}
-            },
-        }
-
     async def test_no_op_when_no_panel_has_context(self):
         """No siblings hold a force context — nothing fires, nothing clears."""
         alarm = make_alarm()
-        self._setup(alarm)
+        setup_alarm_entry_data(alarm)
 
         await alarm._dismiss_pending_force_context_on_siblings(
             reason="user_arm",
@@ -2851,7 +2844,7 @@ class TestDismissPendingForceContextOnSiblings:
 
     async def test_fires_for_self_when_self_has_context(self):
         alarm = make_alarm()
-        self._setup(alarm)
+        setup_alarm_entry_data(alarm)
         alarm._force_context = {
             "reference_id": "ref-1",
             "suid": "suid-1",
@@ -2901,7 +2894,7 @@ class TestDismissPendingForceContextOnSiblings:
             "exceptions": [{"alias": "Door"}],
             "created_at": datetime.now(),
         }
-        self._setup(combined, sub_panels=(sub,))
+        setup_alarm_entry_data(combined, sub_panels=(sub,))
 
         # Interior triggers dismissal.
         # Use combined's helper but invoke from sub's perspective by
@@ -2957,7 +2950,7 @@ class TestDismissPendingForceContextOnSiblings:
             "created_at": datetime.now(),
         }
 
-        self._setup(combined, sub_panels=(sub,))
+        setup_alarm_entry_data(combined, sub_panels=(sub,))
 
         await combined._dismiss_pending_force_context_on_siblings(
             reason="user_disarm",
@@ -2982,18 +2975,9 @@ class TestArmDisarmDismissesPendingForceContext:
     """Regular arm/disarm entry points must clear stale force contexts
     BEFORE dispatching, so the user sees notifications vanish immediately."""
 
-    def _setup_lone_panel(self, alarm):
-        from custom_components.verisure_owa import DOMAIN
-
-        alarm.hass.data = {DOMAIN: {}}
-        alarm.hass.data[DOMAIN]["entry-id-1"] = {
-            "combined_alarm_panels": {alarm.installation.number: alarm},
-            "axis_alarm_panels": {alarm.installation.number: {}},
-        }
-
     async def test_async_arm_fires_dismissed_when_context_present(self):
         alarm = make_alarm()
-        self._setup_lone_panel(alarm)
+        setup_alarm_entry_data(alarm)
         alarm._force_context = {
             "reference_id": "ref-1",
             "suid": "suid-1",
@@ -3027,7 +3011,7 @@ class TestArmDisarmDismissesPendingForceContext:
 
     async def test_async_arm_no_event_when_no_context(self):
         alarm = make_alarm()
-        self._setup_lone_panel(alarm)
+        setup_alarm_entry_data(alarm)
         assert alarm._force_context is None
         alarm.client.arm_alarm = AsyncMock(
             return_value=OperationStatus(
@@ -3052,7 +3036,7 @@ class TestArmDisarmDismissesPendingForceContext:
 
     async def test_async_alarm_disarm_fires_dismissed_when_context_present(self):
         alarm = make_alarm()
-        self._setup_lone_panel(alarm)
+        setup_alarm_entry_data(alarm)
         alarm._force_context = {
             "reference_id": "ref-1",
             "suid": "suid-1",
@@ -3101,7 +3085,7 @@ class TestArmDisarmDismissesPendingForceContext:
         so the user sees notifications vanish immediately even if the new
         arm itself fails or hangs."""
         alarm = make_alarm()
-        self._setup_lone_panel(alarm)
+        setup_alarm_entry_data(alarm)
         alarm._force_context = {
             "reference_id": "ref-1",
             "suid": "suid-1",
@@ -3125,7 +3109,7 @@ class TestArmDisarmDismissesPendingForceContext:
     async def test_force_arm_does_not_fire_dismissed_event(self):
         """async_force_arm is the canonical resolution — must not fire dismissed."""
         alarm = make_alarm()
-        self._setup_lone_panel(alarm)
+        setup_alarm_entry_data(alarm)
         alarm._state = AlarmControlPanelState.DISARMED
         alarm._force_context = {
             "reference_id": "ref-1",
@@ -3158,7 +3142,7 @@ class TestArmDisarmDismissesPendingForceContext:
     async def test_force_arm_cancel_does_not_fire_dismissed_event(self):
         """async_force_arm_cancel is the canonical resolution — must not fire."""
         alarm = make_alarm()
-        self._setup_lone_panel(alarm)
+        setup_alarm_entry_data(alarm)
         alarm._force_context = {
             "reference_id": "ref-1",
             "suid": "suid-1",

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2527,6 +2527,192 @@ class TestSiblingPanelLookup:
         assert other_sub not in siblings
 
 
+class TestFireArmingExceptionDismissedEvent:
+    """The verisure_owa_arming_exception_dismissed event fired when a panel's
+    force-arm context is cleared by a different arm/disarm action."""
+
+    def test_payload_shape(self):
+        alarm = make_alarm()
+
+        alarm._fire_arming_exception_dismissed_event(
+            reason="user_arm",
+            new_mode=AlarmControlPanelState.ARMED_HOME,
+        )
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 1
+        payload = dismissed[0][0][1]
+        assert payload["entity_id"] == alarm.entity_id
+        assert payload["reason"] == "user_arm"
+        assert payload["new_mode"] == AlarmControlPanelState.ARMED_HOME
+        assert payload["details"] == {"installation": "123456"}
+        assert "_event_id" in payload
+
+
+class TestDismissPendingForceContextOnSiblings:
+    """The cross-panel dismissal helper called by _async_arm / async_alarm_disarm."""
+
+    def _setup(self, alarm, sub_panels=()):
+        from custom_components.verisure_owa import DOMAIN
+
+        alarm.hass.data = {DOMAIN: {}}
+        alarm.hass.data[DOMAIN]["entry-id-1"] = {
+            "combined_alarm_panels": {alarm.installation.number: alarm},
+            "axis_alarm_panels": {
+                alarm.installation.number: {p._AXIS: p for p in sub_panels}
+            },
+        }
+
+    async def test_no_op_when_no_panel_has_context(self):
+        """No siblings hold a force context — nothing fires, nothing clears."""
+        alarm = make_alarm()
+        self._setup(alarm)
+
+        await alarm._dismiss_pending_force_context_on_siblings(
+            reason="user_arm",
+            new_mode=AlarmControlPanelState.ARMED_HOME,
+        )
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert dismissed == []
+
+    async def test_fires_for_self_when_self_has_context(self):
+        alarm = make_alarm()
+        self._setup(alarm)
+        alarm._force_context = {
+            "reference_id": "ref-1",
+            "suid": "suid-1",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+        alarm._attr_extra_state_attributes["force_arm_available"] = True
+
+        await alarm._dismiss_pending_force_context_on_siblings(
+            reason="user_disarm",
+            new_mode="disarmed",
+        )
+
+        # Event fired with self.entity_id
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 1
+        payload = dismissed[0][0][1]
+        assert payload["entity_id"] == alarm.entity_id
+        assert payload["reason"] == "user_disarm"
+        # Self's context cleared
+        assert alarm._force_context is None
+        assert "force_arm_available" not in alarm._attr_extra_state_attributes
+
+    async def test_fires_for_sibling_with_context_attributing_to_sibling(self):
+        """If Combined holds context and Interior triggered the dismissal,
+        the event must carry Combined's entity_id (the panel that held
+        the context)."""
+        combined = make_alarm()
+        # Build a sibling sub-panel as a MagicMock with the minimum
+        # surface the helper depends on.
+        sub = MagicMock()
+        sub._AXIS = "interior"
+        sub.entity_id = "alarm_control_panel.home_interior"
+        sub._force_context = None  # sibling doesn't hold context
+        sub._clear_force_context = MagicMock()
+        # Combined holds the context.
+        combined._force_context = {
+            "reference_id": "ref-1",
+            "suid": "suid-1",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+        self._setup(combined, sub_panels=(sub,))
+
+        # Interior triggers dismissal.
+        # Use combined's helper but invoke from sub's perspective by
+        # binding the unbound method (sub is a MagicMock so it can't run
+        # the real coroutine). Equivalently: call combined's helper —
+        # the helper attributes events to whichever sibling held the
+        # context, which is the property under test.
+        await combined._dismiss_pending_force_context_on_siblings(
+            reason="user_arm",
+            new_mode=AlarmControlPanelState.ARMED_NIGHT,
+        )
+
+        fire_calls = combined.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 1
+        payload = dismissed[0][0][1]
+        # Attributed to the panel that held the context (Combined),
+        # not the panel that triggered the dismissal.
+        assert payload["entity_id"] == combined.entity_id
+        # Sibling without context: not cleared.
+        sub._clear_force_context.assert_not_called()
+
+    async def test_fires_one_event_per_panel_with_context(self):
+        """If multiple siblings hold contexts (theoretically possible),
+        each gets its own dismissed event."""
+        combined = make_alarm()
+        # Build a sibling with its own context.
+        sub = MagicMock()
+        sub._AXIS = "interior"
+        sub.entity_id = "alarm_control_panel.home_interior"
+        sub._force_context = {
+            "reference_id": "ref-sub",
+            "suid": "suid-sub",
+            "mode": AlarmControlPanelState.ARMED_NIGHT,
+            "exceptions": [{"alias": "Window"}],
+            "created_at": datetime.now(),
+        }
+        sub._clear_force_context = MagicMock()
+        sub.installation = combined.installation
+        sub.hass = combined.hass
+
+        combined._force_context = {
+            "reference_id": "ref-comb",
+            "suid": "suid-comb",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+
+        self._setup(combined, sub_panels=(sub,))
+
+        await combined._dismiss_pending_force_context_on_siblings(
+            reason="user_disarm",
+            new_mode="disarmed",
+        )
+
+        fire_calls = combined.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 2
+        attributed_ids = {c[0][1]["entity_id"] for c in dismissed}
+        assert attributed_ids == {combined.entity_id, sub.entity_id}
+        # Both contexts cleared.
+        assert combined._force_context is None
+        sub._clear_force_context.assert_called_once_with(force=True)
+
+
 # ===========================================================================
 # force_arm_cancel service
 # ===========================================================================

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -124,6 +124,28 @@ class TestNotificationTranslationsPersistentMessageTrim:
             )
 
 
+class TestForceArmExpiredMobileMessageTranslation:
+    """force_arm_expired entry must carry a mobile_message string per locale
+    for the button-less informational mobile notification on expiry."""
+
+    LOCALES = ("en", "es", "fr", "it", "pt", "pt-BR", "ca")
+
+    def test_mobile_message_present_for_all_locales(self):
+        from custom_components.verisure_owa.notification_translations import (
+            NOTIFICATION_TRANSLATIONS,
+        )
+
+        for locale in self.LOCALES:
+            entry = NOTIFICATION_TRANSLATIONS[locale]["force_arm_expired"]
+            assert "mobile_message" in entry, (
+                f"Locale {locale!r} force_arm_expired entry missing mobile_message"
+            )
+            mobile = entry["mobile_message"]
+            assert isinstance(mobile, str) and mobile.strip(), (
+                f"Locale {locale!r} force_arm_expired.mobile_message is empty"
+            )
+
+
 class TestForceArmNotificationsConfig:
     """Tests for the force_arm_notifications config toggle."""
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2715,6 +2715,206 @@ class TestDismissPendingForceContextOnSiblings:
         assert sub._force_context is None
 
 
+class TestArmDisarmDismissesPendingForceContext:
+    """Regular arm/disarm entry points must clear stale force contexts
+    BEFORE dispatching, so the user sees notifications vanish immediately."""
+
+    def _setup_lone_panel(self, alarm):
+        from custom_components.verisure_owa import DOMAIN
+
+        alarm.hass.data = {DOMAIN: {}}
+        alarm.hass.data[DOMAIN]["entry-id-1"] = {
+            "combined_alarm_panels": {alarm.installation.number: alarm},
+            "axis_alarm_panels": {alarm.installation.number: {}},
+        }
+
+    async def test_async_arm_fires_dismissed_when_context_present(self):
+        alarm = make_alarm()
+        self._setup_lone_panel(alarm)
+        alarm._force_context = {
+            "reference_id": "ref-1",
+            "suid": "suid-1",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+        alarm.client.arm_alarm = AsyncMock(
+            return_value=OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                installation_number="123456",
+                protom_response="N",
+                protom_response_date="",
+            )
+        )
+
+        await alarm._async_arm(AlarmControlPanelState.ARMED_HOME)
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 1
+        payload = dismissed[0][0][1]
+        assert payload["reason"] == "user_arm"
+        assert payload["new_mode"] == AlarmControlPanelState.ARMED_HOME
+
+    async def test_async_arm_no_event_when_no_context(self):
+        alarm = make_alarm()
+        self._setup_lone_panel(alarm)
+        assert alarm._force_context is None
+        alarm.client.arm_alarm = AsyncMock(
+            return_value=OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                installation_number="123456",
+                protom_response="N",
+                protom_response_date="",
+            )
+        )
+
+        await alarm._async_arm(AlarmControlPanelState.ARMED_HOME)
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert dismissed == []
+
+    async def test_async_alarm_disarm_fires_dismissed_when_context_present(self):
+        alarm = make_alarm()
+        self._setup_lone_panel(alarm)
+        alarm._force_context = {
+            "reference_id": "ref-1",
+            "suid": "suid-1",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+        alarm._state = AlarmControlPanelState.ARMED_AWAY
+        alarm._last_proto_code = "T"
+        alarm.client.disarm_alarm = AsyncMock(
+            return_value=OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                installation_number="123456",
+                protom_response="D",
+                protom_response_date="",
+            )
+        )
+        alarm.client.arm_alarm = AsyncMock(
+            return_value=OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                installation_number="123456",
+                protom_response="D",
+                protom_response_date="",
+            )
+        )
+
+        await alarm.async_alarm_disarm()
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 1
+        payload = dismissed[0][0][1]
+        assert payload["reason"] == "user_disarm"
+        assert payload["new_mode"] == "disarmed"
+
+    async def test_dismiss_runs_before_dispatch(self):
+        """The dismissed event fires BEFORE the new arm operation dispatches —
+        so the user sees notifications vanish immediately even if the new
+        arm itself fails or hangs."""
+        alarm = make_alarm()
+        self._setup_lone_panel(alarm)
+        alarm._force_context = {
+            "reference_id": "ref-1",
+            "suid": "suid-1",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+        # New arm raises — confirms the dismissed event still fires.
+        alarm.client.arm_alarm = AsyncMock(side_effect=VerisureOwaError("boom"))
+
+        await alarm._async_arm(AlarmControlPanelState.ARMED_HOME)
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert len(dismissed) == 1
+
+    async def test_force_arm_does_not_fire_dismissed_event(self):
+        """async_force_arm is the canonical resolution — must not fire dismissed."""
+        alarm = make_alarm()
+        self._setup_lone_panel(alarm)
+        alarm._state = AlarmControlPanelState.DISARMED
+        alarm._force_context = {
+            "reference_id": "ref-1",
+            "suid": "suid-1",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+        alarm.client.arm_alarm = AsyncMock(
+            return_value=OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                installation_number="123456",
+                protom_response="T",
+                protom_response_date="",
+            )
+        )
+
+        await alarm.async_force_arm()
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert dismissed == []
+
+    async def test_force_arm_cancel_does_not_fire_dismissed_event(self):
+        """async_force_arm_cancel is the canonical resolution — must not fire."""
+        alarm = make_alarm()
+        self._setup_lone_panel(alarm)
+        alarm._force_context = {
+            "reference_id": "ref-1",
+            "suid": "suid-1",
+            "mode": AlarmControlPanelState.ARMED_AWAY,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),
+        }
+
+        await alarm.async_force_arm_cancel()
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        dismissed = [
+            c
+            for c in fire_calls
+            if c[0][0] == "verisure_owa_arming_exception_dismissed"
+        ]
+        assert dismissed == []
+
+
 # ===========================================================================
 # force_arm_cancel service
 # ===========================================================================

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -2176,6 +2176,100 @@ class TestForceArmContext:
         assert alarm._force_context is not None  # untouched
 
 
+class TestForceArmExpiredEventFire:
+    """Tests that the verisure_owa_force_arm_expired event is fired when the
+    180s force-arm context expires."""
+
+    @staticmethod
+    def _expired_context(mode=AlarmControlPanelState.ARMED_AWAY):
+        return {
+            "reference_id": "ref-expire",
+            "suid": "suid-expire",
+            "mode": mode,
+            "exceptions": [
+                {"alias": "Front door", "deviceType": "MG", "zone_id": "1"},
+                {"alias": "Garage", "deviceType": "MG", "zone_id": "2"},
+            ],
+            "created_at": datetime.now() - timedelta(seconds=300),
+        }
+
+    def test_event_fires_on_expiry_via_coordinator_update(self):
+        alarm = make_alarm()
+        alarm._force_context = self._expired_context()
+        alarm._attr_extra_state_attributes["force_arm_available"] = True
+        alarm._attr_extra_state_attributes["arm_exceptions"] = ["Front door", "Garage"]
+        alarm.coordinator.data = AlarmStatusData(
+            status=SStatus(status="D"), protom_response="D"
+        )
+
+        alarm._handle_coordinator_update()
+
+        # Expiry path fires verisure_owa_force_arm_expired with the original
+        # mode + zones derived from the saved exceptions.
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        force_expired = [
+            c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        ]
+        assert len(force_expired) == 1
+        payload = force_expired[0][0][1]
+        assert payload["entity_id"] == alarm.entity_id
+        assert payload["mode"] == AlarmControlPanelState.ARMED_AWAY
+        assert payload["zones"] == ["Front door", "Garage"]
+        assert payload["details"]["installation"] == "123456"
+        assert payload["details"]["exceptions"] == [
+            {"alias": "Front door", "deviceType": "MG", "zone_id": "1"},
+            {"alias": "Garage", "deviceType": "MG", "zone_id": "2"},
+        ]
+        assert "_event_id" in payload
+
+    def test_event_does_not_fire_on_force_clear(self):
+        """force=True clear (cancel/confirm path) must NOT fire the event."""
+        alarm = make_alarm()
+        alarm._force_context = self._expired_context()  # even when expired
+
+        alarm._clear_force_context(force=True)
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        force_expired = [
+            c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        ]
+        assert force_expired == []
+
+    def test_event_does_not_fire_when_context_still_fresh(self):
+        alarm = make_alarm()
+        alarm._force_context = {
+            "reference_id": "ref-fresh",
+            "suid": "suid-fresh",
+            "mode": AlarmControlPanelState.ARMED_HOME,
+            "exceptions": [{"alias": "Door"}],
+            "created_at": datetime.now(),  # fresh
+        }
+
+        alarm._clear_force_context(force=False)
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        force_expired = [
+            c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        ]
+        assert force_expired == []
+        # Context remains because TTL not exceeded
+        assert alarm._force_context is not None
+
+    def test_event_fires_even_when_notifications_disabled(self):
+        """Events are the public API and fire regardless of the notification toggle."""
+        alarm = make_alarm()
+        alarm.client.config["force_arm_notifications"] = False
+        alarm._force_context = self._expired_context()
+
+        alarm._clear_force_context(force=False)
+
+        fire_calls = alarm.hass.bus.async_fire.call_args_list
+        force_expired = [
+            c for c in fire_calls if c[0][0] == "verisure_owa_force_arm_expired"
+        ]
+        assert len(force_expired) == 1
+
+
 # ===========================================================================
 # force_arm_cancel service
 # ===========================================================================

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2234,3 +2234,64 @@ async def test_lock_automations_skipped_when_no_locks_discovered(hass):
     )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+# ===========================================================================
+# Notify-service dropdown — exclude persistent_notification
+# ===========================================================================
+
+
+class TestNotifyServiceDropdown:
+    """The notify-service dropdown must exclude `notify.persistent_notification`.
+
+    The integration already creates its own persistent notification directly
+    via the `persistent_notification` domain — using `notify.persistent_notification`
+    as the Notify service would produce a second, duplicate persistent card on
+    every arming-exception event with no useful content (no actions, generic
+    title), and never reach an actual mobile device.
+    """
+
+    def test_persistent_notification_not_in_dropdown(self):
+        """`notify.persistent_notification` is filtered out of the dropdown."""
+        from custom_components.verisure_owa.config_flow import _get_notify_options
+
+        hass = MagicMock()
+        hass.services.async_services = MagicMock(
+            return_value={
+                "notify": {
+                    "persistent_notification": MagicMock(),
+                    "mobile_app_phone": MagicMock(),
+                    "send_message": MagicMock(),
+                    "notify": MagicMock(),
+                }
+            }
+        )
+
+        options = _get_notify_options(hass)
+        labels = {opt["label"] for opt in options}
+        values = {opt["value"] for opt in options}
+
+        assert "persistent_notification" not in labels
+        assert "persistent_notification" not in values
+        # Real notify targets should still be present.
+        assert "mobile_app_phone" in labels
+
+    def test_dropdown_keeps_existing_exclusions(self):
+        """Pre-existing exclusions (`notify`, `send_message`) still apply."""
+        from custom_components.verisure_owa.config_flow import _get_notify_options
+
+        hass = MagicMock()
+        hass.services.async_services = MagicMock(
+            return_value={
+                "notify": {
+                    "notify": MagicMock(),
+                    "send_message": MagicMock(),
+                    "mobile_app_phone": MagicMock(),
+                }
+            }
+        )
+
+        labels = {opt["label"] for opt in _get_notify_options(hass)}
+        assert "notify" not in labels
+        assert "send_message" not in labels
+        assert "mobile_app_phone" in labels


### PR DESCRIPTION
## Summary

- Two new HA events fire regardless of the `force_arm_notifications` toggle:
  - `verisure_owa_force_arm_expired` — the 180 s force-arm window timed out.
  - `verisure_owa_arming_exception_dismissed` — context cleared by something other than the user tapping Force Arm / Cancel (different arm/disarm action, or integration teardown).
- On 180 s expiry, the mobile notification is now replaced in place with a button-less informational card (same `tag`, no `actions`), matching the persistent notification's existing expiry behaviour.
- Any subsequent arm/disarm action clears stale arming-exception notifications across all panels for the installation (Combined + Interior + Perimeter + Annex), *before* dispatching the new action.
- TTL is now driven by an independent `async_call_later` timer scheduled at `_set_force_context`. The previous coordinator-update-driven check could miss the expiry entirely during a sustained API outage (HA only calls coordinator listeners on success and on success↔fail transitions, not on consecutive failures).
- Reload safety net: if the entity is torn down with `_force_context` still alive (options change, reauth, manual reload), the dismissed event fires with `reason="integration_reload"` and `new_mode=null` so user automations can react.
- Persistent-notification text trimmed in 8 locales — dropped the "or on your mobile notification" clause; anyone reading the persistent card is already in the HA UI.
- 41+ new tests across 10 test classes; full suite 1494 passing; pylint 10/10; ruff clean.

## Test plan

- [x] Unit tests — 1494 passing, lint clean, pylint 10/10.
- [x] Android Companion app: trigger arming exception, wait 180 s, confirm mobile card updates in place to button-less informational with new body text.
- [x] iOS Companion: same.
- [x] Cross-panel dismissal (Combined + sub-panel installations): exception on Combined + arm on Interior clears Combined's notifications.
- [x] Events visible in Developer Tools → Events with documented payloads.
- [x] `force_arm_notifications=False`: events still fire, no built-in mobile/persistent calls.
- [x] Force Arm / Cancel paths unchanged: no dismissed event fires (canonical resolutions keep direct dismissal).
- [x] DNS outage scenario: triggered arming exception then killed network; expired event fires reliably at 180 s regardless of coordinator state.
- [x] Integration reload with context alive: dismissed event fires with `reason="integration_reload"`, `new_mode=null`.

## Breaking changes

- The `verisure_owa_arming_exception_dismissed` event's `reason` field gained a third possible value: `"integration_reload"`. Automations that match a closed set of `'user_arm' | 'user_disarm'` will silently miss this case.
- That event's `new_mode` field can now be `null` (specifically when `reason == "integration_reload"`). Automations that read `new_mode.startswith(...)` or otherwise treat it as always-a-string will need a `new_mode is not none` guard.
- The persistent-notification `arm_blocked_open_sensors.message` text was trimmed in 8 locales. Automations that match the message text would need updating (very unlikely in practice — the text is localized).

README documents both events with payload tables and the breaking-change caveats inline.