### PR TITLE
ci: split unit/integration tests with combined 90% coverage gate

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,12 +61,13 @@ jobs:
         run: pyright custom_components/
 
   test:
-    name: Tests (${{ matrix.ha-channel }})
+    name: Tests (${{ matrix.ha-channel }}, ${{ matrix.suite }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ha-channel: [dev, stable, minimum]
+        suite: [unit, integration]
     steps:
       - uses: actions/checkout@v4
 
@@ -100,10 +101,56 @@ jobs:
           python -m pip install --pre pytest-homeassistant-custom-component
           pip install -r requirements_test.txt
 
-      - name: Run tests with coverage
+      - name: Run ${{ matrix.suite }} tests with coverage
+        env:
+          # parallel=true in pyproject.toml suffixes the data file per process;
+          # COVERAGE_FILE pins the base so artifacts upload cleanly.
+          COVERAGE_FILE: .coverage.${{ matrix.ha-channel }}.${{ matrix.suite }}
         run: |
+          if [ "${{ matrix.suite }}" = "unit" ]; then
+            MARKER="not integration"
+          else
+            MARKER="integration"
+          fi
           python -m pytest tests/ -v --tb=short \
-            --cov=custom_components/verisure_owa \
-            --cov=custom_components/securitas \
-            --cov-report=term-missing \
-            --cov-fail-under=90
+            -m "$MARKER" \
+            --cov --cov-report=term-missing --no-cov-on-fail
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.ha-channel }}-${{ matrix.suite }}
+          path: .coverage.${{ matrix.ha-channel }}.${{ matrix.suite }}*
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
+  coverage-gate:
+    name: Coverage gate (90%)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - run: pip install coverage
+
+      # Gate on the stable channel only — code is identical across channels,
+      # so running the gate 3x would just multiply CI minutes for no signal.
+      - name: Download unit coverage (stable)
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-stable-unit
+
+      - name: Download integration coverage (stable)
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-stable-integration
+
+      - name: Combine and report
+        run: |
+          coverage combine
+          coverage report --fail-under=90

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+.coverage.*
 .tox
 coverage.xml
 nosetests.xml

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -754,7 +754,7 @@ def register_service_aliases(hass: HomeAssistant) -> None:
         async_set_service_schema(hass, ALIAS_DOMAIN, service_name, schema)
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG001  # pylint: disable=unused-argument
+async def async_setup(hass: HomeAssistant, config: dict[str, object]) -> bool:  # noqa: ARG001  # pylint: disable=unused-argument
     """Integration-wide setup, called once regardless of config entries.
 
     Surfaces a Repairs issue if an orphaned ``custom_components/verisure_owa/``

--- a/custom_components/securitas/events.py
+++ b/custom_components/securitas/events.py
@@ -42,7 +42,7 @@ FORCE_ARM_EXPIRED_EVENT_TYPE = "verisure_owa_force_arm_expired"
 ARMING_EXCEPTION_DISMISSED_EVENT_TYPE = "verisure_owa_arming_exception_dismissed"
 
 
-def fire_event(hass: HomeAssistant, suffix: str, payload: dict) -> None:
+def fire_event(hass: HomeAssistant, suffix: str, payload: dict[str, object]) -> None:
     """Fire ``verisure_owa_<suffix>`` and ``securitas_<suffix>`` in the same tick.
 
     Both events carry identical payloads. Subscribers that match either

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -475,7 +475,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
     // re-allocate it for every unrelated entity update.
     this._statesFP = config.states === undefined
       ? "*"
-      : (config.states || []).join(",");
+      : (Array.isArray(config.states) ? config.states : []).join(",");
     if (this._hass) this._render();
   }
 
@@ -1185,7 +1185,7 @@ class VerisureOwaAlarmCardEditor extends HTMLElement {
       const cb      = document.createElement("input");
       cb.type       = "checkbox";
       cb.dataset.armKey = action.key;
-      cb.checked    = configStates === undefined || configStates.includes(action.key);
+      cb.checked    = !Array.isArray(configStates) || configStates.includes(action.key);
 
       const text = document.createElement("span");
       text.textContent = _t(lang, action.labelKey);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,29 @@
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "integration: test exercises an external surface (HA core or mock_graphql). Auto-applied by conftest.pytest_collection_modifyitems based on imports/fixtures.",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["custom_components/securitas"]
+parallel = true
+# Distinct data file per worker/job so `coverage combine` can merge unit + integration runs.
+data_file = ".coverage"
+
+[tool.coverage.report]
+# fail_under intentionally NOT set here — applied by the CI `coverage-gate` job
+# via `coverage report --fail-under=90` after combining unit + integration runs.
+# Setting it here would cause individual subset runs (local or per-CI-job) to
+# trip the gate before the combine step.
+show_missing = true
+skip_covered = false
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "@(abc\\.)?abstractmethod",
+]
 
 [tool.ruff]
 exclude = [".claude"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Shared fixtures for the Verisure OWA HA integration tests."""
 
+import re
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
@@ -46,6 +48,42 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     CONF_USERNAME,
 )
+
+
+# ── integration-marker auto-application ───────────────────────────────────────
+#
+# Tests that import `homeassistant` or `tests.mock_graphql`, or request the
+# `mock_server` fixture, are integration tests. Rather than relying on developers
+# to remember `pytestmark = pytest.mark.integration` on every such file, we
+# auto-apply the marker at collection time. See tests/test_markers.py for the
+# meta-test that pins the expected file set.
+
+_INTEGRATION_IMPORT_RE = re.compile(
+    r"^\s*(?:from|import)\s+(?:homeassistant|tests\.mock_graphql|\.mock_graphql)",
+    re.MULTILINE,
+)
+
+
+def _file_is_integration(path: Path) -> bool:
+    try:
+        source = path.read_text()
+    except OSError:
+        return False
+    return bool(_INTEGRATION_IMPORT_RE.search(source))
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Auto-apply the `integration` marker to tests touching external surfaces."""
+    file_cache: dict[Path, bool] = {}
+    for item in items:
+        path = Path(str(item.fspath))
+        if path not in file_cache:
+            file_cache[path] = _file_is_integration(path)
+        uses_mock_server = "mock_server" in getattr(item, "fixturenames", ())
+        if file_cache[path] or uses_mock_server:
+            item.add_marker(pytest.mark.integration)
 
 
 # ── JWT helpers ──────────────────────────────────────────────────────────────

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -14,8 +14,8 @@ import ast
 import re
 from pathlib import Path
 
-CLIENT_PACKAGE = Path("custom_components/verisure_owa/verisure_owa_api")
-INTEGRATION_PACKAGE = Path("custom_components/verisure_owa")
+CLIENT_PACKAGE = Path("custom_components/securitas/verisure_owa_api")
+INTEGRATION_PACKAGE = Path("custom_components/securitas")
 
 # Pydantic validators legitimately use bare dict/Any in signatures
 _VALIDATOR_DECORATORS = frozenset({"field_validator", "model_validator", "validator"})
@@ -267,4 +267,33 @@ class TestIntegrationAnyUsageBaseline:
             f"Standalone `Any` count ({count}) exceeds integration baseline "
             f"({self._BASELINE}). If you intentionally added `Any`, "
             f"update _BASELINE. Otherwise, use a more specific type."
+        )
+
+
+# ── Path sanity checks ──────────────────────────────────────────────────────
+#
+# The architecture tests above all rely on `_client_files()` and
+# `_integration_files()` returning a non-empty list. If the path constants
+# drift (e.g. after a rename) these would silently return [] and every
+# architecture assertion would trivially pass. These tests catch that.
+
+
+class TestPackagePathsResolve:
+    """Pin that the package path constants point to real, non-empty directories."""
+
+    def test_client_package_is_non_empty(self):
+        files = _client_files()
+        assert files, (
+            f"_client_files() is empty — CLIENT_PACKAGE ({CLIENT_PACKAGE}) "
+            f"likely points to a renamed/removed directory. Architecture "
+            f"checks would silently pass without scanning anything."
+        )
+
+    def test_integration_package_is_non_empty(self):
+        files = _integration_files()
+        assert files, (
+            f"_integration_files() is empty — INTEGRATION_PACKAGE "
+            f"({INTEGRATION_PACKAGE}) likely points to a renamed/removed "
+            f"directory. Architecture checks would silently pass without "
+            f"scanning anything."
         )

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -34,11 +34,16 @@ EXPECTED_INTEGRATION_FILES = frozenset(
     }
 )
 
-INTEGRATION_MARKERS = ("from homeassistant", "import homeassistant", "mock_graphql")
+INTEGRATION_MARKERS = (
+    "from homeassistant",
+    "import homeassistant",
+    "mock_graphql",
+    "mock_server",
+)
 
 
 def _has_integration_imports(path: Path) -> bool:
-    source = path.read_text()
+    source = path.read_text(encoding="utf-8")
     return any(marker in source for marker in INTEGRATION_MARKERS)
 
 
@@ -51,13 +56,13 @@ def test_expected_integration_files_have_integration_imports() -> None:
     ]
     assert not missing_imports, (
         f"Files listed in EXPECTED_INTEGRATION_FILES no longer import "
-        f"homeassistant or mock_graphql — remove them from the expected set: "
-        f"{missing_imports}"
+        f"homeassistant or mock_graphql, nor request the mock_server fixture — "
+        f"remove them from the expected set: {missing_imports}"
     )
 
 
 def test_no_unlisted_test_file_has_integration_imports() -> None:
-    """Every test_*.py file with HA or mock_graphql imports is in the expected set."""
+    """Every test_*.py file with HA, mock_graphql, or mock_server is in the expected set."""
     unlisted_with_imports: list[str] = []
     for path in sorted(TESTS_DIR.glob("test_*.py")):
         if path.name in EXPECTED_INTEGRATION_FILES or path.name == "test_markers.py":
@@ -65,7 +70,8 @@ def test_no_unlisted_test_file_has_integration_imports() -> None:
         if _has_integration_imports(path):
             unlisted_with_imports.append(path.name)
     assert not unlisted_with_imports, (
-        f"These files import homeassistant or mock_graphql but are not in "
-        f"EXPECTED_INTEGRATION_FILES. Add them to the set so the integration "
-        f"marker stays in sync: {unlisted_with_imports}"
+        f"These files import homeassistant or mock_graphql, or request the "
+        f"mock_server fixture, but are not in EXPECTED_INTEGRATION_FILES. Add "
+        f"them to the set so the integration marker stays in sync: "
+        f"{unlisted_with_imports}"
     )

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,71 @@
+"""Meta-test pinning which test files belong in the `integration` bucket.
+
+The `integration` marker is auto-applied by `conftest.pytest_collection_modifyitems`
+to tests whose source file imports `homeassistant` or `tests.mock_graphql`, or
+that request the `mock_server` fixture.
+
+This file does NOT verify the hook itself fires at collection time (that would
+require running a sub-pytest). Instead it verifies the *invariant the hook
+depends on*: that every file in `EXPECTED_INTEGRATION_FILES` actually has those
+imports, and that no other test file does. If the hook is ever deleted, the CI
+integration job will collect 0 tests and fail loudly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent
+
+EXPECTED_INTEGRATION_FILES = frozenset(
+    {
+        "test_alarm_panel.py",
+        "test_binary_sensor.py",
+        "test_camera_platform.py",
+        "test_config_flow.py",
+        "test_coordinators.py",
+        "test_ha_platforms.py",
+        "test_hub.py",
+        "test_init.py",
+        "test_integration.py",
+        "test_migrate_unique_ids.py",
+        "test_orphan_directory_repair.py",
+        "test_services.py",
+    }
+)
+
+INTEGRATION_MARKERS = ("from homeassistant", "import homeassistant", "mock_graphql")
+
+
+def _has_integration_imports(path: Path) -> bool:
+    source = path.read_text()
+    return any(marker in source for marker in INTEGRATION_MARKERS)
+
+
+def test_expected_integration_files_have_integration_imports() -> None:
+    """Every file we expect to be integration actually has the qualifying imports."""
+    missing_imports = [
+        name
+        for name in sorted(EXPECTED_INTEGRATION_FILES)
+        if not _has_integration_imports(TESTS_DIR / name)
+    ]
+    assert not missing_imports, (
+        f"Files listed in EXPECTED_INTEGRATION_FILES no longer import "
+        f"homeassistant or mock_graphql — remove them from the expected set: "
+        f"{missing_imports}"
+    )
+
+
+def test_no_unlisted_test_file_has_integration_imports() -> None:
+    """Every test_*.py file with HA or mock_graphql imports is in the expected set."""
+    unlisted_with_imports: list[str] = []
+    for path in sorted(TESTS_DIR.glob("test_*.py")):
+        if path.name in EXPECTED_INTEGRATION_FILES or path.name == "test_markers.py":
+            continue
+        if _has_integration_imports(path):
+            unlisted_with_imports.append(path.name)
+    assert not unlisted_with_imports, (
+        f"These files import homeassistant or mock_graphql but are not in "
+        f"EXPECTED_INTEGRATION_FILES. Add them to the set so the integration "
+        f"marker stays in sync: {unlisted_with_imports}"
+    )


### PR DESCRIPTION
> ⚠️ **Stacked on #474** — please merge #474 first. This branch is rebased on top of `feat/configurable-alarm-card-states`; once #474 lands, this PR becomes a clean fast-forward onto `main`.

## Summary

- Auto-applies `pytest.mark.integration` to any test importing `homeassistant` or `tests.mock_graphql`, or requesting the `mock_server` fixture. No manual marker discipline required for new test files.
- CI now runs unit and integration suites as separate jobs per HA channel (6 test jobs total). A new `coverage-gate` job downloads the stable-channel artifacts, runs `coverage combine`, and enforces `--fail-under=90` on the combined run.
- Removes the stale `--cov=custom_components/verisure_owa` path (directory was removed in c10eb6e — the old path was silently ignored by pytest-cov).
- Moves coverage configuration into `pyproject.toml` (`branch = true`, sensible exclusions for `TYPE_CHECKING` / `abstractmethod`, etc.) so local and CI runs share the same settings.
- Adds `tests/test_markers.py` — meta-test pinning the expected integration-file set so the auto-marker stays in sync as new files are added.
- Fixes `tests/test_architecture.py` paths that pointed at the removed `custom_components/verisure_owa/` directory (assertions were iterating over zero files and trivially passing). Caught two real bare-dict annotations (`async_setup`, `fire_event`) that had been silently grandfathered.

Current numbers: **720 unit + 851 integration + 2 markers + 2 architecture sanity = 1573 tests**, combined branch coverage **92%** (gate at 90%).

## Test plan

- [ ] CI: `test (stable, unit)` job runs unit subset and uploads `.coverage.stable.unit` artifact
- [ ] CI: `test (stable, integration)` job runs integration subset and uploads `.coverage.stable.integration` artifact
- [ ] CI: `coverage-gate` job downloads both artifacts, combines, and asserts >= 90%
- [ ] CI: dev and minimum channel jobs continue to run both suites for HA-compat smoke
- [ ] Local: `pytest -m "not integration"` runs only unit tests (fast feedback loop)
- [ ] Local: `pytest -m integration` runs only integration tests
- [ ] Local: full `pytest` run reports combined coverage of ~92%