### PR TITLE
chore: release 5.0.1

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.0.0"
+    "version": "5.0.1"
 }

--- a/custom_components/verisure_owa/manifest.json
+++ b/custom_components/verisure_owa/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.0.0"
+    "version": "5.0.1"
 }


### PR DESCRIPTION
Bumps both manifests from 5.0.0 to 5.0.1 ahead of the v5.0.1 prerelease tag.

The dispatched `release.yaml` workflow can't push the bump commit directly to `main` (branch protection requires a PR), so this PR carries the bump. Once merged, I'll tag `v5.0.1` against the merge commit and create the GitHub prerelease.

Follow-up: `release.yaml` should be reworked to open-bump-PR-then-tag, since the current direct-push design is incompatible with branch protection.