### PR TITLE
fix: alarm panel entity_id healer respects user renames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ docs/superpowers/
 # Raw HAR captures (contain auth tokens — only sanitised fixtures committed)
 tests/fixtures/*-events.json
 tests/fixtures/*.har
+
+# Local pyright config (user-specific venv path)
+pyrightconfig.json

--- a/custom_components/securitas/alarm_control_panel/__init__.py
+++ b/custom_components/securitas/alarm_control_panel/__init__.py
@@ -57,6 +57,28 @@ __all__ = [
 ]
 
 
+def _is_broken_upgrade_slug(entity_id: str, alias_slug: str, middle: str) -> bool:
+    """Return True when ``entity_id`` matches the known upgrade-path-broken slug.
+
+    Heals exactly one pattern:
+    ``alarm_control_panel.<alias_slug>_<middle>_<alias_slug>`` — the v5
+    doubled-alias bug where HA slugified the friendly name
+    ``<Middle> - <alias>`` and prepended the device name, ending up with the
+    alias twice. ``middle`` is ``"main"`` for the combined panel and the
+    circuit name (``"interior"`` / ``"perimeter"`` / ``"annex"``) for the axis
+    sub-panels.
+
+    A ``<canonical>_<N>`` collision-suffix heal used to exist for the v4→v5
+    upgrade scenario where a stale v4 entity squatted on the canonical slot.
+    That window has closed, and matching ``_<N>`` had a false-positive failure
+    mode: two installations sharing an alias legitimately produce
+    ``<canonical>_<N>`` for the second one, which is NOT broken. Anything
+    other than the doubled-alias pattern is treated as user customization (or
+    a legitimate collision) and left alone.
+    """
+    return entity_id == f"alarm_control_panel.{alias_slug}_{middle}_{alias_slug}"
+
+
 async def _heal_combined_panel_entity_id(
     hass: HomeAssistant, installation: Installation
 ) -> None:
@@ -69,16 +91,23 @@ async def _heal_combined_panel_entity_id(
     canonical slot which pushes the new entity to ``_2``.
 
     Also rewrites the ``deleted_entities`` tombstone if one is present with
-    a non-canonical entity_id, so a delete/re-add cycle doesn't reintroduce
+    a known-broken entity_id, so a delete/re-add cycle doesn't reintroduce
     a stale slug from HA's ``async_get_or_create`` restoration path.
+
+    The healer is **pattern-precise** — it only relocates entity_ids matching
+    the two known-broken patterns enumerated in ``_is_broken_upgrade_slug``.
+    Anything else (notably entity_ids the user renamed via HA's UI) is treated
+    as user customization and left where it is.
 
     This helper:
 
     1. Finds the entity registered under our v5 unique_id for this installation.
     2. If it is already at the canonical slot, returns.
-    3. If the canonical slot is held by another verisure_owa entity (an orphan
+    3. If its current entity_id is NOT a known-broken pattern, returns
+       (user-customized slug, do not touch).
+    4. If the canonical slot is held by another verisure_owa entity (an orphan
        from a previous setup), removes the orphan to free the slot.
-    4. Renames our entity into the canonical slot.
+    5. Renames our entity into the canonical slot.
 
     A non-verisure_owa entity holding the slot is left untouched (we log a
     warning and skip the rename).
@@ -88,9 +117,10 @@ async def _heal_combined_panel_entity_id(
     except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # heal is best-effort; never fail setup
         return
     our_unique_id = f"v4_securitas_direct.{installation.number}"
-    canonical = f"alarm_control_panel.{slugify(installation.alias)}"
+    alias_slug = slugify(installation.alias)
+    canonical = f"alarm_control_panel.{alias_slug}"
 
-    _rewrite_tombstone_entity_id(ent_reg, our_unique_id, canonical)
+    _rewrite_tombstone_entity_id(ent_reg, our_unique_id, canonical, alias_slug, "main")
 
     try:
         our_entity_id = ent_reg.async_get_entity_id(
@@ -99,6 +129,9 @@ async def _heal_combined_panel_entity_id(
     except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         return
     if our_entity_id is None or our_entity_id == canonical:
+        return
+    if not _is_broken_upgrade_slug(our_entity_id, alias_slug, "main"):
+        # User-customized entity_id — leave it alone.
         return
 
     occupant = ent_reg.async_get(canonical)
@@ -156,12 +189,14 @@ async def _heal_subpanel_entity_id(
     except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # heal is best-effort; never fail setup
         return
     our_unique_id = f"v4_securitas_direct.{installation.number}{suffix}"
-    canonical = f"alarm_control_panel.{slugify(installation.alias)}{suffix}"
+    alias_slug = slugify(installation.alias)
+    canonical = f"alarm_control_panel.{alias_slug}{suffix}"
+    circuit = suffix.lstrip("_")
 
     # Rewrite the tombstone first — if the entity is also live (a partial
     # state where both exist on different ids), the live-rename below picks
     # up the canonical slot afterwards.
-    _rewrite_tombstone_entity_id(ent_reg, our_unique_id, canonical)
+    _rewrite_tombstone_entity_id(ent_reg, our_unique_id, canonical, alias_slug, circuit)
 
     try:
         our_entity_id = ent_reg.async_get_entity_id(
@@ -170,6 +205,9 @@ async def _heal_subpanel_entity_id(
     except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         return
     if our_entity_id is None or our_entity_id == canonical:
+        return
+    if not _is_broken_upgrade_slug(our_entity_id, alias_slug, circuit):
+        # User-customized sub-panel entity_id — leave it alone.
         return
 
     occupant = ent_reg.async_get(canonical)
@@ -198,9 +236,13 @@ async def _heal_subpanel_entity_id(
 
 
 def _rewrite_tombstone_entity_id(
-    ent_reg: er.EntityRegistry, unique_id: str, canonical: str
+    ent_reg: er.EntityRegistry,
+    unique_id: str,
+    canonical: str,
+    alias_slug: str,
+    middle: str,
 ) -> None:
-    """Rewrite a non-canonical ``entity_id`` on a deleted-entity tombstone.
+    """Rewrite a known-broken ``entity_id`` on a deleted-entity tombstone.
 
     HA stores deleted entities in ``ent_reg.deleted_entities`` so that user
     customisations (area, name, options) survive a delete/re-add cycle. On
@@ -213,6 +255,11 @@ def _rewrite_tombstone_entity_id(
     (preserving every other field) so the next re-add lands on the correct
     slot from the first registration, not after a follow-up restart's
     healer pass.
+
+    Only rewrites when the tombstone's entity_id matches a known upgrade-path-
+    broken pattern (see ``_is_broken_upgrade_slug``). A tombstone holding a
+    user-customized entity_id is left untouched so a delete/re-add cycle
+    preserves the user's chosen slug.
     """
     import attr
 
@@ -222,6 +269,8 @@ def _rewrite_tombstone_entity_id(
     key = ("alarm_control_panel", DOMAIN, unique_id)
     tombstone = deleted.get(key)
     if tombstone is None or tombstone.entity_id == canonical:
+        return
+    if not _is_broken_upgrade_slug(tombstone.entity_id, alias_slug, middle):
         return
     _LOGGER.info(
         "Rewriting deleted alarm-panel tombstone: %s -> %s",

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -7241,8 +7241,8 @@ class TestCombinedPanelEntityIdHealer:
 
     async def test_evicts_squatting_orphan_in_our_domain(self, hass):
         """When a stale verisure_owa entity holds the canonical slot and ours
-        is languishing at `_2`, the healer removes the squatter and renames
-        ours into the freed slot.
+        is on the broken doubled-alias slug, the healer removes the squatter
+        and renames ours into the freed slot.
         """
         from homeassistant.helpers import entity_registry as er
         from homeassistant.util import slugify
@@ -7266,31 +7266,23 @@ class TestCombinedPanelEntityIdHealer:
         entry = MockConfigEntry(domain=DOMAIN, data={})
         entry.add_to_hass(hass)
         ent_reg = er.async_get(hass)
-        canonical = f"alarm_control_panel.{slugify(installation.alias)}"
+        alias_slug = slugify(installation.alias)
+        canonical = f"alarm_control_panel.{alias_slug}"
         # Stale verisure_owa entity squatting on the canonical slot.
         ent_reg.async_get_or_create(
             "alarm_control_panel",
             DOMAIN,
             "v4_securitas_direct.legacy-stub",
-            suggested_object_id=slugify(installation.alias),
+            suggested_object_id=alias_slug,
             config_entry=entry,
         )
-        # Ours, pushed to `_2`.
+        # Ours, on the broken doubled-alias slug.
         ent_reg.async_get_or_create(
             "alarm_control_panel",
             DOMAIN,
             f"v4_securitas_direct.{installation.number}",
-            suggested_object_id=slugify(installation.alias),
+            suggested_object_id=f"{alias_slug}_main_{alias_slug}",
             config_entry=entry,
-        )
-        # Sanity: HA assigned `_2` to ours.
-        assert (
-            ent_reg.async_get_entity_id(
-                "alarm_control_panel",
-                DOMAIN,
-                f"v4_securitas_direct.{installation.number}",
-            )
-            == f"{canonical}_2"
         )
 
         await _heal_combined_panel_entity_id(hass, installation)
@@ -7335,26 +7327,29 @@ class TestCombinedPanelEntityIdHealer:
         entry = MockConfigEntry(domain=DOMAIN, data={})
         entry.add_to_hass(hass)
         ent_reg = er.async_get(hass)
-        canonical = f"alarm_control_panel.{slugify(installation.alias)}"
+        alias_slug = slugify(installation.alias)
+        canonical = f"alarm_control_panel.{alias_slug}"
+        broken = f"{alias_slug}_main_{alias_slug}"
         # An unrelated integration's entity occupies the slot.
         ent_reg.async_get_or_create(
             "alarm_control_panel",
             "manual_alarm",
             "manual-alarm-unique-id",
-            suggested_object_id=slugify(installation.alias),
+            suggested_object_id=alias_slug,
             config_entry=entry,
         )
+        # Ours, on the broken doubled-alias slug.
         ent_reg.async_get_or_create(
             "alarm_control_panel",
             DOMAIN,
             f"v4_securitas_direct.{installation.number}",
-            suggested_object_id=slugify(installation.alias),
+            suggested_object_id=broken,
             config_entry=entry,
         )
 
         await _heal_combined_panel_entity_id(hass, installation)
 
-        # Other-domain entity still there; ours stays at `_2`.
+        # Other-domain entity still there; ours stays on the broken slug.
         assert (
             ent_reg.async_get_entity_id(
                 "alarm_control_panel", "manual_alarm", "manual-alarm-unique-id"
@@ -7367,8 +7362,207 @@ class TestCombinedPanelEntityIdHealer:
                 DOMAIN,
                 f"v4_securitas_direct.{installation.number}",
             )
+            == f"alarm_control_panel.{broken}"
+        )
+
+    async def test_does_not_evict_another_installation_with_same_alias(self, hass):
+        """Two combined panels sharing an alias must not clobber each other.
+
+        Installation A registers first and takes the canonical slot;
+        installation B (same alias) collides → HA assigns ``<canonical>_2``.
+        Both are legitimately live. Heal for B must NOT treat ``_2`` as a
+        broken upgrade artifact and evict A — that would silently delete A's
+        combined panel on every restart.
+        """
+        from homeassistant.helpers import entity_registry as er
+        from homeassistant.util import slugify
+
+        from custom_components.securitas.alarm_control_panel import (
+            _heal_combined_panel_entity_id,
+        )
+        from custom_components.securitas.const import DOMAIN
+        from custom_components.securitas.verisure_owa_api.models import (
+            Installation,
+        )
+
+        installation_a = Installation(
+            number="100001",
+            alias="Home",
+            panel="SDVFAST",
+            type="PLUS",
+            address="",
+            city="",
+        )
+        installation_b = Installation(
+            number="100002",
+            alias="Home",
+            panel="SDVFAST",
+            type="PLUS",
+            address="",
+            city="",
+        )
+        entry = MockConfigEntry(domain=DOMAIN, data={})
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        alias_slug = slugify(installation_a.alias)
+        canonical = f"alarm_control_panel.{alias_slug}"
+        # A is correctly registered at the canonical slot.
+        ent_reg.async_get_or_create(
+            "alarm_control_panel",
+            DOMAIN,
+            f"v4_securitas_direct.{installation_a.number}",
+            suggested_object_id=alias_slug,
+            config_entry=entry,
+        )
+        # B collided and landed on `<canonical>_2`.
+        ent_reg.async_get_or_create(
+            "alarm_control_panel",
+            DOMAIN,
+            f"v4_securitas_direct.{installation_b.number}",
+            suggested_object_id=alias_slug,
+            config_entry=entry,
+        )
+
+        await _heal_combined_panel_entity_id(hass, installation_b)
+
+        # A must still be at canonical.
+        assert (
+            ent_reg.async_get_entity_id(
+                "alarm_control_panel",
+                DOMAIN,
+                f"v4_securitas_direct.{installation_a.number}",
+            )
+            == canonical
+        )
+        # B stays where it landed.
+        assert (
+            ent_reg.async_get_entity_id(
+                "alarm_control_panel",
+                DOMAIN,
+                f"v4_securitas_direct.{installation_b.number}",
+            )
             == f"{canonical}_2"
         )
+
+    async def test_preserves_user_customized_entity_id(self, hass):
+        """A user-customized entity_id (renamed via HA UI) must survive the
+        healer. The healer is only allowed to relocate entities that sit on
+        the known-broken ``<alias>_main_<alias>`` upgrade slug — any other
+        non-canonical slug is treated as user customization and left alone.
+        """
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.securitas.alarm_control_panel import (
+            _heal_combined_panel_entity_id,
+        )
+        from custom_components.securitas.const import DOMAIN
+        from custom_components.securitas.verisure_owa_api.models import (
+            Installation,
+        )
+
+        installation = Installation(
+            number="100001",
+            alias="Corso Vittorio Emanuele 252 Roma",
+            panel="SDVFAST",
+            type="PLUS",
+            address="",
+            city="",
+        )
+        entry = MockConfigEntry(domain=DOMAIN, data={})
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        custom_slug = "chiesa_nuova_alarm_corso_vittorio_emanuele_252_roma"
+        ent_reg.async_get_or_create(
+            "alarm_control_panel",
+            DOMAIN,
+            f"v4_securitas_direct.{installation.number}",
+            suggested_object_id=custom_slug,
+            config_entry=entry,
+        )
+
+        await _heal_combined_panel_entity_id(hass, installation)
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "alarm_control_panel",
+                DOMAIN,
+                f"v4_securitas_direct.{installation.number}",
+            )
+            == f"alarm_control_panel.{custom_slug}"
+        )
+
+    @pytest.mark.skipif(
+        not _DELETED_REGISTRY_ENTRY_HAS_ALIASES,
+        reason=(
+            "DeletedRegistryEntry.aliases field was added after our "
+            "minimum-supported HA (2025.2); the test seeds a tombstone via "
+            "the dataclass constructor so its kwargs have to match the live "
+            "HA's attr fields."
+        ),
+    )
+    async def test_preserves_user_customized_tombstone(self, hass):
+        """A tombstone holding a user-customized entity_id must NOT be
+        rewritten to canonical. Otherwise a delete/re-add cycle would silently
+        discard the user's chosen slug on re-add.
+        """
+        from datetime import datetime, timezone
+
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.securitas.alarm_control_panel import (
+            _heal_combined_panel_entity_id,
+        )
+        from custom_components.securitas.const import DOMAIN
+        from custom_components.securitas.verisure_owa_api.models import (
+            Installation,
+        )
+
+        installation = Installation(
+            number="100001",
+            alias="Corso Vittorio Emanuele 252 Roma",
+            panel="SDVFAST",
+            type="PLUS",
+            address="",
+            city="",
+        )
+        ent_reg = er.async_get(hass)
+        unique_id = f"v4_securitas_direct.{installation.number}"
+        custom_entity_id = (
+            "alarm_control_panel.chiesa_nuova_alarm_corso_vittorio_emanuele_252_roma"
+        )
+
+        now = datetime.now(timezone.utc)
+        ent_reg.deleted_entities[("alarm_control_panel", DOMAIN, unique_id)] = (
+            DeletedRegistryEntry(
+                entity_id=custom_entity_id,
+                unique_id=unique_id,
+                platform=DOMAIN,
+                aliases=set(),
+                area_id=None,
+                categories={},
+                config_entry_id=None,
+                config_subentry_id=None,
+                created_at=now,
+                device_class=None,
+                disabled_by=None,
+                hidden_by=None,
+                icon=None,
+                id="some-id",
+                labels=set(),
+                modified_at=now,
+                name=None,
+                options={},
+                orphaned_timestamp=None,
+            )
+        )
+
+        await _heal_combined_panel_entity_id(hass, installation)
+
+        tombstone = ent_reg.deleted_entities.get(
+            ("alarm_control_panel", DOMAIN, unique_id)
+        )
+        assert tombstone is not None
+        assert tombstone.entity_id == custom_entity_id
 
 
 # ===========================================================================
@@ -7645,6 +7839,131 @@ class TestSubPanelEntityIdHealer:
         assert tombstone.entity_id == canonical, (
             f"tombstone still has broken entity_id {tombstone.entity_id!r}"
         )
+
+    @pytest.mark.parametrize(
+        "suffix",
+        ["_interior", "_perimeter", "_annex"],
+    )
+    async def test_preserves_user_customized_entity_id(self, hass, suffix):
+        """A user-customized sub-panel entity_id must survive the healer.
+        Only known-broken patterns (``<alias>_<circuit>_<alias>`` or
+        ``<alias>_<circuit>_<N>`` collision suffix) may be relocated.
+        """
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.securitas.alarm_control_panel import (
+            _heal_subpanel_entity_id,
+        )
+        from custom_components.securitas.const import DOMAIN
+        from custom_components.securitas.verisure_owa_api.models import (
+            Installation,
+        )
+
+        installation = Installation(
+            number="100001",
+            alias="Corso Vittorio Emanuele 252 Roma",
+            panel="SDVFAST",
+            type="PLUS",
+            address="",
+            city="",
+        )
+        entry = MockConfigEntry(domain=DOMAIN, data={})
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        circuit = suffix.lstrip("_")
+        custom_slug = f"chiesa_nuova_{circuit}"
+        ent_reg.async_get_or_create(
+            "alarm_control_panel",
+            DOMAIN,
+            f"v4_securitas_direct.{installation.number}{suffix}",
+            suggested_object_id=custom_slug,
+            config_entry=entry,
+        )
+
+        await _heal_subpanel_entity_id(hass, installation, suffix)
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "alarm_control_panel",
+                DOMAIN,
+                f"v4_securitas_direct.{installation.number}{suffix}",
+            )
+            == f"alarm_control_panel.{custom_slug}"
+        )
+
+    @pytest.mark.skipif(
+        not _DELETED_REGISTRY_ENTRY_HAS_ALIASES,
+        reason=(
+            "DeletedRegistryEntry.aliases field was added after our "
+            "minimum-supported HA (2025.2); see the doubled-alias tombstone "
+            "test above for the rationale."
+        ),
+    )
+    @pytest.mark.parametrize(
+        "suffix",
+        ["_interior", "_perimeter", "_annex"],
+    )
+    async def test_preserves_user_customized_tombstone(self, hass, suffix):
+        """A sub-panel tombstone holding a user-customized entity_id must NOT
+        be rewritten to canonical.
+        """
+        from datetime import datetime, timezone
+
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.securitas.alarm_control_panel import (
+            _heal_subpanel_entity_id,
+        )
+        from custom_components.securitas.const import DOMAIN
+        from custom_components.securitas.verisure_owa_api.models import (
+            Installation,
+        )
+
+        installation = Installation(
+            number="100001",
+            alias="Corso Vittorio Emanuele 252 Roma",
+            panel="SDVFAST",
+            type="PLUS",
+            address="",
+            city="",
+        )
+        ent_reg = er.async_get(hass)
+        unique_id = f"v4_securitas_direct.{installation.number}{suffix}"
+        circuit = suffix.lstrip("_")
+        custom_entity_id = f"alarm_control_panel.chiesa_nuova_{circuit}"
+
+        now = datetime.now(timezone.utc)
+        ent_reg.deleted_entities[("alarm_control_panel", DOMAIN, unique_id)] = (
+            DeletedRegistryEntry(
+                entity_id=custom_entity_id,
+                unique_id=unique_id,
+                platform=DOMAIN,
+                aliases=set(),
+                area_id=None,
+                categories={},
+                config_entry_id=None,
+                config_subentry_id=None,
+                created_at=now,
+                device_class=None,
+                disabled_by=None,
+                hidden_by=None,
+                icon=None,
+                id=f"some-id-{suffix}",
+                labels=set(),
+                modified_at=now,
+                name=None,
+                options={},
+                orphaned_timestamp=None,
+            )
+        )
+
+        await _heal_subpanel_entity_id(hass, installation, suffix)
+
+        tombstone = ent_reg.deleted_entities.get(
+            ("alarm_control_panel", DOMAIN, unique_id)
+        )
+        assert tombstone is not None
+        assert tombstone.entity_id == custom_entity_id
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

The combined- and sub-panel healers in `alarm_control_panel/__init__.py` used to rename any non-canonical entity_id back to `alarm_control_panel.<alias>[_<circuit>]` on every restart. That caused two regressions:

1. **User renames reverted on restart.** Users who renamed their alarm entity via the HA UI (e.g. `alarm_control_panel.chiesa_nuova`) would see the entity_id forced back to the address-based canonical form on the next restart.
2. **Multi-installation collision evicted the first installation.** Two installations sharing an alias collided on the canonical slot. The second one (at `<canonical>_2`) would evict the first on every restart.

The healer now matches one pattern only: `<alias>_<middle>_<alias>` — the v5 doubled-alias bug from HA slugifying the friendly name `Main - <alias>` with the device-name prepended. Anything else is treated as user customization (or a legitimate collision) and left where it is. The tombstone rewriter is gated by the same check so a delete/re-add cycle preserves user slugs.

The `<canonical>_<N>` collision-suffix heal originally added in 664b1b6 for the v4→v5 upgrade window is dropped — the window has closed, and matching `_<N>` was exactly what caused the multi-installation eviction bug.

## Test plan

- [x] `pytest tests/` — 1565 pass (8 new tests added: combined + sub-panel user-customization survival, multi-installation same-alias separation; doubled-alias healing still covered)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pylint custom_components/securitas/` — 10.00/10
- [x] `pyright custom_components/` — 0 errors