### PR TITLE
fix: humanize bare alarm-manager panel-rejection codes

### DIFF
--- a/custom_components/securitas/verisure_owa_api/client/_alarm.py
+++ b/custom_components/securitas/verisure_owa_api/client/_alarm.py
@@ -42,32 +42,43 @@ _ERROR_TYPE_LABELS: dict[str, str] = {
     "TECHNICAL_ERROR": "Technical error",
 }
 
-# All known error-shaped msgs start with this prefix (covers both
-# ``alarm-manager.error_<word>...`` and ``alarm-manager.errdca3``-style
-# bare codes). ``alarm-manager.processed.request`` and
-# ``alarm-manager.processing.request`` are success codes that don't start
-# with ``err`` and pass through unchanged.
-_ALARM_ERR_PREFIX = "alarm-manager.err"
-_ALARM_ERROR_PREFIX = "alarm-manager.error_"
+_ALARM_MANAGER_PREFIX = "alarm-manager."
+
+# Surfaced when the panel rejects an arm/disarm because the user's
+# state mapping asks for a mode the panel isn't configured to support.
+# Exported so tests can build the same expected message without
+# duplicating the wording.
+PANEL_REJECTION_TEMPLATE = (
+    "Unsupported operation `{msg}` — check the Alarm State Mappings "
+    "in Settings > Devices > Verisure OWA > ⚙️"
+)
 
 
 def humanize_panel_error_msg(msg: str, error: dict[str, Any] | None = None) -> str:
     """Convert a raw panel error to a short label suitable for a notification.
 
-    Three input shapes the panel actually emits in the wild:
+    Four input shapes the panel actually emits in the wild, all under the
+    ``alarm-manager.`` namespace plus a pass-through for anything else:
 
     1. ``alarm-manager.error_<code>[#zone_id]`` — the structured form. Known
        codes get a curated label; unknown ones get the code title-cased.
        If a ``#zone_id`` suffix is present, the underscore-separated path
        is shown in parens.
-    2. ``alarm-manager.<bare-code>`` (e.g. ``alarm-manager.errdca3``) —
+    2. ``alarm-manager.err<bare-code>`` (e.g. ``alarm-manager.errdca3``) —
        terse internal codes with no human-readable suffix. When the caller
        passes ``error`` (the structured ``error`` field from the response)
        and it has a ``type``, we surface the type label and keep the raw
        code in parens for support. Without the error dict, we fall back
        to title-casing the bare code.
-    3. Anything else — passed through unchanged so non-panel error
-       messages (network errors, library exceptions, etc.) aren't mangled.
+    3. ``alarm-manager.<single-token>`` outside the err* family (e.g.
+       ``usm8``, ``usm9``) — panel rejected the requested action because
+       the user's alarm state mappings ask for a mode the panel isn't
+       configured to support. Point the user at the mappings rather than
+       guessing at each code's meaning. The dot-free body check excludes
+       success/progress messages like ``alarm-manager.processed.request``.
+    4. Anything else — passed through unchanged so non-panel error
+       messages (network errors, library exceptions, etc.) and
+       alarm-manager success messages aren't mangled.
 
     Pre-v5 (and v5.0.0/.1) surfaced shapes 1 and 2 raw via the
     ``arm_failed`` notification, producing user-facing text like
@@ -75,12 +86,13 @@ def humanize_panel_error_msg(msg: str, error: dict[str, Any] | None = None) -> s
     or ``Arm command failed: alarm-manager.errdca3``.
     """
     if not msg:
-        return msg or ""
+        return ""
+    if not msg.startswith(_ALARM_MANAGER_PREFIX):
+        return msg
+    body = msg.removeprefix(_ALARM_MANAGER_PREFIX)
 
-    # Shape 1 — structured error_<code>[#zone] form.
-    if msg.startswith(_ALARM_ERROR_PREFIX):
-        body = msg[len(_ALARM_ERROR_PREFIX) :]
-        code, sep, suffix = body.partition("#")
+    if body.startswith("error_"):
+        code, sep, suffix = body.removeprefix("error_").partition("#")
         label = (
             _KNOWN_PANEL_ERROR_CODES.get(code) or code.replace("_", " ").capitalize()
         )
@@ -89,18 +101,20 @@ def humanize_panel_error_msg(msg: str, error: dict[str, Any] | None = None) -> s
             return f"{label} ({zone_path})"
         return label
 
-    # Shape 2 — bare alarm-manager.err<code>. Use error.type as the label
-    # when available; otherwise strip the alarm-manager. prefix and
-    # title-case what's left.
-    if msg.startswith(_ALARM_ERR_PREFIX):
+    # err* must be checked before the dot-free fallback — bare err codes
+    # like ``errdca3`` also have no dot in the body and would otherwise be
+    # captured by the panel-rejection shape.
+    if body.startswith("err"):
         if error and (error_type := error.get("type")):
             type_label = _ERROR_TYPE_LABELS.get(
                 error_type, error_type.replace("_", " ").capitalize()
             )
             return f"{type_label} ({msg})"
-        return msg[len("alarm-manager.") :].capitalize()
+        return body.capitalize()
 
-    # Shape 3 — pass through.
+    if "." not in body:
+        return PANEL_REJECTION_TEMPLATE.format(msg=msg)
+
     return msg
 
 

--- a/tests/test_humanize_panel_error.py
+++ b/tests/test_humanize_panel_error.py
@@ -5,6 +5,7 @@ something a user can read in a notification."""
 from __future__ import annotations
 
 from custom_components.securitas.verisure_owa_api.client._alarm import (
+    PANEL_REJECTION_TEMPLATE,
     humanize_panel_error_msg,
 )
 
@@ -121,6 +122,45 @@ class TestStructuredErrorFormStillWorks:
         )
         # The structured form's curated label wins; the error dict is ignored.
         assert out == "Open zone (Pl / Home / Cocina / Puertajardi)"
+
+
+class TestPanelRejectionBareCode:
+    """Bare ``alarm-manager.<code>`` strings outside the ``err*`` family
+    (e.g. ``usm8``, ``usm9``) signal that the panel rejected the requested
+    action — typically because the user's alarm state mappings ask for a
+    mode the panel isn't configured to support (e.g. day-mode arm with no
+    sensors assigned to that mode, disarm-with-annex on a panel without an
+    annex circuit). The fix is almost always to reconfigure the alarm
+    state mappings, so the surfaced message points the user there rather
+    than guessing at the specific code's meaning.
+    """
+
+    def test_usm9_arm_failure(self) -> None:
+        """Real case: day-mode arm rejected because no sensors are
+        assigned to that mode in the panel configuration."""
+        msg = "alarm-manager.usm9"
+        assert humanize_panel_error_msg(msg) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
+
+    def test_usm8_disarm_failure(self) -> None:
+        """Real case: disarm-with-annex rejected on a panel that doesn't
+        support the requested combination."""
+        msg = "alarm-manager.usm8"
+        assert humanize_panel_error_msg(msg) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
+
+    def test_unknown_bare_code_gets_same_treatment(self) -> None:
+        """Any bare ``alarm-manager.<single-token>`` that isn't an err* or
+        error_* shape gets the panel-rejection message — we don't try to
+        decode each code individually."""
+        msg = "alarm-manager.something_new"
+        assert humanize_panel_error_msg(msg) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
+
+    def test_error_dict_does_not_break_bare_code_handling(self) -> None:
+        """A bare non-err code should not pick up the err* error.type
+        fallback path even when an error dict is passed in."""
+        msg = "alarm-manager.usm9"
+        assert humanize_panel_error_msg(
+            msg, error={"code": msg, "type": "BLOCKING"}
+        ) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
 
 
 class TestPassThroughForNonPanelMessages:

--- a/tests/test_humanize_panel_error.py
+++ b/tests/test_humanize_panel_error.py
@@ -5,7 +5,6 @@ something a user can read in a notification."""
 from __future__ import annotations
 
 from custom_components.securitas.verisure_owa_api.client._alarm import (
-    PANEL_REJECTION_TEMPLATE,
     humanize_panel_error_msg,
 )
 
@@ -138,29 +137,38 @@ class TestPanelRejectionBareCode:
     def test_usm9_arm_failure(self) -> None:
         """Real case: day-mode arm rejected because no sensors are
         assigned to that mode in the panel configuration."""
-        msg = "alarm-manager.usm9"
-        assert humanize_panel_error_msg(msg) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
+        assert humanize_panel_error_msg("alarm-manager.usm9") == (
+            "Unsupported operation `alarm-manager.usm9` — check the Alarm "
+            "State Mappings in Settings > Devices > Verisure OWA > ⚙️"
+        )
 
     def test_usm8_disarm_failure(self) -> None:
         """Real case: disarm-with-annex rejected on a panel that doesn't
         support the requested combination."""
-        msg = "alarm-manager.usm8"
-        assert humanize_panel_error_msg(msg) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
+        assert humanize_panel_error_msg("alarm-manager.usm8") == (
+            "Unsupported operation `alarm-manager.usm8` — check the Alarm "
+            "State Mappings in Settings > Devices > Verisure OWA > ⚙️"
+        )
 
     def test_unknown_bare_code_gets_same_treatment(self) -> None:
         """Any bare ``alarm-manager.<single-token>`` that isn't an err* or
         error_* shape gets the panel-rejection message — we don't try to
         decode each code individually."""
-        msg = "alarm-manager.something_new"
-        assert humanize_panel_error_msg(msg) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
+        assert humanize_panel_error_msg("alarm-manager.something_new") == (
+            "Unsupported operation `alarm-manager.something_new` — check "
+            "the Alarm State Mappings in Settings > Devices > Verisure OWA > ⚙️"
+        )
 
     def test_error_dict_does_not_break_bare_code_handling(self) -> None:
         """A bare non-err code should not pick up the err* error.type
         fallback path even when an error dict is passed in."""
-        msg = "alarm-manager.usm9"
         assert humanize_panel_error_msg(
-            msg, error={"code": msg, "type": "BLOCKING"}
-        ) == PANEL_REJECTION_TEMPLATE.format(msg=msg)
+            "alarm-manager.usm9",
+            error={"code": "alarm-manager.usm9", "type": "BLOCKING"},
+        ) == (
+            "Unsupported operation `alarm-manager.usm9` — check the Alarm "
+            "State Mappings in Settings > Devices > Verisure OWA > ⚙️"
+        )
 
 
 class TestPassThroughForNonPanelMessages:


### PR DESCRIPTION
## Summary

Bare `alarm-manager.<code>` codes outside the `err*` family (e.g. `usm8`, `usm9`) were passing through `humanize_panel_error_msg` untouched, so users saw raw codes like `Arm command failed: alarm-manager.usm9` in the failed-arm notification.

Observed in the wild:
- `usm9` — day-mode arm rejected because no sensors are assigned to that mode
- `usm8` — disarm-with-annex rejected on a panel that doesn't support the combination

The remediation is the same regardless of the specific code: the user's alarm state mapping is asking the panel for a mode it doesn't support. Add a generic panel-rejection shape that catches any `alarm-manager.<single-token>` body and points the user at the mappings UI:

> Arm command failed: Unsupported operation \`alarm-manager.usm9\` — check the Alarm State Mappings in Settings > Devices > Verisure OWA > ⚙️

The dot-free body check excludes success/progress messages like `alarm-manager.processed.request` so those still pass through.

Also collapsed three prefix constants to one (`_ALARM_MANAGER_PREFIX`) and switched to `removeprefix` — the function now strips the namespace once at the top and dispatches on body shape.

## Test plan

- [x] 4 new tests in `TestPanelRejectionBareCode` covering `usm8`, `usm9`, an unknown bare code, and the error-dict-doesn't-interfere case
- [x] All existing `humanize_panel_error_msg` tests still pass (21 total)
- [x] Full suite: 1569 tests pass
- [x] `ruff check` / `ruff format` clean
- [x] `pylint custom_components/securitas/` 10.00/10
- [x] `pyright custom_components/` 0 errors