### PR TITLE
test: add JS test infrastructure for Lovelace cards (Vitest + 90% coverage gate)

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,51 @@
+name: JS Tests
+
+on:
+  pull_request:
+    paths:
+      - "custom_components/securitas/www/**"
+      - "tests-js/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vitest.config.js"
+      - "eslint.config.js"
+      - ".prettierrc.json"
+      - ".github/workflows/js-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "custom_components/securitas/www/**"
+      - "tests-js/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vitest.config.js"
+      - "eslint.config.js"
+      - ".prettierrc.json"
+      - ".github/workflows/js-tests.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,8 @@ tests/fixtures/*.har
 
 # Local pyright config (user-specific venv path)
 pyrightconfig.json
+
+# JS test infrastructure
+node_modules/
+coverage/
+.vitest-cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+.vitest-cache/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -582,3 +582,18 @@ For protocol-level bugs — wrong alarm state, lock or camera misbehaving — a 
 
 The same technique is used to [capture payloads for new operations](./docs/new_operations.md) if you'd like to help add support.
 
+## Frontend tests
+
+The Lovelace cards under `custom_components/securitas/www/` are covered by a Vitest suite with a 90% coverage gate enforced in CI.
+
+```bash
+npm ci
+npm run lint          # ESLint + Prettier check
+npm test              # one-shot
+npm run test:watch    # watch mode
+npm run test:coverage # writes ./coverage/index.html
+```
+
+- Tests live in `tests-js/`.
+- The runtime cards have no Node dependencies — `node_modules/` is a dev-only concern and is gitignored.
+

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -22,7 +22,7 @@ import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 
-const TRANSLATIONS = {
+export const TRANSLATIONS = {
   en: {
     category: {
       armed: "Armed",

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -305,7 +305,7 @@ const CATEGORY_COLORS = {
 
 // ── Utilities ─────────────────────────────────────────────────────────────────
 
-function _hassLang(hass) {
+export function hassLang(hass) {
   return hass?.locale?.language || hass?.language || "en";
 }
 
@@ -324,7 +324,7 @@ function _rtf(lang) {
  * Treats the panel-local "YYYY-MM-DD HH:MM:SS" string as the user's local
  * timezone — correct in the common case where HA runs near the panel.
  */
-function _relativeTime(timeStr, lang) {
+export function relativeTime(timeStr, lang) {
   if (!timeStr || timeStr.length < 16) return "";
   // "2026-05-05 15:00:00" → "2026-05-05T15:00:00" → local Date
   const date = new Date(timeStr.replace(" ", "T"));
@@ -341,7 +341,7 @@ function _relativeTime(timeStr, lang) {
 }
 
 /** Format an event's actor as "by Luci" or "(Cucina)" or "" */
-function _formatActor(event, lang) {
+export function formatActor(event, lang) {
   if (event.verisure_user) return `${_t(lang, "by")} ${escHtml(event.verisure_user)}`;
   if (event.device_name) return `(${escHtml(event.device_name)})`;
   return "";
@@ -350,7 +350,7 @@ function _formatActor(event, lang) {
 // Fields shown in the expanded details block, in display order.
 // Skipped: __typename (internal), category (already shown), the redundant
 // signal_type (always equal to type in observed data).
-const DETAIL_FIELDS = [
+export const DETAIL_FIELDS = [
   "time",
   "alias",
   "type",
@@ -371,7 +371,7 @@ const DETAIL_FIELDS = [
 ];
 
 /** Render `exceptions[]` as a small list — "Pfincameret — Low battery" */
-function _renderExceptions(exceptions, lang) {
+export function renderExceptions(exceptions, lang) {
   if (!Array.isArray(exceptions) || exceptions.length === 0) return "";
   const items = exceptions.map((exc) => {
     const aliasText = exc.alias ? escHtml(exc.alias) : "";
@@ -382,14 +382,14 @@ function _renderExceptions(exceptions, lang) {
   return `<ul class="exceptions">${items.join("")}</ul>`;
 }
 
-function _renderRows(event, lang) {
+export function renderRows(event, lang) {
   const rows = [];
   for (const key of DETAIL_FIELDS) {
     const val = event[key];
     if (val == null || val === "" || val === 0) continue;
     let display;
     if (key === "exceptions") {
-      display = _renderExceptions(val, lang);
+      display = renderExceptions(val, lang);
     } else if (Array.isArray(val) || (typeof val === "object" && val !== null)) {
       display = `<pre>${escHtml(JSON.stringify(val, null, 2))}</pre>`;
     } else {
@@ -550,7 +550,7 @@ class VerisureOwaActivityLogCard extends HTMLElement {
 
   _render() {
     if (!this._config || !this._hass) return;
-    const lang = _hassLang(this._hass);
+    const lang = hassLang(this._hass);
     const entityId = this._config.entity;
     const stateObj = this._hass.states[entityId];
     this._lastRenderedState = stateObj;
@@ -705,8 +705,8 @@ class VerisureOwaActivityLogCard extends HTMLElement {
     const icon = CATEGORY_ICONS[cat] || CATEGORY_ICONS.unknown;
     const color = CATEGORY_COLORS[cat] || CATEGORY_COLORS.unknown;
     const label = _t(lang, `category.${cat}`);
-    const actor = _formatActor(event, lang);
-    const rel = _relativeTime(event.time, lang);
+    const actor = formatActor(event, lang);
+    const rel = relativeTime(event.time, lang);
     const id = String(event.id_signal || "");
     const isExpanded = this._expanded.has(id);
     const isInjected = event.injected === true;
@@ -737,11 +737,11 @@ class VerisureOwaActivityLogCard extends HTMLElement {
       event.category === "unknown"
         ? `<div class="unknown-prompt">${escHtml(_t(lang, "unknown_event_prompt"))}</div>`
         : "";
-    return `${imageBlock}${prompt}<table class="details">${_renderRows(event, lang)}</table>`;
+    return `${imageBlock}${prompt}<table class="details">${renderRows(event, lang)}</table>`;
   }
 
   _renderImageBlock(event) {
-    const lang = _hassLang(this._hass);
+    const lang = hassLang(this._hass);
     const id = String(event.id_signal || "");
     // Synthetic ids (prefix `ha-`) can't resolve to a server-side image.
     if (id.startsWith("ha-")) return "";
@@ -769,7 +769,7 @@ class VerisureOwaActivityLogCard extends HTMLElement {
     // after.  Without this, expanding a row that triggers a render
     // (e.g. lazy image fetch) jumps the user back to the top.
     const prevScroll = this.shadowRoot.querySelector(".scroll")?.scrollTop || 0;
-    const lang = _hassLang(this._hass);
+    const lang = hassLang(this._hass);
     const titleHtml = this._config.title
       ? `<div class="card-header">${escHtml(this._config.title)}</div>`
       : "";
@@ -1019,7 +1019,7 @@ class VerisureOwaActivityLogCardEditor extends HTMLElement {
     const entityForm = this.shadowRoot.getElementById("entity-form");
     entityForm.hass = this._hass;
     entityForm.data = this._formData();
-    const lang = _hassLang(this._hass);
+    const lang = hassLang(this._hass);
     const categoryOptions = Object.keys(CATEGORY_ICONS).map((c) => ({
       value: c,
       label: _t(lang, `category.${c}`),

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -33,7 +33,7 @@ const FEATURE = {
 };
 
 // ── Translations ─────────────────────────────────────────────────────────────
-const TRANSLATIONS = {
+export const TRANSLATIONS = {
   en: {
     disarmed: "Disarmed", armed_away: "Armed Away", armed_home: "Armed Home",
     armed_night: "Armed Night", armed_vacation: "Armed Vacation",

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -24,7 +24,7 @@
 import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
-const FEATURE = {
+export const FEATURE = {
   ARM_HOME: 1,
   ARM_AWAY: 2,
   ARM_NIGHT: 4,
@@ -215,7 +215,7 @@ const STATE_LABEL_KEYS = {
 const INACTIVE_STATES = new Set(["disarmed", "arming", "pending", "triggered", "unavailable", "unknown"]);
 
 // ── Arm action definitions ────────────────────────────────────────────────────
-const ARM_ACTIONS = [
+export const ARM_ACTIONS = [
   { key: "arm_away",          labelKey: "arm_away",    feature: FEATURE.ARM_AWAY,         service: "alarm_arm_away" },
   { key: "arm_home",          labelKey: "arm_home",    feature: FEATURE.ARM_HOME,         service: "alarm_arm_home" },
   { key: "arm_night",         labelKey: "arm_night",    feature: FEATURE.ARM_NIGHT,        service: "alarm_arm_night" },
@@ -248,7 +248,7 @@ function _filteredArmActions(features, configStates) {
  * First arm state key the entity supports (and is in `configStates`, if
  * given), with fallbacks so callers always get a usable key.
  */
-function _defaultArmState(hass, entityId, configStates) {
+export function defaultArmState(hass, entityId, configStates) {
   const features = hass.states[entityId]?.attributes?.supported_features || 0;
   const { supported, filtered } = _filteredArmActions(features, configStates);
   const pool = filtered.length > 0 ? filtered : supported;
@@ -422,7 +422,7 @@ function executeAction(action, hass, entityId, srcEl, callbacks = {}, cardStates
         }
       } else if (state === "disarmed") {
         // Arm
-        const armKey = action.arm_state || _defaultArmState(hass, entityId, cardStates);
+        const armKey = action.arm_state || defaultArmState(hass, entityId, cardStates);
         const armDef = ARM_ACTIONS.find(a => a.key === armKey);
         if (!armDef) return;
         const svcAction = { service: armDef.service, labelKey: armDef.labelKey };
@@ -1217,7 +1217,7 @@ class VerisureOwaAlarmCardEditor extends HTMLElement {
       // supported" for the dropdown anyway, so saved arm_state stays valid.
       const nextStates = nextConfig.states;
       if (Array.isArray(nextStates) && nextStates.length > 0) {
-        const newDefault = _defaultArmState(this._hass, this._config.entity, nextStates);
+        const newDefault = defaultArmState(this._hass, this._config.entity, nextStates);
         for (const gestureKey of GESTURE_KEYS) {
           const gestureAction = nextConfig[gestureKey];
           if (
@@ -1262,7 +1262,7 @@ class VerisureOwaAlarmCardEditor extends HTMLElement {
     let actionValue   = currentAction;
     let armStateValue = userHiddenAll
       ? undefined
-      : (current.arm_state || _defaultArmState(this._hass, this._config.entity, configStates));
+      : (current.arm_state || defaultArmState(this._hass, this._config.entity, configStates));
 
     const section = document.createElement("div");
     section.className = "gesture-section";
@@ -1630,7 +1630,7 @@ class VerisureOwaAlarmCardEditor extends HTMLElement {
     const holdDefaults = isBadge
       ? {
           action: "arm_or_disarm",
-          arm_state: _defaultArmState(this._hass, this._config.entity, this._config.states),
+          arm_state: defaultArmState(this._hass, this._config.entity, this._config.states),
         }
       : { action: "none" };
     const dblDefaults  = { action: "none" };
@@ -1735,7 +1735,7 @@ class VerisureOwaAlarmBadge extends HTMLElement {
     const badgeEl = this.shadowRoot.getElementById("badge");
     const gestureConfig = {
       tap_action:        this._config.tap_action        || { action: "more-info" },
-      hold_action:       this._config.hold_action       || { action: "arm_or_disarm", arm_state: _defaultArmState(this._hass, this._config.entity, this._config.states) },
+      hold_action:       this._config.hold_action       || { action: "arm_or_disarm", arm_state: defaultArmState(this._hass, this._config.entity, this._config.states) },
       double_tap_action: this._config.double_tap_action || { action: "none" },
     };
 

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -18,7 +18,7 @@ import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 
-const TRANSLATIONS = {
+export const TRANSLATIONS = {
   en: {
     editor_entity: "Entity",
     editor_name: "Name",

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -117,7 +117,7 @@ const _t = (lang, key, vars) => formatTranslation(lang, TRANSLATIONS, key, vars)
 const _FULL_IMAGE_ENTITY_ID_RE = /^camera\..*_full_image(_\d+)?$/;
 const _OUR_PLATFORMS = new Set(["securitas", "verisure_owa"]);
 
-function _findFullImageEntityIds(hass) {
+export function findFullImageEntityIds(hass) {
   const ids = [];
   for (const [eid, entry] of Object.entries(hass?.entities || {})) {
     if (!_OUR_PLATFORMS.has(entry?.platform)) continue;
@@ -164,7 +164,7 @@ class VerisureOwaCameraCardEditor extends HTMLElement {
 
   _buildEntitySchema() {
     if (this._fullImageIdsRef !== this._hass?.entities) {
-      this._fullImageIdsCache = _findFullImageEntityIds(this._hass);
+      this._fullImageIdsCache = findFullImageEntityIds(this._hass);
       this._fullImageIdsRef = this._hass?.entities;
     }
     const entitySelector = { domain: "camera" };
@@ -477,7 +477,7 @@ class VerisureOwaCameraCard extends HTMLElement {
   }
 
   static getStubConfig(hass) {
-    const fullImageIds = new Set(_findFullImageEntityIds(hass));
+    const fullImageIds = new Set(findFullImageEntityIds(hass));
     const entity = Object.keys(hass?.states || {}).find(
       (e) => e.startsWith("camera.") && !fullImageIds.has(e),
     );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,45 @@
+import js from "@eslint/js";
+import globals from "globals";
+import vitest from "eslint-plugin-vitest";
+
+export default [
+  {
+    ignores: ["node_modules/**", "coverage/**", ".vitest-cache/**"],
+  },
+  js.configs.recommended,
+  {
+    files: ["custom_components/securitas/www/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: { ...globals.browser },
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: "off",
+    },
+    rules: {
+      "no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrors: "none",
+        },
+      ],
+      "no-empty": ["error", { allowEmptyCatch: true }],
+    },
+  },
+  {
+    files: ["tests-js/**/*.js"],
+    plugins: { vitest },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: { ...globals.browser, ...globals.node, ...vitest.environments.env.globals },
+    },
+    rules: {
+      ...vitest.configs.recommended.rules,
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3772 @@
+{
+  "name": "verisure-owa-frontend-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "verisure-owa-frontend-tests",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^2.1.0",
+        "eslint": "^9.0.0",
+        "eslint-plugin-vitest": "^0.5.4",
+        "globals": "^15.0.0",
+        "happy-dom": "^15.0.0",
+        "prettier": "^3.3.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vitest": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vitest/-/eslint-plugin-vitest-0.5.4.tgz",
+      "integrity": "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^7.7.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || >= 20.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "15.11.7",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
+      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "verisure-owa-frontend-tests",
       "devDependencies": {
+        "@eslint/js": "^9.0.0",
         "@vitest/coverage-v8": "^2.1.0",
         "eslint": "^9.0.0",
         "eslint-plugin-vitest": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test": "TZ=UTC vitest run",
+    "test:watch": "TZ=UTC vitest",
+    "test:coverage": "TZ=UTC vitest run --coverage",
     "lint": "eslint . && prettier --check 'package.json' 'vitest.config.js' 'eslint.config.js' '.prettierrc.json' 'tests-js/**/*.js'",
     "lint:fix": "eslint . --fix && prettier --write 'package.json' 'vitest.config.js' 'eslint.config.js' '.prettierrc.json' 'tests-js/**/*.js'"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix && prettier --write 'package.json' 'vitest.config.js' 'eslint.config.js' '.prettierrc.json' 'tests-js/**/*.js'"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
     "@vitest/coverage-v8": "^2.1.0",
     "eslint": "^9.0.0",
     "eslint-plugin-vitest": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "verisure-owa-frontend-tests",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint . && prettier --check 'package.json' 'vitest.config.js' 'eslint.config.js' '.prettierrc.json' 'tests-js/**/*.js'",
+    "lint:fix": "eslint . --fix && prettier --write 'package.json' 'vitest.config.js' 'eslint.config.js' '.prettierrc.json' 'tests-js/**/*.js'"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^2.1.0",
+    "eslint": "^9.0.0",
+    "eslint-plugin-vitest": "^0.5.4",
+    "globals": "^15.0.0",
+    "happy-dom": "^15.0.0",
+    "prettier": "^3.3.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/tests-js/fixtures/entities.js
+++ b/tests-js/fixtures/entities.js
@@ -1,0 +1,54 @@
+const ALL_FEATURES = 1 | 2 | 4 | 16 | 32;
+
+export function makeAlarmEntity({
+  state = "disarmed",
+  supportedFeatures = ALL_FEATURES,
+  codeArmRequired = false,
+  codeFormat = null,
+  forceArmAvailable = false,
+  armExceptions = [],
+  wafBlocked = false,
+  refreshFailed = false,
+  friendlyName = "Test Alarm",
+} = {}) {
+  return {
+    state,
+    attributes: {
+      friendly_name: friendlyName,
+      supported_features: supportedFeatures,
+      code_arm_required: codeArmRequired,
+      code_format: codeFormat,
+      force_arm_available: forceArmAvailable,
+      arm_exceptions: armExceptions,
+      waf_blocked: wafBlocked,
+      refresh_failed: refreshFailed,
+    },
+  };
+}
+
+export function makeCameraEntity({
+  state = "idle",
+  accessToken = "token-abc",
+  entityPicture = null,
+  friendlyName = "Test Camera",
+} = {}) {
+  const token = accessToken;
+  return {
+    state,
+    attributes: {
+      friendly_name: friendlyName,
+      access_token: token,
+      entity_picture: entityPicture || `/api/camera_proxy/camera.test?token=${token}`,
+    },
+  };
+}
+
+export function makeActivityLogEntity({ events = [], friendlyName = "Test Activity Log" } = {}) {
+  return {
+    state: String(events.length),
+    attributes: {
+      friendly_name: friendlyName,
+      events,
+    },
+  };
+}

--- a/tests-js/fixtures/hass.js
+++ b/tests-js/fixtures/hass.js
@@ -1,0 +1,14 @@
+import { vi } from "vitest";
+
+export function makeHass(overrides = {}) {
+  return {
+    language: "en",
+    locale: { language: overrides.language || "en" },
+    states: {},
+    entities: {},
+    devices: {},
+    callService: vi.fn(async () => {}),
+    callWS: vi.fn(async () => ({})),
+    ...overrides,
+  };
+}

--- a/tests-js/integration/activity-log-card-editor.test.js
+++ b/tests-js/integration/activity-log-card-editor.test.js
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import "../../custom_components/securitas/www/verisure-owa-activity-log-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeActivityLogEntity } from "../fixtures/entities.js";
+
+describe("verisure-owa-activity-log-card-editor", () => {
+  it("registers as a custom element", () => {
+    expect(customElements.get("verisure-owa-activity-log-card-editor")).toBeDefined();
+  });
+
+  it("restricts the entity picker to detected activity-log sensors via include_entities", () => {
+    // The editor delegates entity selection to HA's <ha-form> with an entity
+    // selector — the dropdown contents are resolved lazily by HA at runtime,
+    // not embedded in the editor's shadow DOM. Activity-log sensors are
+    // detected by their attribute shape (an `events` array) rather than by
+    // name or platform, so we assert on the ha-form schema: when at least
+    // one sensor has an `events` attribute, the selector must carry an
+    // include_entities list of those sensor entity IDs.
+    // hass MUST be assigned before setConfig: the editor builds the entity
+    // schema inside _render(), and _render() is invoked synchronously by
+    // setConfig — so any include_entities list is captured at that moment
+    // from this._hass.states, with no later schema recompute on hass updates.
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.hass = makeHass({
+      states: {
+        "sensor.house_activity_log": makeActivityLogEntity(),
+        "sensor.cabin_activity_log": makeActivityLogEntity(),
+        "sensor.unrelated": { state: "1", attributes: {} },
+        "light.kitchen": { state: "on", attributes: {} },
+      },
+    });
+    editor.setConfig({ entity: "sensor.house_activity_log" });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm).not.toBeNull();
+    expect(entityForm.tagName.toLowerCase()).toBe("ha-form");
+    const [entityField] = entityForm.schema;
+    expect(entityField.name).toBe("entity");
+    // Only the two sensors with an `events` array attribute should be included.
+    expect(entityField.selector.entity.include_entities).toEqual(
+      expect.arrayContaining(["sensor.house_activity_log", "sensor.cabin_activity_log"]),
+    );
+    expect(entityField.selector.entity.include_entities).toHaveLength(2);
+    expect(entityField.selector.entity.domain).toBeUndefined();
+  });
+
+  it("falls back to a sensor-domain selector when no activity-log sensors are loaded", () => {
+    // If hass.states has no sensors carrying an `events` array, the editor
+    // must fall back to a domain-scoped selector (sensor) instead of emitting
+    // an empty include_entities list (which would render an empty dropdown).
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "light.kitchen": { state: "on", attributes: {} } },
+    });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    const [entityField] = entityForm.schema;
+    expect(entityField).toEqual({
+      name: "entity",
+      selector: { entity: { domain: "sensor" } },
+    });
+  });
+
+  it("exposes the full editor schema (entity, limit, title, max_height, hide_categories)", () => {
+    // The editor manages five fields beyond the entity picker: number-slider
+    // limit, free-text title and max_height, and a multi-select category
+    // filter. The category options list is built from CATEGORY_ICONS — we
+    // can't import it from the card module, so we sanity-check the multi-
+    // select shape and confirm a known category ("armed") is present.
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "sensor.house_activity_log": makeActivityLogEntity() },
+    });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    const names = entityForm.schema.map((s) => s.name);
+    expect(names).toEqual(["entity", "limit", "title", "max_height", "hide_categories"]);
+
+    const limit = entityForm.schema.find((s) => s.name === "limit");
+    expect(limit.selector).toEqual({
+      number: { min: 1, max: 30, step: 1, mode: "slider" },
+    });
+
+    const title = entityForm.schema.find((s) => s.name === "title");
+    expect(title.selector).toEqual({ text: {} });
+
+    const maxHeight = entityForm.schema.find((s) => s.name === "max_height");
+    expect(maxHeight.selector).toEqual({ text: {} });
+
+    const hideCategories = entityForm.schema.find((s) => s.name === "hide_categories");
+    expect(hideCategories.selector.select.multiple).toBe(true);
+    expect(hideCategories.selector.select.mode).toBe("list");
+    const optionValues = hideCategories.selector.select.options.map((o) => o.value);
+    expect(optionValues).toContain("armed");
+    expect(optionValues).toContain("alarm");
+    expect(optionValues).toContain("unknown");
+    // Every option must carry both a value and a (localized) label.
+    for (const opt of hideCategories.selector.select.options) {
+      expect(typeof opt.value).toBe("string");
+      expect(typeof opt.label).toBe("string");
+    }
+  });
+
+  it("seeds ha-form data with config defaults (limit 10, max_height 400px, empty arrays)", () => {
+    // _formData() applies defaults for unset fields so that the form renders
+    // sensible values on first open. We assert the defaults reach ha-form.data
+    // unmodified for an empty config.
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "sensor.house_activity_log": makeActivityLogEntity() },
+    });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm.data).toEqual({
+      entity: "",
+      limit: 10,
+      title: "",
+      max_height: "400px",
+      hide_categories: [],
+    });
+  });
+
+  it("propagates an existing config (entity, limit, hide_categories) to ha-form data", () => {
+    // When opening the editor on an already-configured card, every field set
+    // in the user's config must round-trip into ha-form.data without being
+    // overwritten by defaults.
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.setConfig({
+      entity: "sensor.house_activity_log",
+      limit: 25,
+      title: "Recent",
+      max_height: "50vh",
+      hide_categories: ["status_check", "unknown"],
+    });
+    editor.hass = makeHass({
+      states: { "sensor.house_activity_log": makeActivityLogEntity() },
+    });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm.data).toEqual({
+      entity: "sensor.house_activity_log",
+      limit: 25,
+      title: "Recent",
+      max_height: "50vh",
+      hide_categories: ["status_check", "unknown"],
+    });
+  });
+
+  it("dispatches config-changed merging updates when ha-form emits value-changed", () => {
+    // The editor wires to ha-form's "value-changed" event (HA convention).
+    // happy-dom renders <ha-form> as a generic HTMLElement so we dispatch the
+    // event directly. The dispatched config-changed must carry a merged config
+    // (previous + new values) on detail.config, matching HA's editor contract.
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.setConfig({ entity: "sensor.house_activity_log", limit: 10 });
+    editor.hass = makeHass({
+      states: { "sensor.house_activity_log": makeActivityLogEntity() },
+    });
+    document.body.appendChild(editor);
+
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    entityForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { limit: 5, hide_categories: ["unknown"] } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    expect(captured).toEqual({
+      entity: "sensor.house_activity_log",
+      limit: 5,
+      hide_categories: ["unknown"],
+    });
+  });
+
+  it("reuses the same ha-form on subsequent setConfig calls and refreshes data", () => {
+    // setConfig is called whenever the user edits in the lovelace editor.
+    // The editor should NOT re-render (which would discard ha-form state) and
+    // should instead push the new defaults into the existing entity-form.data.
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "sensor.house_activity_log": makeActivityLogEntity() },
+    });
+    document.body.appendChild(editor);
+
+    const firstForm = editor.shadowRoot.getElementById("entity-form");
+    editor.setConfig({ entity: "sensor.house_activity_log", limit: 7 });
+    const secondForm = editor.shadowRoot.getElementById("entity-form");
+
+    expect(secondForm).toBe(firstForm);
+    expect(secondForm.data).toEqual({
+      entity: "sensor.house_activity_log",
+      limit: 7,
+      title: "",
+      max_height: "400px",
+      hide_categories: [],
+    });
+  });
+});

--- a/tests-js/integration/activity-log-card.test.js
+++ b/tests-js/integration/activity-log-card.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "../../custom_components/securitas/www/verisure-owa-activity-log-card.js";
 import { makeHass } from "../fixtures/hass.js";
 import { makeActivityLogEntity } from "../fixtures/entities.js";
@@ -155,5 +155,527 @@ describe("verisure-owa-activity-log-card callWS wiring", () => {
       }),
     );
     warnSpy.mockRestore();
+  });
+});
+
+describe("verisure-owa-activity-log-card not-an-activity-log branch", () => {
+  it("renders 'not_an_activity_log' message when state has no events array", () => {
+    // When the configured entity exists but its attributes lack an
+    // `events` array, _render() takes the not_an_activity_log branch.
+    const card = mountActivityCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: { state: "0", attributes: { friendly_name: "Bogus" } },
+        },
+      }),
+    });
+    expect(card.shadowRoot.innerHTML).toMatch(/not an activity log/i);
+  });
+});
+
+describe("verisure-owa-activity-log-card row interactions", () => {
+  it("ignores click after pointerdown moved more than the drag threshold", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "55",
+              time: "2026-05-17 11:30:00",
+              category: "armed",
+              alias: "Drag",
+            },
+          ],
+        }),
+      },
+    });
+    const card = mountActivityCard({ hass });
+    const row = card.shadowRoot.querySelector('.event[data-id="55"]');
+    expect(row.classList.contains("expanded")).toBe(false);
+
+    row.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }));
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 20, clientY: 0 }));
+
+    // The row should NOT have been toggled because the cursor moved > 4 px.
+    const after = card.shadowRoot.querySelector('.event[data-id="55"]');
+    expect(after.classList.contains("expanded")).toBe(false);
+  });
+
+  it("toggles row open then closed via Enter keypress, updating aria-expanded", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "kbd-1",
+              time: "2026-05-17 11:30:00",
+              category: "armed",
+              alias: "Keyboard",
+            },
+          ],
+        }),
+      },
+    });
+    const card = mountActivityCard({ hass });
+    const row = card.shadowRoot.querySelector('.event[data-id="kbd-1"]');
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+
+    // Open with Enter
+    row.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+    expect(
+      card.shadowRoot.querySelector('.event[data-id="kbd-1"]').getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(
+      card.shadowRoot.querySelector('.details-row[data-id="kbd-1"]').classList.contains("expanded"),
+    ).toBe(true);
+
+    // Close with Space
+    card.shadowRoot
+      .querySelector('.event[data-id="kbd-1"]')
+      .dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: " " }));
+    expect(
+      card.shadowRoot.querySelector('.event[data-id="kbd-1"]').getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
+  it("does not fetch image when expanded id starts with 'ha-' (synthetic)", async () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "ha-injected-1",
+              time: "2026-05-17 11:30:00",
+              category: "image_request",
+              alias: "Synthetic",
+              img: 1,
+              type: 14,
+              injected: true,
+            },
+          ],
+        }),
+      },
+    });
+    const card = mountActivityCard({ hass });
+    const row = card.shadowRoot.querySelector('.event[data-id="ha-injected-1"]');
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 0, clientY: 0 }));
+    await Promise.resolve();
+    // callWS is the wire used by _fetchEventImage — synthetic ids must not trigger it.
+    expect(hass.callWS).not.toHaveBeenCalled();
+    // Injected event's badge icon is rendered.
+    expect(card.shadowRoot.innerHTML).toContain("mdi:home-assistant");
+  });
+
+  it("falls back to an error placeholder when fetch_activity_image returns no image_b64", async () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "no-img",
+              time: "2026-05-17 11:30:00",
+              category: "image_request",
+              alias: "NoImage",
+              img: 1,
+              type: 14,
+            },
+          ],
+        }),
+      },
+    });
+    hass.callWS.mockResolvedValueOnce({ response: { [ENTITY]: {} } });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const card = mountActivityCard({ hass });
+
+    const row = card.shadowRoot.querySelector('.event[data-id="no-img"]');
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 0, clientY: 0 }));
+    // Two microtask ticks: one for callWS resolution, one for the post-fetch re-render.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(card.shadowRoot.innerHTML).toMatch(/Image not available/i);
+    warnSpy.mockRestore();
+  });
+
+  it("falls back to an error placeholder when callWS rejects", async () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "throw-1",
+              time: "2026-05-17 11:30:00",
+              category: "image_request",
+              alias: "Boom",
+              img: 1,
+              type: 14,
+            },
+          ],
+        }),
+      },
+    });
+    hass.callWS.mockRejectedValueOnce(new Error("network"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const card = mountActivityCard({ hass });
+
+    const row = card.shadowRoot.querySelector('.event[data-id="throw-1"]');
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 0, clientY: 0 }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(card.shadowRoot.innerHTML).toMatch(/Image not available/i);
+    warnSpy.mockRestore();
+  });
+
+  it("renders a loaded image when fetch returns image_b64", async () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "img-loaded",
+              time: "2026-05-17 11:30:00",
+              category: "image_request",
+              alias: "Cam",
+              img: 1,
+              type: 14,
+            },
+          ],
+        }),
+      },
+    });
+    hass.callWS.mockResolvedValueOnce({
+      response: { [ENTITY]: { image_b64: "AAAA", mime_type: "image/png" } },
+    });
+    const card = mountActivityCard({ hass });
+
+    const row = card.shadowRoot.querySelector('.event[data-id="img-loaded"]');
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 0, clientY: 0 }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const img = card.shadowRoot.querySelector("img.event-image");
+    expect(img).not.toBeNull();
+    expect(img.getAttribute("src")).toContain("data:image/png;base64,AAAA");
+  });
+
+  it("renders the unknown-event prompt for events with category=unknown", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "u-1",
+              time: "2026-05-17 11:30:00",
+              category: "unknown",
+              alias: "Mystery",
+            },
+          ],
+        }),
+      },
+    });
+    const card = mountActivityCard({ hass });
+    const row = card.shadowRoot.querySelector('.event[data-id="u-1"]');
+    row.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+    expect(card.shadowRoot.querySelector(".unknown-prompt")).not.toBeNull();
+  });
+});
+
+describe("verisure-owa-activity-log-card lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("installs a tick timer on connect and clears it on disconnect", () => {
+    const card = mountActivityCard({
+      hass: makeHass({ states: { [ENTITY]: makeActivityLogEntity({ events: [] }) } }),
+    });
+    // connectedCallback runs synchronously when appended.
+
+    expect(card._tickTimer).not.toBeNull();
+    card.remove();
+
+    expect(card._tickTimer).toBeNull();
+  });
+
+  it("re-renders on the periodic tick to refresh relative timestamps", () => {
+    const renderSpy = vi.fn();
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [{ id_signal: "1", time: "2026-05-17 11:30:00", category: "armed", alias: "A" }],
+        }),
+      },
+    });
+    const card = mountActivityCard({ hass });
+    // Patch _render to count re-renders triggered by the timer
+    const originalRender = card._render.bind(card);
+    card._render = (...args) => {
+      renderSpy();
+      return originalRender(...args);
+    };
+    vi.advanceTimersByTime(60_001);
+    expect(renderSpy).toHaveBeenCalled();
+  });
+});
+
+describe("verisure-owa-activity-log-card refresh paths", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("the 8s fallback clears the spinner if no state update arrives", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeActivityLogEntity({ events: [] }) },
+    });
+    // Make callService settle (so finally completes) but no state update
+    // is delivered to the card from outside.
+    hass.callService.mockResolvedValueOnce(undefined);
+    const card = mountActivityCard({ hass });
+    const refreshBtn = card.shadowRoot.getElementById("refresh-btn");
+    refreshBtn.click();
+    // Spinner should be active immediately.
+
+    expect(card._refreshing).toBe(true);
+    // Advance past the 8000ms fallback.
+    vi.advanceTimersByTime(8001);
+
+    expect(card._refreshing).toBe(false);
+  });
+
+  it("a subsequent hass state change clears the refreshing flag", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeActivityLogEntity({ events: [] }) },
+    });
+    const card = mountActivityCard({ hass });
+    const refreshBtn = card.shadowRoot.getElementById("refresh-btn");
+    refreshBtn.click();
+
+    expect(card._refreshing).toBe(true);
+    // Push a new hass with a fresh state object — triggers _clearRefreshing path.
+    card.hass = makeHass({
+      states: { [ENTITY]: makeActivityLogEntity({ events: [{ id_signal: "x" }] }) },
+    });
+
+    expect(card._refreshing).toBe(false);
+  });
+
+  it("swallows callService rejections without throwing (sync click is safe)", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeActivityLogEntity({ events: [] }) },
+    });
+    hass.callService.mockRejectedValueOnce(new Error("boom"));
+    const card = mountActivityCard({ hass });
+    expect(() => card.shadowRoot.getElementById("refresh-btn").click()).not.toThrow();
+    // Let the rejected promise propagate through finally.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hass.callService).toHaveBeenCalled();
+  });
+});
+
+describe("verisure-owa-activity-log-card static helpers", () => {
+  it("getConfigElement returns the matching editor element", () => {
+    const ctor = customElements.get("verisure-owa-activity-log-card");
+    const el = ctor.getConfigElement();
+    expect(el.tagName.toLowerCase()).toBe("verisure-owa-activity-log-card-editor");
+  });
+
+  it("getStubConfig picks the first sensor with an events array", () => {
+    const ctor = customElements.get("verisure-owa-activity-log-card");
+    const hass = makeHass({
+      states: {
+        "sensor.other": { state: "1", attributes: {} },
+        "sensor.activity_a": makeActivityLogEntity(),
+        "sensor.activity_b": makeActivityLogEntity(),
+      },
+    });
+    const stub = ctor.getStubConfig(hass);
+    expect(stub.entity).toBe("sensor.activity_a");
+    expect(stub.limit).toBe(10);
+  });
+
+  it("getStubConfig returns empty entity when no activity log sensors exist", () => {
+    const ctor = customElements.get("verisure-owa-activity-log-card");
+    const stub = ctor.getStubConfig(makeHass());
+    expect(stub.entity).toBe("");
+  });
+
+  it("getCardSize scales with the configured limit, capped at 8", () => {
+    const card = mountActivityCard({
+      config: { limit: 30 },
+      hass: makeHass({ states: { [ENTITY]: makeActivityLogEntity({ events: [] }) } }),
+    });
+    expect(card.getCardSize()).toBe(8);
+  });
+});
+
+describe("verisure-owa-activity-log-card setConfig validation", () => {
+  it("throws when entity is missing", () => {
+    const el = document.createElement("verisure-owa-activity-log-card");
+    expect(() => el.setConfig({})).toThrow(/entity is required/i);
+  });
+
+  it("filters out events whose category is listed in hide_categories", () => {
+    const card = mountActivityCard({
+      config: { hide_categories: ["status_check"] },
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeActivityLogEntity({
+            events: [
+              { id_signal: "1", time: "2026-05-17 11:30:00", category: "armed", alias: "A" },
+              { id_signal: "2", time: "2026-05-17 11:00:00", category: "status_check", alias: "S" },
+            ],
+          }),
+        },
+      }),
+    });
+    const rows = card.shadowRoot.querySelectorAll(".event");
+    expect(rows.length).toBe(1);
+    expect(rows[0].getAttribute("data-id")).toBe("1");
+  });
+});
+
+describe("verisure-owa-activity-log-card extra branches", () => {
+  it("renders the configured title in the card header", () => {
+    const card = mountActivityCard({
+      config: { title: "Recent" },
+      hass: makeHass({ states: { [ENTITY]: makeActivityLogEntity({ events: [] }) } }),
+    });
+    expect(card.shadowRoot.querySelector(".card-header").textContent).toBe("Recent");
+  });
+
+  it("renders an event whose category is not in CATEGORY_ICONS with the unknown icon", () => {
+    const card = mountActivityCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeActivityLogEntity({
+            events: [
+              {
+                id_signal: "u-2",
+                time: "2026-05-17 11:30:00",
+                // Deliberately unmapped category to take the `|| unknown` branch.
+                category: "made-up-category",
+                alias: "Mystery",
+              },
+            ],
+          }),
+        },
+      }),
+    });
+    expect(card.shadowRoot.innerHTML).toContain("mdi:help-circle");
+  });
+
+  it("renders an injected event with the ha-badge marker", () => {
+    const card = mountActivityCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeActivityLogEntity({
+            events: [
+              {
+                id_signal: "inj-1",
+                time: "2026-05-17 11:30:00",
+                category: "armed",
+                alias: "Inj",
+                injected: true,
+              },
+            ],
+          }),
+        },
+      }),
+    });
+    expect(card.shadowRoot.querySelector(".injected-badge")).not.toBeNull();
+    expect(card.shadowRoot.querySelector(".event.injected")).not.toBeNull();
+  });
+
+  it("_handleRefresh early-returns while already refreshing (re-entrant click ignored)", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeActivityLogEntity({ events: [] }) },
+    });
+    let calls = 0;
+    hass.callService.mockImplementation(async () => {
+      calls += 1;
+    });
+    const card = mountActivityCard({ hass });
+    const btn = card.shadowRoot.getElementById("refresh-btn");
+    btn.click();
+    btn.click();
+    await Promise.resolve();
+    expect(calls).toBe(1);
+  });
+
+  it("_callServiceWithResponse returns the service_response key when present, else null", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeActivityLogEntity({ events: [] }) },
+    });
+    const card = mountActivityCard({ hass });
+    // service_response key (alternate shape supported by HA frontends).
+    hass.callWS.mockResolvedValueOnce({ service_response: { ok: true } });
+
+    let result = await card._callServiceWithResponse("d", "s", {});
+    expect(result).toEqual({ ok: true });
+    // Null when neither response nor service_response is present.
+    hass.callWS.mockResolvedValueOnce(null);
+
+    result = await card._callServiceWithResponse("d", "s", {});
+    expect(result).toBeNull();
+    // Null when callWS rejects.
+    hass.callWS.mockRejectedValueOnce(new Error("net"));
+
+    result = await card._callServiceWithResponse("d", "s", {});
+    expect(result).toBeNull();
+  });
+
+  it("prunes _expanded entries for events that scroll out of view", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            { id_signal: "1", time: "2026-05-17 11:30:00", category: "armed", alias: "A" },
+            { id_signal: "2", time: "2026-05-17 11:00:00", category: "armed", alias: "B" },
+          ],
+        }),
+      },
+    });
+    const card = mountActivityCard({ config: { limit: 2 }, hass });
+    // Expand row 1 via Enter.
+    card.shadowRoot
+      .querySelector('.event[data-id="1"]')
+      .dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+
+    expect(card._expanded.has("1")).toBe(true);
+    // Push a new state with only row 2 — row 1 falls out and should be pruned.
+    card.hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [{ id_signal: "2", time: "2026-05-17 11:00:00", category: "armed", alias: "B" }],
+        }),
+      },
+    });
+
+    expect(card._expanded.has("1")).toBe(false);
+  });
+});
+
+describe("verisure-owa-activity-log-card-editor change events", () => {
+  it("computeLabel returns localized strings for each known schema field", () => {
+    const editor = document.createElement("verisure-owa-activity-log-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "sensor.house_activity_log": makeActivityLogEntity() },
+    });
+    document.body.appendChild(editor);
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm.computeLabel({ name: "entity" })).toBe("Activity log entity");
+    expect(entityForm.computeLabel({ name: "limit" })).toBe("Number of events to show");
+    expect(entityForm.computeLabel({ name: "title" })).toBe("Card title (optional)");
+    expect(entityForm.computeLabel({ name: "max_height" })).toBe(
+      "Max card height (e.g. 400px, 60vh)",
+    );
+    expect(entityForm.computeLabel({ name: "hide_categories" })).toBe("Categories to hide");
+    // Unknown fields fall through to the raw name (defensive default).
+    expect(entityForm.computeLabel({ name: "unknown" })).toBe("unknown");
   });
 });

--- a/tests-js/integration/activity-log-card.test.js
+++ b/tests-js/integration/activity-log-card.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from "vitest";
+import "../../custom_components/securitas/www/verisure-owa-activity-log-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeActivityLogEntity } from "../fixtures/entities.js";
+
+const ENTITY = "sensor.test_activity_log";
+
+function mountActivityCard({ config = {}, hass = makeHass() } = {}) {
+  const el = document.createElement("verisure-owa-activity-log-card");
+  el.setConfig({
+    type: "custom:verisure-owa-activity-log-card",
+    entity: ENTITY,
+    ...config,
+  });
+  el.hass = hass;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("verisure-owa-activity-log-card render", () => {
+  it("registers", () => {
+    expect(customElements.get("verisure-owa-activity-log-card")).toBeDefined();
+  });
+
+  it("renders empty state when events list is empty", () => {
+    const card = mountActivityCard({
+      hass: makeHass({ states: { [ENTITY]: makeActivityLogEntity({ events: [] }) } }),
+    });
+    // The card emits a `.empty` div with the localised "no events" string
+    // (English fixture: "No events recorded yet"). Assert on that real
+    // marker rather than the toBeDefined placeholder from the plan.
+    const empty = card.shadowRoot.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty.textContent).toMatch(/No events recorded yet/);
+  });
+
+  it("renders one row per event", () => {
+    const card = mountActivityCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeActivityLogEntity({
+            events: [
+              {
+                id_signal: "1",
+                time: "2026-05-17 11:30:00",
+                category: "armed",
+                alias: "ArmedAlias",
+              },
+              {
+                id_signal: "2",
+                time: "2026-05-17 11:00:00",
+                category: "disarmed",
+                alias: "DisarmedAlias",
+              },
+            ],
+          }),
+        },
+      }),
+    });
+    // The card renders one .event row per visible event — count them.
+    // This catches a buggy zero-row render that toContain("arm") would miss.
+    const rows = card.shadowRoot.querySelectorAll(".event");
+    expect(rows.length).toBe(2);
+    // Each row should carry the event's id_signal as data-id.
+    const ids = Array.from(rows).map((r) => r.getAttribute("data-id"));
+    expect(ids).toEqual(["1", "2"]);
+    // The category-label strings are rendered into the row meta.
+    const html = card.shadowRoot.innerHTML;
+    expect(html).toContain("Armed");
+    expect(html).toContain("Disarmed");
+    // The alias is rendered in .line2 — assert it is present too.
+    expect(html).toContain("ArmedAlias");
+    expect(html).toContain("DisarmedAlias");
+  });
+
+  it("renders entity-not-found when state is missing", () => {
+    const card = mountActivityCard({ hass: makeHass() });
+    expect(card.shadowRoot.innerHTML).toMatch(/Entity not found/);
+  });
+});
+
+describe("verisure-owa-activity-log-card refresh service", () => {
+  it("clicking Refresh calls verisure_owa.refresh_activity_log", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeActivityLogEntity({ events: [] }) },
+    });
+    const card = mountActivityCard({ hass });
+
+    // The refresh trigger is an icon-only button in the top-right corner
+    // (mdi:refresh icon, no text content) — identified by its id, same
+    // pattern as the camera card.
+    const refreshBtn = card.shadowRoot.getElementById("refresh-btn");
+    expect(refreshBtn).not.toBeNull();
+    refreshBtn.click();
+    // _handleRefresh is async — give the microtask queue a chance to settle.
+    await Promise.resolve();
+    expect(hass.callService).toHaveBeenCalledWith(
+      "verisure_owa",
+      "refresh_activity_log",
+      expect.objectContaining({ entity_id: ENTITY }),
+    );
+  });
+});
+
+describe("verisure-owa-activity-log-card callWS wiring", () => {
+  // Note: the activity-log card has no pagination UI. The plan's "load
+  // more / older / previous" button does not exist. The card's only
+  // callWS usage is _callServiceWithResponse, invoked by _fetchEventImage
+  // when an event with img: 1 (and a non-ha- id_signal) is expanded.
+  // We exercise that path here as the realistic callWS trigger.
+  it("expanding an image-request row calls hass.callWS with fetch_activity_image", async () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeActivityLogEntity({
+          events: [
+            {
+              id_signal: "9001",
+              time: "2026-05-17 11:30:00",
+              category: "image_request",
+              alias: "Camera",
+              img: 1,
+              type: 14,
+            },
+          ],
+        }),
+      },
+    });
+    // Resolve with a valid base64 payload so _fetchEventImage takes the
+    // "loaded" branch and doesn't emit a benign console.warn that would
+    // clutter test output.
+    hass.callWS.mockResolvedValueOnce({
+      response: { [ENTITY]: { image_b64: "AAAA", mime_type: "image/jpeg" } },
+    });
+    // Suppress any other unforeseen console.warn from the card during
+    // this scenario — we only care about asserting the callWS arguments.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const card = mountActivityCard({ hass });
+
+    const row = card.shadowRoot.querySelector('.event[data-id="9001"]');
+    expect(row).not.toBeNull();
+    // Bypass the pointerdown drag-threshold check by issuing a click with
+    // matching coordinates. Without a prior pointerdown, downX/downY are 0,
+    // so a click at clientX/Y=0 falls under the 4-px drag threshold.
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 0, clientY: 0 }));
+    await Promise.resolve();
+    expect(hass.callWS).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "call_service",
+        domain: "verisure_owa",
+        service: "fetch_activity_image",
+        service_data: expect.objectContaining({
+          entity_id: ENTITY,
+          id_signal: "9001",
+        }),
+      }),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/tests-js/integration/alarm-card-editor.test.js
+++ b/tests-js/integration/alarm-card-editor.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeAlarmEntity } from "../fixtures/entities.js";
+
+describe("verisure-owa-alarm-card-editor", () => {
+  it("registers as a custom element", () => {
+    expect(customElements.get("verisure-owa-alarm-card-editor")).toBeDefined();
+  });
+
+  it("renders an entity picker scoped to alarm_control_panel via ha-form", () => {
+    // The editor delegates entity selection to HA's <ha-form> with an entity
+    // selector — the list of alarm panels is resolved lazily by HA at runtime,
+    // not embedded in the editor's shadow DOM. We instead assert that the
+    // editor wires up the entity ha-form with the alarm_control_panel domain
+    // restriction, and that the current entity flows into ha-form.data.
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.panel_a" });
+    editor.hass = makeHass({
+      states: {
+        "alarm_control_panel.panel_a": makeAlarmEntity(),
+        "alarm_control_panel.panel_b": makeAlarmEntity(),
+        "light.kitchen": { state: "on", attributes: {} },
+      },
+    });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm).not.toBeNull();
+    expect(entityForm.tagName.toLowerCase()).toBe("ha-form");
+    expect(entityForm.schema).toEqual([
+      { name: "entity", selector: { entity: { domain: "alarm_control_panel" } } },
+    ]);
+    expect(entityForm.data).toEqual({ entity: "alarm_control_panel.panel_a" });
+  });
+
+  it("dispatches config-changed when the entity ha-form emits value-changed", () => {
+    // The editor wires to ha-form's "value-changed" event (HA convention),
+    // not a native <select> change. happy-dom renders <ha-form> as a generic
+    // HTMLElement so we dispatch the event the editor actually listens for.
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.panel_a": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm).not.toBeNull();
+    entityForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { entity: "alarm_control_panel.panel_a" } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    expect(captured?.entity).toBe("alarm_control_panel.panel_a");
+  });
+});

--- a/tests-js/integration/alarm-card-editor.test.js
+++ b/tests-js/integration/alarm-card-editor.test.js
@@ -333,8 +333,15 @@ describe("verisure-owa-alarm-card-editor defensive defaults", () => {
   });
 });
 
-describe("verisure-owa-alarm-card-editor reuse on subsequent setConfig", () => {
-  it("does not rebuild the DOM when only non-structural keys change", () => {
+describe("verisure-owa-alarm-card-editor setConfig re-render behavior", () => {
+  // PR #475 made the editor re-render on every external setConfig (YAML edits,
+  // initial mount, parent resets), and re-render on internal structural
+  // changes (entity / type). Internal non-structural writes (name, colors,
+  // gestures) routed through _fireChanged are suppressed for one tick by the
+  // _internalWriteInFlight flag so the parent's round-trip doesn't tear down
+  // the editor while the user is still editing.
+
+  it("external setConfig (YAML edit) rebuilds the editor DOM", () => {
     const editor = document.createElement("verisure-owa-alarm-card-editor");
     editor.setConfig({ entity: "alarm_control_panel.x" });
     editor.hass = makeHass({
@@ -342,8 +349,337 @@ describe("verisure-owa-alarm-card-editor reuse on subsequent setConfig", () => {
     });
     document.body.appendChild(editor);
     const firstEditor = editor.shadowRoot.querySelector(".editor");
+    // Simulate an external YAML edit — the parent calls setConfig with a fresh
+    // config object and no _internalWriteInFlight flag pending.
     editor.setConfig({ entity: "alarm_control_panel.x", name: "Renamed" });
     const secondEditor = editor.shadowRoot.querySelector(".editor");
+    expect(secondEditor).not.toBe(firstEditor);
+    // The new name flows into the rebuilt textfield.
+    const nameTf = editor.shadowRoot.querySelector("#name-slot ha-textfield");
+    expect(nameTf.value).toBe("Renamed");
+  });
+
+  it("internal non-structural write (name typed into textfield) does NOT rebuild the DOM", () => {
+    // After _fireChanged the parent re-calls setConfig with the same entity
+    // and type, but _internalWriteInFlight is set — the suppression branch
+    // skips _render so the user's typing cursor isn't lost.
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x" });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    const firstEditor = editor.shadowRoot.querySelector(".editor");
+    const nameTf = editor.shadowRoot.querySelector("#name-slot ha-textfield");
+    nameTf.value = "Typed";
+    nameTf.dispatchEvent(new Event("input", { bubbles: true }));
+    // Simulate the parent's round-trip (same entity/type → not structural).
+    editor.setConfig({ entity: "alarm_control_panel.x", name: "Typed" });
+    const secondEditor = editor.shadowRoot.querySelector(".editor");
     expect(secondEditor).toBe(firstEditor);
+  });
+
+  it("structural change (entity) rebuilds the DOM even when _internalWriteInFlight is set", () => {
+    // Copilot-caught regression from PR #475: setConfig must NOT short-circuit
+    // when entity (or type) changes, even mid-flight, because the Arm modes
+    // checkboxes + each gesture's arm_state dropdown are derived from the new
+    // entity's supported_features. Without this safeguard the editor showed
+    // the previous entity's modes until close/reopen.
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x" });
+    editor.hass = makeHass({
+      states: {
+        "alarm_control_panel.x": makeAlarmEntity(),
+        "alarm_control_panel.y": makeAlarmEntity(),
+      },
+    });
+    document.body.appendChild(editor);
+    const firstEditor = editor.shadowRoot.querySelector(".editor");
+    // Simulate the race: an internal write set the flag, and now a structural
+    // setConfig arrives before the queueMicrotask has cleared it.
+    editor._internalWriteInFlight = true;
+    editor.setConfig({ entity: "alarm_control_panel.y" });
+    const secondEditor = editor.shadowRoot.querySelector(".editor");
+    expect(secondEditor).not.toBe(firstEditor);
+  });
+
+  it("structural change (type — card → badge) rebuilds the DOM", () => {
+    // The gesture defaults differ per variant; a card→badge swap must rebuild
+    // the gesture sections so the new defaults (hold=arm_or_disarm, etc.)
+    // surface immediately.
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({
+      type: "custom:verisure-owa-alarm-card",
+      entity: "alarm_control_panel.x",
+    });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    const firstEditor = editor.shadowRoot.querySelector(".editor");
+    editor.setConfig({
+      type: "custom:verisure-owa-alarm-badge",
+      entity: "alarm_control_panel.x",
+    });
+    const secondEditor = editor.shadowRoot.querySelector(".editor");
+    expect(secondEditor).not.toBe(firstEditor);
+  });
+});
+
+describe("verisure-owa-alarm-card-editor arm modes checkbox section", () => {
+  // PR #475 added a checkbox group listing every mode the entity advertises
+  // via `supported_features`. Toggling rewrites `config.states`; when every
+  // supported box is checked the editor drops the key so the YAML stays
+  // minimal and naturally tracks future `supported_features` expansions.
+
+  function mountEditor(config = {}, hassOverrides = {}) {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x", ...config });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity(hassOverrides) },
+    });
+    document.body.appendChild(editor);
+    return editor;
+  }
+
+  it("renders a checkbox per supported arm mode", () => {
+    // makeAlarmEntity defaults to all 5 features supported.
+    const editor = mountEditor();
+    const checkboxes = editor.shadowRoot.querySelectorAll(".arm-modes-list input[type='checkbox']");
+    expect(checkboxes.length).toBe(5);
+    const keys = Array.from(checkboxes).map((cb) => cb.dataset.armKey);
+    expect(keys).toEqual([
+      "arm_away",
+      "arm_home",
+      "arm_night",
+      "arm_vacation",
+      "arm_custom_bypass",
+    ]);
+  });
+
+  it("all checkboxes checked by default when config.states is unset", () => {
+    const editor = mountEditor();
+    const checkboxes = editor.shadowRoot.querySelectorAll(".arm-modes-list input[type='checkbox']");
+    Array.from(checkboxes).forEach((cb) => expect(cb.checked).toBe(true));
+  });
+
+  it("only configured modes are checked when config.states is set", () => {
+    const editor = mountEditor({ states: ["arm_away", "arm_night"] });
+    const checked = Array.from(
+      editor.shadowRoot.querySelectorAll(".arm-modes-list input[type='checkbox']"),
+    )
+      .filter((cb) => cb.checked)
+      .map((cb) => cb.dataset.armKey);
+    expect(checked).toEqual(["arm_away", "arm_night"]);
+  });
+
+  it("unchecking a checkbox writes config.states with only the still-checked modes", () => {
+    const editor = mountEditor();
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    // Uncheck arm_home.
+    const homeCb = editor.shadowRoot.querySelector(
+      ".arm-modes-list input[type='checkbox'][data-arm-key='arm_home']",
+    );
+    homeCb.checked = false;
+    homeCb.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(captured.states).toEqual(["arm_away", "arm_night", "arm_vacation", "arm_custom_bypass"]);
+  });
+
+  it("re-checking the last hidden mode (all supported again) drops the states key", () => {
+    const editor = mountEditor({
+      states: ["arm_away", "arm_home", "arm_night", "arm_vacation"],
+    });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    // Re-check arm_custom_bypass — now all 5 are on again.
+    const customCb = editor.shadowRoot.querySelector(
+      ".arm-modes-list input[type='checkbox'][data-arm-key='arm_custom_bypass']",
+    );
+    customCb.checked = true;
+    customCb.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(captured).not.toHaveProperty("states");
+  });
+
+  it("renders the all-hidden hint when every checkbox is unchecked", () => {
+    const editor = mountEditor({ states: [] });
+    // The arm_or_disarm section inside each gesture should show the
+    // editor_arm_state_no_modes hint when filtered = [].
+    // First switch a gesture to arm_or_disarm to trigger the conditional
+    // rendering of the hint.
+    const tapSection = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const tapActionForm = tapSection.querySelector("ha-form");
+    tapActionForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { action: "arm_or_disarm" } },
+        bubbles: true,
+      }),
+    );
+    // The arm-fields block should now hold the hint and NO arm-state ha-form.
+    const tapSectionAfter = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const armFields = tapSectionAfter.querySelectorAll(".conditional-fields")[2];
+    expect(armFields.querySelector(".arm-modes-empty")).not.toBeNull();
+    expect(armFields.querySelector(".arm-modes-empty").textContent).toMatch(
+      /at least one arm mode/i,
+    );
+  });
+
+  it("renders the no-supported-modes message when the entity has zero features", () => {
+    const editor = mountEditor({}, { supportedFeatures: 0 });
+    // The arm-modes section appends a `.arm-modes-empty` div instead of the
+    // `.arm-modes-list`.
+    const armModesSection = editor.shadowRoot.querySelector(".arm-modes-section");
+    expect(armModesSection.querySelector(".arm-modes-list")).toBeNull();
+    const emptyMsg = armModesSection.querySelector(".arm-modes-empty");
+    expect(emptyMsg).not.toBeNull();
+    expect(emptyMsg.textContent).toMatch(/no supported arm modes/i);
+  });
+
+  it("toggling a checkbox refreshes each gesture's arm_state dropdown options live", () => {
+    // Seed with the hold gesture set to arm_or_disarm — its dropdown options
+    // should match all 5 supported modes initially.
+    const editor = mountEditor({ hold_action: { action: "arm_or_disarm" } });
+    let armFields = editor.shadowRoot
+      .querySelectorAll(".gesture-section")[1] // hold section
+      .querySelectorAll(".conditional-fields")[2];
+    let armForm = armFields.querySelector("ha-form");
+    const initialOpts = armForm.schema[0].selector.select.options.map((o) => o.value);
+    expect(initialOpts.length).toBe(5);
+    // Uncheck arm_night — gesture dropdowns should rebuild without it.
+    const nightCb = editor.shadowRoot.querySelector(
+      ".arm-modes-list input[type='checkbox'][data-arm-key='arm_night']",
+    );
+    nightCb.checked = false;
+    nightCb.dispatchEvent(new Event("change", { bubbles: true }));
+    // The gesture slot is rebuilt — re-query for the new form.
+    armFields = editor.shadowRoot
+      .querySelectorAll(".gesture-section")[1]
+      .querySelectorAll(".conditional-fields")[2];
+    armForm = armFields.querySelector("ha-form");
+    const newOpts = armForm.schema[0].selector.select.options.map((o) => o.value);
+    expect(newOpts).not.toContain("arm_night");
+    expect(newOpts.length).toBe(4);
+  });
+
+  it("scrubs a gesture's arm_state when its referenced mode is hidden", () => {
+    const editor = mountEditor({
+      hold_action: { action: "arm_or_disarm", arm_state: "arm_home" },
+    });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    // Uncheck arm_home — the gesture's arm_state references it; it must be
+    // rewritten to the new default.
+    const homeCb = editor.shadowRoot.querySelector(
+      ".arm-modes-list input[type='checkbox'][data-arm-key='arm_home']",
+    );
+    homeCb.checked = false;
+    homeCb.dispatchEvent(new Event("change", { bubbles: true }));
+    // hold_action.arm_state must NOT still be "arm_home" — it should fall back
+    // to the first remaining supported mode (arm_away).
+    expect(captured.hold_action.arm_state).not.toBe("arm_home");
+    expect(captured.hold_action.arm_state).toBe("arm_away");
+  });
+
+  it("leaves an unrelated (non-arm_or_disarm) gesture's arm_state untouched", () => {
+    // Only arm_or_disarm gestures should be scrubbed — a navigate gesture
+    // with a stale arm_state should not be modified.
+    const editor = mountEditor({
+      hold_action: { action: "navigate", navigation_path: "/lovelace/0" },
+    });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const homeCb = editor.shadowRoot.querySelector(
+      ".arm-modes-list input[type='checkbox'][data-arm-key='arm_home']",
+    );
+    homeCb.checked = false;
+    homeCb.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(captured.hold_action.action).toBe("navigate");
+    expect(captured.hold_action.navigation_path).toBe("/lovelace/0");
+  });
+
+  it("does not scrub gesture arm_state when the resulting states list is empty (falls back to all supported)", () => {
+    // Edge case: when the user unchecks every mode, the editor leaves the
+    // gesture's saved arm_state alone — the dropdown's empty-list branch is
+    // already handled by the userHiddenAll hint.
+    const editor = mountEditor({
+      states: ["arm_home"],
+      hold_action: { action: "arm_or_disarm", arm_state: "arm_home" },
+    });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    // Uncheck the only remaining mode (arm_home) — now states becomes [].
+    const homeCb = editor.shadowRoot.querySelector(
+      ".arm-modes-list input[type='checkbox'][data-arm-key='arm_home']",
+    );
+    homeCb.checked = false;
+    homeCb.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(captured.states).toEqual([]);
+    // Per code: scrub only runs when nextStates.length > 0, so arm_home
+    // stays in the saved config (the gesture section will show the hint
+    // instead of the dropdown).
+    expect(captured.hold_action.arm_state).toBe("arm_home");
+  });
+});
+
+describe("verisure-owa-alarm-card-editor per-variant gesture defaults", () => {
+  // PR #475: editor's gesture defaults mirror each variant's runtime
+  // fallbacks. card: tap=none, hold=none. badge: tap=more-info,
+  // hold=arm_or_disarm. chip: tap=more-info, hold=none. Otherwise the editor
+  // would display an action the runtime would never actually invoke.
+
+  function mountEditorForType(type) {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ type, entity: "alarm_control_panel.x" });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    return editor;
+  }
+
+  it("card variant: tap default is 'none', hold default is 'none'", () => {
+    const editor = mountEditorForType("custom:verisure-owa-alarm-card");
+    const sections = editor.shadowRoot.querySelectorAll(".gesture-section");
+    expect(sections[0].querySelector("ha-form").data.action).toBe("none");
+    expect(sections[1].querySelector("ha-form").data.action).toBe("none");
+  });
+
+  it("badge variant: tap default is 'more-info', hold default is 'arm_or_disarm'", () => {
+    const editor = mountEditorForType("custom:verisure-owa-alarm-badge");
+    const sections = editor.shadowRoot.querySelectorAll(".gesture-section");
+    expect(sections[0].querySelector("ha-form").data.action).toBe("more-info");
+    expect(sections[1].querySelector("ha-form").data.action).toBe("arm_or_disarm");
+  });
+
+  it("chip variant: tap default is 'more-info', hold default is 'none'", () => {
+    // The chip's runtime defaults are tap=more-info, hold=none (chips have
+    // no PIN-overlay-on-long-press fallback like the badge does).
+    const editor = mountEditorForType("custom:verisure-owa-alarm-chip");
+    const sections = editor.shadowRoot.querySelectorAll(".gesture-section");
+    expect(sections[0].querySelector("ha-form").data.action).toBe("more-info");
+    expect(sections[1].querySelector("ha-form").data.action).toBe("none");
+  });
+
+  it("mushroom chip variant resolves to chip defaults via the -alarm-chip suffix match", () => {
+    const editor = mountEditorForType("custom:mushroom-verisure-owa-alarm-chip");
+    const sections = editor.shadowRoot.querySelectorAll(".gesture-section");
+    expect(sections[0].querySelector("ha-form").data.action).toBe("more-info");
+  });
+
+  it("legacy securitas-alarm-badge type alias still resolves to badge defaults", () => {
+    const editor = mountEditorForType("custom:securitas-alarm-badge");
+    const sections = editor.shadowRoot.querySelectorAll(".gesture-section");
+    expect(sections[0].querySelector("ha-form").data.action).toBe("more-info");
+    expect(sections[1].querySelector("ha-form").data.action).toBe("arm_or_disarm");
   });
 });

--- a/tests-js/integration/alarm-card-editor.test.js
+++ b/tests-js/integration/alarm-card-editor.test.js
@@ -63,3 +63,287 @@ describe("verisure-owa-alarm-card-editor", () => {
     expect(captured?.entity).toBe("alarm_control_panel.panel_a");
   });
 });
+
+describe("verisure-owa-alarm-card-editor name field", () => {
+  function mountEditor() {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x" });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    return editor;
+  }
+
+  it("setting a non-empty name in the textfield merges it into the config", () => {
+    const editor = mountEditor();
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const nameTf = editor.shadowRoot.querySelector("#name-slot ha-textfield");
+    expect(nameTf).not.toBeNull();
+    nameTf.value = "My Panel";
+    nameTf.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(captured?.name).toBe("My Panel");
+  });
+
+  it("clearing the name field removes the name key from the config", () => {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x", name: "Old" });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const nameTf = editor.shadowRoot.querySelector("#name-slot ha-textfield");
+    nameTf.value = "";
+    nameTf.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(captured).not.toHaveProperty("name");
+  });
+});
+
+describe("verisure-owa-alarm-card-editor color pickers", () => {
+  function mountEditor(config = {}) {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x", ...config });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    return editor;
+  }
+
+  it("changing a color picker merges colors.<state> into the config and unhides reset", () => {
+    const editor = mountEditor();
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const picker = editor.shadowRoot.querySelector('input[type="color"][data-state="disarmed"]');
+    picker.value = "#123456";
+    picker.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(captured.colors.disarmed).toBe("#123456");
+    const resetBtn = editor.shadowRoot.querySelector('.reset-btn[data-reset="disarmed"]');
+    expect(resetBtn.hasAttribute("hidden")).toBe(false);
+  });
+
+  it("clicking reset on the only override removes the colors key entirely", () => {
+    const editor = mountEditor({ colors: { disarmed: "#123456" } });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const resetBtn = editor.shadowRoot.querySelector('.reset-btn[data-reset="disarmed"]');
+    resetBtn.click();
+    expect(captured).not.toHaveProperty("colors");
+    expect(resetBtn.hasAttribute("hidden")).toBe(true);
+  });
+
+  it("clicking reset on one of two overrides keeps the other", () => {
+    const editor = mountEditor({
+      colors: { disarmed: "#111111", armed_away: "#222222" },
+    });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const resetBtn = editor.shadowRoot.querySelector('.reset-btn[data-reset="disarmed"]');
+    resetBtn.click();
+    expect(captured.colors).toEqual({ armed_away: "#222222" });
+  });
+});
+
+describe("verisure-owa-alarm-card-editor gesture sections", () => {
+  function mountEditor(config = {}) {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x", ...config });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    return editor;
+  }
+
+  it("renders three gesture sections (tap / hold / double-tap)", () => {
+    const editor = mountEditor();
+    const sections = editor.shadowRoot.querySelectorAll(".gesture-section");
+    expect(sections.length).toBe(3);
+  });
+
+  it("badge-type editor uses more-info as the default tap action", () => {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({
+      type: "custom:securitas-alarm-badge",
+      entity: "alarm_control_panel.x",
+    });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    const sections = editor.shadowRoot.querySelectorAll(".gesture-section");
+    // First section is tap_action — its ha-form.data.action should be more-info.
+    const tapForm = sections[0].querySelector("ha-form");
+    expect(tapForm.data.action).toBe("more-info");
+  });
+
+  it("transitioning action through perform-action and arm_or_disarm toggles each sub-field block", () => {
+    const editor = mountEditor();
+    const tapSection = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const actionForm = tapSection.querySelector("ha-form");
+    const [navFields, perfFields, armFields] = tapSection.querySelectorAll(".conditional-fields");
+
+    actionForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { action: "perform-action" } },
+        bubbles: true,
+      }),
+    );
+    expect(perfFields.style.display).toBe("");
+    expect(navFields.style.display).toBe("none");
+    expect(armFields.style.display).toBe("none");
+
+    actionForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { action: "arm_or_disarm" } },
+        bubbles: true,
+      }),
+    );
+    expect(armFields.style.display).toBe("");
+    expect(perfFields.style.display).toBe("none");
+  });
+
+  it("changing the action selector to navigate reveals the navigation_path field", () => {
+    const editor = mountEditor();
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const tapSection = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const actionForm = tapSection.querySelector("ha-form");
+    actionForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { action: "navigate" } },
+        bubbles: true,
+      }),
+    );
+    expect(captured.tap_action.action).toBe("navigate");
+    const navFields = tapSection.querySelectorAll(".conditional-fields")[0];
+    expect(navFields.style.display).toBe("");
+  });
+
+  it("setting a navigation_path round-trips into the config", () => {
+    const editor = mountEditor({ tap_action: { action: "navigate" } });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const tapSection = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const navForm = tapSection.querySelectorAll(".conditional-fields ha-form")[0];
+    navForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { navigation_path: "/lovelace/0" } },
+        bubbles: true,
+      }),
+    );
+    expect(captured.tap_action.navigation_path).toBe("/lovelace/0");
+  });
+
+  it("changing perform-action service field writes perform_action into the config", () => {
+    const editor = mountEditor({ tap_action: { action: "perform-action" } });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const tapSection = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const perfFields = tapSection.querySelectorAll(".conditional-fields")[1];
+    const [perfInput, perfDataInput] = perfFields.querySelectorAll("ha-textfield");
+    perfInput.value = "light.turn_on";
+    perfInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(captured.tap_action.perform_action).toBe("light.turn_on");
+    // Valid JSON in the data field becomes a parsed object.
+    perfDataInput.value = '{"entity_id":"light.kitchen"}';
+    perfDataInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(captured.tap_action.data).toEqual({ entity_id: "light.kitchen" });
+    // Invalid JSON silently leaves data unset (the catch is empty).
+    perfDataInput.value = "{not json";
+    perfDataInput.dispatchEvent(new Event("input", { bubbles: true }));
+    // captured will be re-merged — data should not be present anymore.
+    expect(captured.tap_action).not.toHaveProperty("data");
+  });
+
+  it("changing arm_state in arm_or_disarm round-trips into the config", () => {
+    const editor = mountEditor({ tap_action: { action: "arm_or_disarm" } });
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+    const tapSection = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const armFields = tapSection.querySelectorAll(".conditional-fields")[2];
+    const armForm = armFields.querySelector("ha-form");
+    armForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { arm_state: "arm_home" } },
+        bubbles: true,
+      }),
+    );
+    expect(captured.tap_action.arm_state).toBe("arm_home");
+  });
+});
+
+describe("verisure-owa-alarm-card-editor seeds gesture sections from existing config", () => {
+  it("perform-action data is pre-populated as JSON in the Data textfield", () => {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({
+      entity: "alarm_control_panel.x",
+      tap_action: {
+        action: "perform-action",
+        perform_action: "light.turn_on",
+        data: { entity_id: "light.kitchen" },
+      },
+    });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    const tapSection = editor.shadowRoot.querySelectorAll(".gesture-section")[0];
+    const perfFields = tapSection.querySelectorAll(".conditional-fields")[1];
+    const [, perfDataInput] = perfFields.querySelectorAll("ha-textfield");
+    expect(perfDataInput.value).toBe('{"entity_id":"light.kitchen"}');
+    // The conditional perform-action block should be visible.
+    expect(perfFields.style.display).toBe("");
+  });
+});
+
+describe("verisure-owa-alarm-card-editor defensive defaults", () => {
+  it("renders without throwing when hass.language is undefined", () => {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x" });
+    const hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    // Force language to be a falsy value to take the `|| "en"` branch.
+    delete hass.language;
+    editor.hass = hass;
+    document.body.appendChild(editor);
+    expect(editor.shadowRoot.getElementById("entity-form")).not.toBeNull();
+  });
+});
+
+describe("verisure-owa-alarm-card-editor reuse on subsequent setConfig", () => {
+  it("does not rebuild the DOM when only non-structural keys change", () => {
+    const editor = document.createElement("verisure-owa-alarm-card-editor");
+    editor.setConfig({ entity: "alarm_control_panel.x" });
+    editor.hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    document.body.appendChild(editor);
+    const firstEditor = editor.shadowRoot.querySelector(".editor");
+    editor.setConfig({ entity: "alarm_control_panel.x", name: "Renamed" });
+    const secondEditor = editor.shadowRoot.querySelector(".editor");
+    expect(secondEditor).toBe(firstEditor);
+  });
+});

--- a/tests-js/integration/alarm-card-extras.test.js
+++ b/tests-js/integration/alarm-card-extras.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
 import { makeHass } from "../fixtures/hass.js";
 import { makeAlarmEntity } from "../fixtures/entities.js";
@@ -85,5 +85,596 @@ describe("verisure-owa-alarm-chip", () => {
   it("throws when setConfig is called without an entity", () => {
     const chip = document.createElement("verisure-owa-alarm-chip");
     expect(() => chip.setConfig({})).toThrow(/entity/i);
+  });
+
+  it("renders the shield-alert icon when the entity is missing", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    chip.hass = makeHass({ states: {} });
+    document.body.appendChild(chip);
+    expect(chip.shadowRoot.innerHTML).toContain("mdi:shield-alert");
+  });
+
+  it("supports the `set config` alias for setConfig", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.config = { entity: ENTITY };
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    document.body.appendChild(chip);
+    expect(chip.shadowRoot.innerHTML).toContain("mdi:shield-off-outline");
+  });
+
+  it("getCardSize returns 1", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    expect(chip.getCardSize()).toBe(1);
+  });
+});
+
+describe("verisure-owa-alarm-badge dialog and overlay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  function mountBadge({ config = {}, hass } = {}) {
+    const badge = document.createElement("verisure-owa-alarm-badge");
+    badge.setConfig({ entity: ENTITY, ...config });
+    badge.hass =
+      hass ||
+      makeHass({
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      });
+    document.body.appendChild(badge);
+    return badge;
+  }
+
+  it("a tap opens the dialog (default tap_action=more-info)", () => {
+    const badge = mountBadge();
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    // The dialog mounts a verisure-owa-alarm-card under document.body, inside
+    // an overlay div.
+    const dialogCard = document.body.querySelector("securitas-alarm-card");
+    expect(dialogCard).not.toBeNull();
+  });
+
+  it("closing the dialog via the close button removes the overlay", () => {
+    const badge = mountBadge();
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    const dialogCard = document.body.querySelector("securitas-alarm-card");
+    expect(dialogCard).not.toBeNull();
+    // The close button is the first button inside the overlay's content wrapper.
+    const closeBtn = dialogCard.parentElement.querySelector("button");
+    closeBtn.click();
+    expect(document.body.querySelector("securitas-alarm-card")).toBeNull();
+  });
+
+  it("re-entering the dialog is a no-op while one is already open", () => {
+    const badge = mountBadge();
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    // Open dialog
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    // Try to open again — handler should bail out due to _dialogOpen guard.
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(document.body.querySelectorAll("securitas-alarm-card").length).toBe(1);
+  });
+
+  it("a long-press with arm_or_disarm + code opens the PIN overlay", () => {
+    const badge = mountBadge({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "armed_away",
+            codeArmRequired: true,
+            codeFormat: "number",
+          }),
+        },
+      }),
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    // The badge PIN overlay is attached to document.body with #badge-pin-input.
+    const overlayInput = document.querySelector("#badge-pin-input");
+    expect(overlayInput).not.toBeNull();
+  });
+
+  it("the PIN overlay submits alarm_disarm when Confirm is clicked", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const badge = mountBadge({
+      hass,
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    // Type "1" via keypad
+    document.querySelector('[data-badge-key="1"]').click();
+    document.querySelector('[data-badge-key="2"]').click();
+    document.querySelector('[data-badge-key="3"]').click();
+    document.querySelector("#badge-pin-confirm").click();
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+      code: "123",
+    });
+    // Overlay should be torn down
+    expect(document.querySelector("#badge-pin-input")).toBeNull();
+  });
+
+  it("PIN overlay del key removes the last digit; cancel key closes", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const badge = mountBadge({
+      hass,
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    document.querySelector('[data-badge-key="9"]').click();
+    document.querySelector('[data-badge-key="9"]').click();
+    document.querySelector('[data-badge-key="del"]').click();
+    document.querySelector("#badge-pin-confirm").click();
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+      code: "9",
+    });
+    // Reopen and dismiss via cancel key — overlay must close, no service call.
+    const newBadge = mountBadge({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "armed_away",
+            codeArmRequired: true,
+            codeFormat: "number",
+          }),
+        },
+      }),
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const newBadgeEl = newBadge.shadowRoot.getElementById("badge");
+    newBadgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    document.querySelector('[data-badge-key="cancel"]').click();
+    expect(document.querySelector("#badge-pin-input")).toBeNull();
+  });
+
+  it("PIN overlay text input event updates _pin and submit calls service with code", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "text",
+        }),
+      },
+    });
+    const badge = mountBadge({
+      hass,
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    const input = document.querySelector("#badge-pin-input");
+    input.value = "abc!";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    document.querySelector("#badge-pin-confirm").click();
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+      code: "abc!",
+    });
+  });
+
+  it("PIN confirm with empty PIN is a no-op (early-return guard)", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const badge = mountBadge({
+      hass,
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    document.querySelector("#badge-pin-confirm").click();
+    expect(hass.callService).not.toHaveBeenCalled();
+  });
+
+  it("PIN overlay text-format renders a text input (no keypad)", () => {
+    const badge = mountBadge({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "armed_away",
+            codeArmRequired: true,
+            codeFormat: "text",
+          }),
+        },
+      }),
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    expect(document.querySelector('[data-badge-key="1"]')).toBeNull();
+    expect(document.querySelector("#badge-pin-input")).not.toBeNull();
+  });
+
+  it("PIN overlay Enter on the input submits; Escape closes", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "text",
+        }),
+      },
+    });
+    const badge = mountBadge({
+      hass,
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    const input = document.querySelector("#badge-pin-input");
+    input.value = "secret";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+      code: "secret",
+    });
+    // Now open a fresh overlay and dismiss with Escape.
+    const badge2 = mountBadge({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "armed_away",
+            codeArmRequired: true,
+            codeFormat: "text",
+          }),
+        },
+      }),
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl2 = badge2.shadowRoot.getElementById("badge");
+    badgeEl2.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    const input2 = document.querySelector("#badge-pin-input");
+    input2.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(document.querySelector("#badge-pin-input")).toBeNull();
+  });
+
+  it("PIN overlay Cancel button closes without a service call", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const badge = mountBadge({
+      hass,
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    document.querySelector("#badge-pin-cancel").click();
+    expect(hass.callService).not.toHaveBeenCalled();
+    expect(document.querySelector("#badge-pin-input")).toBeNull();
+  });
+
+  it("badge disconnect tears down the PIN overlay if one is open", () => {
+    const badge = mountBadge({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "armed_away",
+            codeArmRequired: true,
+            codeFormat: "number",
+          }),
+        },
+      }),
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    expect(document.querySelector("#badge-pin-input")).not.toBeNull();
+    badge.remove();
+    expect(document.querySelector("#badge-pin-input")).toBeNull();
+  });
+
+  it("badge dialog wires up a connection 'disconnected' listener and unsubscribes on close", () => {
+    let unsubCalled = false;
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      connection: {
+        addEventListener: vi.fn(() => () => {
+          unsubCalled = true;
+        }),
+      },
+    });
+    const badge = mountBadge({ hass });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(hass.connection.addEventListener).toHaveBeenCalledWith(
+      "disconnected",
+      expect.any(Function),
+    );
+    // Closing via the close button should call the unsub fn.
+    const dialogCard = document.body.querySelector("securitas-alarm-card");
+    const closeBtn = dialogCard.parentElement.querySelector("button");
+    closeBtn.click();
+    expect(unsubCalled).toBe(true);
+  });
+
+  it("badge skips re-render when neither state nor force_arm_available change", () => {
+    const badge = mountBadge();
+    const firstHtml = badge.shadowRoot.innerHTML;
+    // Same hass — identity key matches, no rerender.
+    badge.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    expect(badge.shadowRoot.innerHTML).toBe(firstHtml);
+  });
+
+  it("clicking outside the dialog overlay closes it (transparent-area dismissal)", () => {
+    const badge = mountBadge();
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    const dialogCard = document.body.querySelector("securitas-alarm-card");
+    expect(dialogCard).not.toBeNull();
+    // The overlay is the dialogCard's grandparent (overlay → content → card).
+    const overlay = dialogCard.parentElement.parentElement;
+    // Click event targets the overlay itself (not its children).
+    overlay.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.body.querySelector("securitas-alarm-card")).toBeNull();
+  });
+
+  it("clicking outside the PIN overlay closes it (transparent-area dismissal)", () => {
+    const badge = mountBadge({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "armed_away",
+            codeArmRequired: true,
+            codeFormat: "number",
+          }),
+        },
+      }),
+      config: { hold_action: { action: "arm_or_disarm" } },
+    });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    const pinInput = document.querySelector("#badge-pin-input");
+    expect(pinInput).not.toBeNull();
+    // Walk up to the outer overlay div.
+    const overlay = pinInput.closest("div").parentElement;
+    overlay.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector("#badge-pin-input")).toBeNull();
+  });
+
+  it("badge forwards subsequent hass updates to the open dialog card", () => {
+    const badge = mountBadge();
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    const dialogCard = document.body.querySelector("securitas-alarm-card");
+    badge.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "armed_home" }) },
+    });
+    expect(dialogCard.shadowRoot.innerHTML).toContain("Armed Home");
+  });
+
+  it("badge getCardSize returns 1; getConfigElement returns the editor", () => {
+    const badge = mountBadge();
+    expect(badge.getCardSize()).toBe(1);
+    const ctor = customElements.get("verisure-owa-alarm-badge");
+    const editor = ctor.getConfigElement();
+    expect(editor.tagName.toLowerCase()).toBe("securitas-alarm-card-editor");
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity() },
+    });
+    expect(ctor.getStubConfig(hass).entity).toBe(ENTITY);
+    expect(ctor.getStubConfig(makeHass()).entity).toBe("");
+  });
+});
+
+describe("verisure-owa-alarm-chip dialog wiring", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("a tap on the chip opens the dialog", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    document.body.appendChild(chip);
+    const chipEl = chip.shadowRoot.getElementById("chip");
+    chipEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    chipEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(document.body.querySelector("securitas-alarm-card")).not.toBeNull();
+  });
+
+  it("setting hass before setConfig is a no-op (renders only after config arrives)", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    expect(chip.shadowRoot.innerHTML).toBe("");
+    chip.setConfig({ entity: ENTITY });
+    document.body.appendChild(chip);
+    expect(chip.shadowRoot.querySelector(".chip")).not.toBeNull();
+  });
+
+  it("re-rendering the chip is skipped when state hasn't changed (identity-key cache)", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    chip.hass = hass;
+    document.body.appendChild(chip);
+    const firstChipEl = chip.shadowRoot.getElementById("chip");
+    // Same key — should NOT re-render.
+    chip.hass = hass;
+    const secondChipEl = chip.shadowRoot.getElementById("chip");
+    expect(secondChipEl).toBe(firstChipEl);
+  });
+
+  it("chip with force_arm_available renders the warning alert icon and re-renders on change", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    chip.hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({ state: "disarmed", forceArmAvailable: true }),
+      },
+    });
+    document.body.appendChild(chip);
+    expect(chip.shadowRoot.innerHTML).toContain("mdi:alert");
+    // Toggle force_arm_available off — chip should re-render to the regular icon.
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    expect(chip.shadowRoot.innerHTML).toContain("mdi:shield-off-outline");
+  });
+
+  it("chip forwards subsequent hass updates to the open dialog card", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    document.body.appendChild(chip);
+    const chipEl = chip.shadowRoot.getElementById("chip");
+    chipEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    chipEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    const dialogCard = document.body.querySelector("securitas-alarm-card");
+    expect(dialogCard).not.toBeNull();
+    // Push a new hass with armed state — the dialog card should re-render to armed.
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "armed_away" }) },
+    });
+    expect(dialogCard.shadowRoot.innerHTML).toContain("Armed Away");
+  });
+
+  it("a long-press on the chip with arm_or_disarm + code opens the PIN overlay", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({
+      entity: ENTITY,
+      hold_action: { action: "arm_or_disarm" },
+    });
+    chip.hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    document.body.appendChild(chip);
+    const chipEl = chip.shadowRoot.getElementById("chip");
+    chipEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    expect(document.querySelector("#badge-pin-input")).not.toBeNull();
   });
 });

--- a/tests-js/integration/alarm-card-extras.test.js
+++ b/tests-js/integration/alarm-card-extras.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeAlarmEntity } from "../fixtures/entities.js";
+
+const ENTITY = "alarm_control_panel.test";
+
+describe("verisure-owa-alarm-badge", () => {
+  it("registers", () => {
+    expect(customElements.get("verisure-owa-alarm-badge")).toBeDefined();
+  });
+
+  it("renders a shield-lock icon when armed_away", () => {
+    // The badge intentionally renders only an icon — not state text — so we
+    // assert on the per-state icon mapping from STATE_CFG (armed_away ->
+    // mdi:shield-lock) instead of the original "Armed Away" text assertion.
+    const badge = document.createElement("verisure-owa-alarm-badge");
+    badge.setConfig({ entity: ENTITY });
+    badge.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "armed_away" }) },
+    });
+    document.body.appendChild(badge);
+    const html = badge.shadowRoot.innerHTML;
+    expect(html).toContain("mdi:shield-lock");
+    expect(html).toContain("<ha-icon");
+  });
+
+  it("renders the shield-off-outline icon for unavailable state", () => {
+    // Same reasoning as above: badge has no text rendering. The STATE_CFG
+    // entry for unavailable maps to mdi:shield-off-outline.
+    const badge = document.createElement("verisure-owa-alarm-badge");
+    badge.setConfig({ entity: ENTITY });
+    badge.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "unavailable" }) },
+    });
+    document.body.appendChild(badge);
+    expect(badge.shadowRoot.innerHTML).toContain("mdi:shield-off-outline");
+  });
+
+  it("renders the error shield-alert icon when the entity is missing", () => {
+    const badge = document.createElement("verisure-owa-alarm-badge");
+    badge.setConfig({ entity: ENTITY });
+    badge.hass = makeHass({ states: {} });
+    document.body.appendChild(badge);
+    expect(badge.shadowRoot.innerHTML).toContain("mdi:shield-alert");
+  });
+
+  it("throws when setConfig is called without an entity", () => {
+    const badge = document.createElement("verisure-owa-alarm-badge");
+    expect(() => badge.setConfig({})).toThrow(/entity/i);
+  });
+});
+
+describe("verisure-owa-alarm-chip", () => {
+  it("registers", () => {
+    expect(customElements.get("verisure-owa-alarm-chip")).toBeDefined();
+  });
+
+  it("renders the shield-off-outline icon when disarmed", () => {
+    // The chip, like the badge, renders only an icon (no state text). The
+    // disarmed state maps to mdi:shield-off-outline in STATE_CFG.
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    document.body.appendChild(chip);
+    const html = chip.shadowRoot.innerHTML;
+    expect(html).toContain("mdi:shield-off-outline");
+    expect(html).toContain('class="chip"');
+  });
+
+  it("renders the warning alert icon when force_arm_available is true", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    chip.hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({ state: "disarmed", forceArmAvailable: true }),
+      },
+    });
+    document.body.appendChild(chip);
+    expect(chip.shadowRoot.innerHTML).toContain("mdi:alert");
+  });
+
+  it("throws when setConfig is called without an entity", () => {
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    expect(() => chip.setConfig({})).toThrow(/entity/i);
+  });
+});

--- a/tests-js/integration/alarm-card.test.js
+++ b/tests-js/integration/alarm-card.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
 import { makeHass } from "../fixtures/hass.js";
 import { makeAlarmEntity } from "../fixtures/entities.js";
@@ -243,5 +243,648 @@ describe("verisure-owa-alarm-card error paths", () => {
     expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_arm_away", {
       entity_id: ENTITY,
     });
+  });
+});
+
+describe("verisure-owa-alarm-card banners and force-arm", () => {
+  it("renders the refresh_failed banner when the attribute is true", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({ state: "disarmed", refreshFailed: true }),
+        },
+      }),
+    });
+    const banner = card.shadowRoot.querySelector(".stale-banner");
+    expect(banner).not.toBeNull();
+    expect(banner.textContent).toMatch(/Refresh/);
+  });
+
+  it("renders each arm_exception entry as a list item in the force section", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "disarmed",
+            forceArmAvailable: true,
+            armExceptions: ["Front Door", "Garage"],
+          }),
+        },
+      }),
+    });
+    const items = card.shadowRoot.querySelectorAll(".sensor-list li");
+    expect(items.length).toBe(2);
+    expect(items[0].textContent).toBe("Front Door");
+    expect(items[1].textContent).toBe("Garage");
+  });
+
+  it("disarm button next to force-arm calls alarm_disarm when armed", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({ state: "armed_away", forceArmAvailable: true }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    const disarmBtn = Array.from(card.shadowRoot.querySelectorAll("button")).find((b) =>
+      /Disarm/i.test(b.textContent.trim()),
+    );
+    expect(disarmBtn).not.toBeUndefined();
+    disarmBtn.click();
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+    });
+  });
+});
+
+describe("verisure-owa-alarm-card refresh button", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("clicking refresh calls verisure_owa.refresh_alarm and toggles spinning class", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    hass.callService.mockResolvedValueOnce(undefined);
+    const card = mountAlarmCard({ hass });
+    const refreshBtn = card.shadowRoot.querySelector(".refresh-btn");
+    refreshBtn.click();
+    // Spinner is added synchronously
+    expect(card.shadowRoot.querySelector(".refresh-btn").classList.contains("spinning")).toBe(true);
+    expect(hass.callService).toHaveBeenCalledWith("verisure_owa", "refresh_alarm", {
+      entity_id: ENTITY,
+    });
+    // Drain microtasks + advance past the 2s clear timer
+    await Promise.resolve();
+    await Promise.resolve();
+    vi.advanceTimersByTime(2001);
+    expect(card.shadowRoot.querySelector(".refresh-btn")?.classList.contains("spinning")).toBe(
+      false,
+    );
+  });
+});
+
+describe("verisure-owa-alarm-card PIN keypad", () => {
+  function showPin(card) {
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Arm Away/i.test(b.textContent.trim()))
+      .click();
+  }
+
+  it("typing digits then cancel-pin resets back to normal UI", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "disarmed",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    showPin(card);
+    // Click the "1" key
+    const oneKey = card.shadowRoot.querySelector('[data-key="1"]');
+    oneKey.click();
+
+    expect(card._pin).toBe("1");
+    // Click backspace
+    card.shadowRoot.querySelector('[data-key="del"]').click();
+
+    expect(card._pin).toBe("");
+    // Click cancel key
+    card.shadowRoot.querySelector('[data-key="cancel"]').click();
+    // After cancel, the keypad should be gone — normal arm buttons return.
+    expect(card.shadowRoot.querySelector('[data-key="1"]')).toBeNull();
+  });
+
+  it("confirm-pin submits alarm_disarm with the entered code and resets state", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    // Open PIN entry by clicking Disarm
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Disarm/i.test(b.textContent.trim()))
+      .click();
+    // Type "1234"
+    ["1", "2", "3", "4"].forEach((n) => card.shadowRoot.querySelector(`[data-key="${n}"]`).click());
+    // Click confirm
+    card.shadowRoot.querySelector('[data-action="confirm-pin"]').click();
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+      code: "1234",
+    });
+
+    expect(card._pin).toBe("");
+
+    expect(card._uiState).toBe("normal");
+  });
+
+  it("PIN input strips non-digits on input event", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "disarmed",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Arm Away/i.test(b.textContent.trim()))
+      .click();
+    const pinInput = card.shadowRoot.getElementById("pin-keyboard-input");
+    pinInput.value = "12a3";
+    pinInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(pinInput.value).toBe("123");
+
+    expect(card._pin).toBe("123");
+  });
+
+  it("Enter on the PIN input submits the pending action", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Disarm/i.test(b.textContent.trim()))
+      .click();
+    const pinInput = card.shadowRoot.getElementById("pin-keyboard-input");
+    pinInput.value = "9999";
+    pinInput.dispatchEvent(new Event("input", { bubbles: true }));
+    pinInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+      code: "9999",
+    });
+  });
+
+  it("Escape on the PIN input resets back to normal UI", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "disarmed",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Arm Away/i.test(b.textContent.trim()))
+      .click();
+    const pinInput = card.shadowRoot.getElementById("pin-keyboard-input");
+    pinInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(card._uiState).toBe("normal");
+  });
+
+  it("text-code input Enter submits the pending action and cancel-pin resets", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "text",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Disarm/i.test(b.textContent.trim()))
+      .click();
+    const codeInput = card.shadowRoot.getElementById("code-input");
+    codeInput.value = "letmein";
+    codeInput.dispatchEvent(new Event("input", { bubbles: true }));
+    codeInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+      code: "letmein",
+    });
+  });
+
+  it("clicking cancel button in the text-code section resets UI", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "text",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Disarm/i.test(b.textContent.trim()))
+      .click();
+    const cancelBtn = card.shadowRoot.querySelector('[data-action="cancel-pin"]');
+    cancelBtn.click();
+
+    expect(card._uiState).toBe("normal");
+  });
+});
+
+describe("verisure-owa-alarm-card gesture (icon-wrap pointer events)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("a single tap on the icon-wrap dispatches hass-more-info via the default tap_action", () => {
+    const card = mountAlarmCard({
+      config: { tap_action: { action: "more-info" } },
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) } }),
+    });
+    let captured = null;
+    card.addEventListener("hass-more-info", (e) => {
+      captured = e.detail.entityId;
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(captured).toBe(ENTITY);
+  });
+
+  it("a hold (>500ms) on the icon-wrap fires hold_action (navigate)", () => {
+    const card = mountAlarmCard({
+      config: {
+        hold_action: { action: "navigate", navigation_path: "/lovelace/0" },
+      },
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) } }),
+    });
+    const pushSpy = vi.spyOn(window.history, "pushState");
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    expect(pushSpy).toHaveBeenCalledWith({}, "", "/lovelace/0");
+    pushSpy.mockRestore();
+  });
+
+  it("a double-tap on the icon-wrap fires double_tap_action (perform-action)", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({
+      config: {
+        double_tap_action: {
+          action: "perform-action",
+          perform_action: "light.turn_on",
+          data: { entity_id: "light.kitchen" },
+        },
+      },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    // Double-tap fires immediately on the second pointerup — no timer needed.
+    expect(hass.callService).toHaveBeenCalledWith("light", "turn_on", {
+      entity_id: "light.kitchen",
+    });
+  });
+
+  it("pointermove beyond 10 px cancels the long-press timer", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({
+      config: { hold_action: { action: "more-info" } },
+      hass,
+    });
+    let captured = false;
+    card.addEventListener("hass-more-info", () => {
+      captured = true;
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointermove", { bubbles: true, clientX: 20, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(600);
+    expect(captured).toBe(false);
+  });
+
+  it("pointercancel after pointerdown clears the long-press timer", () => {
+    const card = mountAlarmCard({
+      config: { hold_action: { action: "more-info" } },
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) } }),
+    });
+    let captured = false;
+    card.addEventListener("hass-more-info", () => {
+      captured = true;
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true }));
+    vi.advanceTimersByTime(600);
+    expect(captured).toBe(false);
+  });
+
+  it("hold-fired click is swallowed via stopImmediatePropagation", () => {
+    const card = mountAlarmCard({
+      config: { hold_action: { action: "more-info" } },
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) } }),
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(600);
+    // Hold fired — subsequent click event must be swallowed (no exception).
+    expect(() => iconWrap.dispatchEvent(new MouseEvent("click", { bubbles: true }))).not.toThrow();
+  });
+
+  it("arm_or_disarm gesture on a disarmed entity calls the default arm service", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({
+      config: { tap_action: { action: "arm_or_disarm" } },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_arm_away", {
+      entity_id: ENTITY,
+    });
+  });
+
+  it("arm_or_disarm gesture on an armed entity calls alarm_disarm", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "armed_away" }) },
+    });
+    const card = mountAlarmCard({
+      config: { tap_action: { action: "arm_or_disarm" } },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+    });
+  });
+
+  it("arm_or_disarm gesture on disarmed with code_arm_required starts PIN entry for arm", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "disarmed",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({
+      config: { tap_action: { action: "arm_or_disarm", arm_state: "arm_away" } },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(hass.callService).not.toHaveBeenCalled();
+
+    expect(card._uiState).toBe("pin");
+  });
+
+  it("perform-action with no perform_action string is a no-op (no service call)", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({
+      config: { tap_action: { action: "perform-action" } },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(hass.callService).not.toHaveBeenCalled();
+  });
+
+  it("navigate without a path is a no-op", () => {
+    const card = mountAlarmCard({
+      config: { tap_action: { action: "navigate" } },
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) } }),
+    });
+    const pushSpy = vi.spyOn(window.history, "pushState");
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    expect(pushSpy).not.toHaveBeenCalled();
+    pushSpy.mockRestore();
+  });
+
+  it("arm_or_disarm gesture with a configured code starts PIN entry instead of calling the service", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({
+      config: { tap_action: { action: "arm_or_disarm" } },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+    // No callService — PIN entry is shown instead.
+    expect(hass.callService).not.toHaveBeenCalled();
+
+    expect(card._uiState).toBe("pin");
+  });
+});
+
+describe("verisure-owa-alarm-card color overrides", () => {
+  it("config.colors override is reflected in the top-bar accent color", () => {
+    const card = mountAlarmCard({
+      config: { colors: { disarmed: "#abcdef" } },
+      hass: makeHass({
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      }),
+    });
+    // The accent color is interpolated into the inline <style> block.
+    expect(card.shadowRoot.innerHTML).toContain("#abcdef");
+  });
+
+  it("falls back to the default disabled color when state is not in STATE_CFG", () => {
+    // happy-dom allows arbitrary state strings — the card's STATE_CFG fallback
+    // path uses `var(--disabled-color,#9E9E9E)`.
+    const card = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: {
+            state: "totally-bogus",
+            attributes: { friendly_name: "X", supported_features: 0 },
+          },
+        },
+      }),
+    });
+    expect(card.shadowRoot.innerHTML).toContain("--disabled-color");
+  });
+});
+
+describe("verisure-owa-alarm-card lifecycle and statics", () => {
+  it("getCardSize returns 6 during PIN entry, 5 for force-arm, 3 by default", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({ hass });
+    expect(card.getCardSize()).toBe(3);
+
+    const forceCard = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({ state: "disarmed", forceArmAvailable: true }),
+        },
+      }),
+    });
+    expect(forceCard.getCardSize()).toBe(5);
+
+    const pinCard = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "disarmed",
+            codeArmRequired: true,
+            codeFormat: "number",
+          }),
+        },
+      }),
+    });
+    Array.from(pinCard.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Arm Away/i.test(b.textContent.trim()))
+      .click();
+    expect(pinCard.getCardSize()).toBe(6);
+  });
+
+  it("getConfigElement returns the matching editor element", () => {
+    const ctor = customElements.get("verisure-owa-alarm-card");
+    const el = ctor.getConfigElement();
+    expect(el.tagName.toLowerCase()).toBe("securitas-alarm-card-editor");
+  });
+
+  it("getStubConfig picks the first alarm_control_panel entity", () => {
+    const ctor = customElements.get("verisure-owa-alarm-card");
+    const hass = makeHass({
+      states: {
+        "light.x": { state: "on", attributes: {} },
+        "alarm_control_panel.a": makeAlarmEntity(),
+      },
+    });
+    expect(ctor.getStubConfig(hass).entity).toBe("alarm_control_panel.a");
+  });
+
+  it("getStubConfig returns empty entity when no alarm panels are loaded", () => {
+    const ctor = customElements.get("verisure-owa-alarm-card");
+    expect(ctor.getStubConfig(makeHass()).entity).toBe("");
+  });
+
+  it("disconnectedCallback zeroes pending PIN state and removes gesture listeners", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "disarmed",
+            codeArmRequired: true,
+            codeFormat: "number",
+          }),
+        },
+      }),
+    });
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Arm Away/i.test(b.textContent.trim()))
+      .click();
+
+    expect(card._uiState).toBe("pin");
+    card.remove();
+
+    expect(card._uiState).toBe("normal");
+
+    expect(card._pin).toBe("");
+
+    expect(card._gestureCleanup).toBeNull();
+  });
+
+  it("re-rendering during PIN entry returns to normal UI when entity arms", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({
+            state: "disarmed",
+            codeArmRequired: true,
+            codeFormat: "number",
+          }),
+        },
+      }),
+    });
+    Array.from(card.shadowRoot.querySelectorAll("button"))
+      .find((b) => /Arm Away/i.test(b.textContent.trim()))
+      .click();
+
+    expect(card._uiState).toBe("pin");
+    card.hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+
+    expect(card._uiState).toBe("normal");
   });
 });

--- a/tests-js/integration/alarm-card.test.js
+++ b/tests-js/integration/alarm-card.test.js
@@ -219,39 +219,29 @@ describe("verisure-owa-alarm-card service calls", () => {
 
     expect(
       card.shadowRoot.querySelector("input[type='password'], input[type='text']"),
-    ).toBeDefined();
+    ).not.toBeNull();
   });
 });
 
 describe("verisure-owa-alarm-card error paths", () => {
-  it("does not throw and swallows rejection when callService fails", async () => {
-    // The card fires service calls without .catch() (HA framework convention).
-    // Capture the expected unhandled rejection at the test scope so vitest
-    // doesn't fail the whole run on this intentionally-rejected mock.
-    const swallowed = [];
-    const handler = (reason) => {
-      swallowed.push(reason);
-    };
-    process.on("unhandledRejection", handler);
+  it("does not throw when callService rejects on Arm Away", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    hass.callService.mockRejectedValueOnce(new Error("boom"));
+    const card = mountAlarmCard({ hass });
 
-    try {
-      const hass = makeHass({
-        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
-      });
-      hass.callService.mockRejectedValueOnce(new Error("boom"));
-      const card = mountAlarmCard({ hass });
+    const armBtn = Array.from(card.shadowRoot.querySelectorAll("button")).find((b) =>
+      /Arm Away/i.test(b.textContent.trim()),
+    );
+    expect(armBtn).not.toBeUndefined();
+    expect(() => armBtn.click()).not.toThrow();
 
-      const armBtn = card.shadowRoot.querySelector("button");
-      expect(() => armBtn.click()).not.toThrow();
+    // Let any async work settle before asserting on the spy.
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
-      // Let the rejected promise settle so the unhandledRejection event fires.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Verify the rejection happened and the card called the service.
-      expect(hass.callService).toHaveBeenCalled();
-      expect(swallowed.map((e) => e.message)).toContain("boom");
-    } finally {
-      process.off("unhandledRejection", handler);
-    }
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_arm_away", {
+      entity_id: ENTITY,
+    });
   });
 });

--- a/tests-js/integration/alarm-card.test.js
+++ b/tests-js/integration/alarm-card.test.js
@@ -858,6 +858,42 @@ describe("verisure-owa-alarm-card lifecycle and statics", () => {
     expect(card._gestureCleanup).toBeNull();
   });
 
+  it("reconnecting the card after detach re-attaches gesture listeners on next hass update", () => {
+    // PR #475 (b77986f): when the dashboard tears the card off the DOM and
+    // re-mounts it, gesture listeners must come back. disconnectedCallback
+    // wipes _lastKey so the next `set hass` after re-mount sees a changed
+    // key and runs _render() — which calls attachGesture again.
+    vi.useFakeTimers();
+    try {
+      const hass = makeHass({
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      });
+      const card = mountAlarmCard({
+        config: { hold_action: { action: "more-info" } },
+        hass,
+      });
+      // Detach (e.g. dashboard tab switch / editor open).
+      document.body.removeChild(card);
+
+      expect(card._gestureCleanup).toBeNull();
+      // Re-attach and push fresh hass — the card must re-render gestures.
+      document.body.appendChild(card);
+      card.hass = hass;
+      let captured = false;
+      card.addEventListener("hass-more-info", () => {
+        captured = true;
+      });
+      const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+      iconWrap.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+      );
+      vi.advanceTimersByTime(600);
+      expect(captured).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("re-rendering during PIN entry returns to normal UI when entity arms", () => {
     const card = mountAlarmCard({
       hass: makeHass({
@@ -886,5 +922,137 @@ describe("verisure-owa-alarm-card lifecycle and statics", () => {
     });
 
     expect(card._uiState).toBe("normal");
+  });
+});
+
+describe("verisure-owa-alarm-card config.states arm-button filter", () => {
+  // PR #475 (4085f1c): when the user adds `states: [...]` to their card
+  // config, only those arm buttons render. The filter is intersected with
+  // `supported_features` — the card never offers a button the entity hasn't
+  // advertised, even if the user lists it.
+
+  function armButtonKeys(card) {
+    return Array.from(card.shadowRoot.querySelectorAll(".btn-arm[data-action]")).map(
+      (b) => b.dataset.action,
+    );
+  }
+
+  it("renders only the listed arm modes when config.states is set", () => {
+    const card = mountAlarmCard({
+      config: { states: ["arm_away", "arm_night"] },
+      hass: makeHass({
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      }),
+    });
+    expect(armButtonKeys(card)).toEqual(["arm_away", "arm_night"]);
+  });
+
+  it("renders all supported modes when config.states is omitted (default behavior)", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      }),
+    });
+    // All 5 features are supported by the default fixture entity.
+    expect(armButtonKeys(card)).toEqual([
+      "arm_away",
+      "arm_home",
+      "arm_night",
+      "arm_vacation",
+      "arm_custom_bypass",
+    ]);
+  });
+
+  it("renders no arm buttons when config.states intersects empty with supported_features", () => {
+    // Entity only supports ARM_AWAY (feature 2); user listed only arm_night.
+    const card = mountAlarmCard({
+      config: { states: ["arm_night"] },
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({ state: "disarmed", supportedFeatures: 2 }),
+        },
+      }),
+    });
+    expect(armButtonKeys(card)).toEqual([]);
+  });
+
+  it("renders no arm buttons when config.states is the empty array", () => {
+    const card = mountAlarmCard({
+      config: { states: [] },
+      hass: makeHass({
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      }),
+    });
+    expect(armButtonKeys(card)).toEqual([]);
+  });
+
+  it("updates the visible buttons when a fresh setConfig narrows the states list", () => {
+    // setConfig resets _lastKey so the next state push triggers a fresh
+    // render with the new states filter.
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({ hass });
+    expect(armButtonKeys(card).length).toBe(5);
+    card.setConfig({
+      type: "custom:verisure-owa-alarm-card",
+      entity: ENTITY,
+      states: ["arm_home"],
+    });
+    expect(armButtonKeys(card)).toEqual(["arm_home"]);
+  });
+});
+
+describe("verisure-owa-alarm-card arm_or_disarm gesture respects config.states", () => {
+  // PR #475 (6be6983): when the user hides arm_away via states: [...], the
+  // hold gesture's arm_or_disarm fallback default must come from the
+  // visible subset — not the global ARM_ACTIONS[0] (arm_away). Otherwise
+  // the hold gesture calls a service for a button the user can't see.
+
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("hold gesture with arm_or_disarm and states=['arm_night'] calls alarm_arm_night", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({
+      config: {
+        states: ["arm_night"],
+        hold_action: { action: "arm_or_disarm" },
+      },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_arm_night", {
+      entity_id: ENTITY,
+    });
+  });
+
+  it("explicit arm_state in the gesture wins over the states-derived default", () => {
+    // The user's explicit arm_state must be honored even if it isn't in the
+    // states filter — that's the same UX as setting it in the editor.
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({
+      config: {
+        states: ["arm_night"],
+        hold_action: { action: "arm_or_disarm", arm_state: "arm_home" },
+      },
+      hass,
+    });
+    const iconWrap = card.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    vi.advanceTimersByTime(501);
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_arm_home", {
+      entity_id: ENTITY,
+    });
   });
 });

--- a/tests-js/integration/alarm-card.test.js
+++ b/tests-js/integration/alarm-card.test.js
@@ -107,3 +107,131 @@ describe("verisure-owa-alarm-card state transitions", () => {
     expect(card.shadowRoot.innerHTML).toContain("Desarmado");
   });
 });
+
+describe("verisure-owa-alarm-card service calls", () => {
+  function findButton(card, labelMatcher) {
+    const buttons = Array.from(card.shadowRoot.querySelectorAll("button"));
+    return buttons.find((b) =>
+      typeof labelMatcher === "string"
+        ? b.textContent.trim() === labelMatcher
+        : labelMatcher.test(b.textContent.trim()),
+    );
+  }
+
+  it("clicking Arm Away calls alarm_arm_away", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({ hass });
+
+    const armBtn = findButton(card, /Arm Away/i);
+    expect(armBtn).toBeDefined();
+    armBtn.click();
+
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_arm_away", {
+      entity_id: ENTITY,
+    });
+  });
+
+  it("clicking Disarm when no code configured calls alarm_disarm immediately", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "armed_away" }) },
+    });
+    const card = mountAlarmCard({ hass });
+
+    const disarmBtn = findButton(card, /Disarm/i);
+    disarmBtn.click();
+
+    expect(hass.callService).toHaveBeenCalledWith("alarm_control_panel", "alarm_disarm", {
+      entity_id: ENTITY,
+    });
+  });
+
+  it("Force Arm button calls verisure_owa.force_arm when force_arm_available", async () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "disarmed",
+          forceArmAvailable: true,
+          armExceptions: [{ alias: "Front Door", status_key: "open" }],
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+
+    const forceBtn = findButton(card, /Force Arm/i);
+    expect(forceBtn).toBeDefined();
+    forceBtn.click();
+
+    expect(hass.callService).toHaveBeenCalledWith("verisure_owa", "force_arm", {
+      entity_id: ENTITY,
+    });
+  });
+
+  it("Cancel button next to Force Arm calls verisure_owa.force_arm_cancel", async () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({ state: "disarmed", forceArmAvailable: true }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+
+    const cancelBtn = findButton(card, /Cancel/i);
+    cancelBtn.click();
+
+    expect(hass.callService).toHaveBeenCalledWith("verisure_owa", "force_arm_cancel", {
+      entity_id: ENTITY,
+    });
+  });
+
+  it("shows PIN keypad when code_arm_required and arm button clicked", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "disarmed",
+          codeArmRequired: true,
+          codeFormat: "number",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+
+    findButton(card, /Arm Away/i).click();
+
+    const html = card.shadowRoot.innerHTML;
+    expect(html).toMatch(/Enter PIN/);
+    expect(card.shadowRoot.querySelectorAll("button").length).toBeGreaterThan(5);
+  });
+
+  it("shows alphanumeric input when code_format is text", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeAlarmEntity({
+          state: "armed_away",
+          codeArmRequired: true,
+          codeFormat: "text",
+        }),
+      },
+    });
+    const card = mountAlarmCard({ hass });
+
+    findButton(card, /Disarm/i).click();
+
+    expect(
+      card.shadowRoot.querySelector("input[type='password'], input[type='text']"),
+    ).toBeDefined();
+  });
+});
+
+describe("verisure-owa-alarm-card error paths", () => {
+  it("logs and does not throw when callService rejects", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    hass.callService.mockRejectedValueOnce(new Error("boom"));
+    const card = mountAlarmCard({ hass });
+
+    const armBtn = card.shadowRoot.querySelector("button");
+    expect(() => armBtn.click()).not.toThrow();
+  });
+});

--- a/tests-js/integration/alarm-card.test.js
+++ b/tests-js/integration/alarm-card.test.js
@@ -224,14 +224,34 @@ describe("verisure-owa-alarm-card service calls", () => {
 });
 
 describe("verisure-owa-alarm-card error paths", () => {
-  it("logs and does not throw when callService rejects", async () => {
-    const hass = makeHass({
-      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
-    });
-    hass.callService.mockRejectedValueOnce(new Error("boom"));
-    const card = mountAlarmCard({ hass });
+  it("does not throw and swallows rejection when callService fails", async () => {
+    // The card fires service calls without .catch() (HA framework convention).
+    // Capture the expected unhandled rejection at the test scope so vitest
+    // doesn't fail the whole run on this intentionally-rejected mock.
+    const swallowed = [];
+    const handler = (reason) => {
+      swallowed.push(reason);
+    };
+    process.on("unhandledRejection", handler);
 
-    const armBtn = card.shadowRoot.querySelector("button");
-    expect(() => armBtn.click()).not.toThrow();
+    try {
+      const hass = makeHass({
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      });
+      hass.callService.mockRejectedValueOnce(new Error("boom"));
+      const card = mountAlarmCard({ hass });
+
+      const armBtn = card.shadowRoot.querySelector("button");
+      expect(() => armBtn.click()).not.toThrow();
+
+      // Let the rejected promise settle so the unhandledRejection event fires.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Verify the rejection happened and the card called the service.
+      expect(hass.callService).toHaveBeenCalled();
+      expect(swallowed.map((e) => e.message)).toContain("boom");
+    } finally {
+      process.off("unhandledRejection", handler);
+    }
   });
 });

--- a/tests-js/integration/alarm-card.test.js
+++ b/tests-js/integration/alarm-card.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeAlarmEntity } from "../fixtures/entities.js";
+
+const ENTITY = "alarm_control_panel.test";
+
+function mountAlarmCard({ config = {}, hass = makeHass() } = {}) {
+  const el = document.createElement("verisure-owa-alarm-card");
+  el.setConfig({ type: "custom:verisure-owa-alarm-card", entity: ENTITY, ...config });
+  el.hass = hass;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("verisure-owa-alarm-card render", () => {
+  it("registers the custom element", () => {
+    expect(customElements.get("verisure-owa-alarm-card")).toBeDefined();
+  });
+
+  it("renders disarmed state with arm-away button visible", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    const card = mountAlarmCard({ hass });
+    const html = card.shadowRoot.innerHTML;
+    expect(html).toContain("Disarmed");
+    expect(html).toMatch(/arm[- _]?away/i);
+  });
+
+  it("renders armed_away state with disarm button visible", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "armed_away" }) },
+    });
+    const card = mountAlarmCard({ hass });
+    const html = card.shadowRoot.innerHTML;
+    expect(html).toContain("Armed Away");
+    expect(html.toLowerCase()).toContain("disarm");
+  });
+
+  it("renders unavailable state", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "unavailable" }) },
+    });
+    const card = mountAlarmCard({ hass });
+    expect(card.shadowRoot.innerHTML).toContain("Unavailable");
+  });
+
+  it("renders entity-not-found message when state is missing", () => {
+    const card = mountAlarmCard({ hass: makeHass() });
+    expect(card.shadowRoot.innerHTML).toMatch(/Entity not found/);
+  });
+});
+
+describe("verisure-owa-alarm-card state transitions", () => {
+  it("re-renders when hass updates", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) } }),
+    });
+    expect(card.shadowRoot.innerHTML).toContain("Disarmed");
+
+    card.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "armed_away" }) },
+    });
+    expect(card.shadowRoot.innerHTML).toContain("Armed Away");
+  });
+
+  it("renders triggered state with warning emphasis", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "triggered" }) } }),
+    });
+    expect(card.shadowRoot.innerHTML).toContain("TRIGGERED");
+  });
+
+  it("renders arming and pending intermediate states", () => {
+    const cardArming = mountAlarmCard({
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "arming" }) } }),
+    });
+    expect(cardArming.shadowRoot.innerHTML).toMatch(/Arming/);
+
+    document.body.innerHTML = "";
+
+    const cardPending = mountAlarmCard({
+      hass: makeHass({ states: { [ENTITY]: makeAlarmEntity({ state: "pending" }) } }),
+    });
+    expect(cardPending.shadowRoot.innerHTML).toMatch(/Pending/);
+  });
+
+  it("shows WAF rate-limit message when waf_blocked attribute is true", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({
+        states: {
+          [ENTITY]: makeAlarmEntity({ state: "disarmed", wafBlocked: true }),
+        },
+      }),
+    });
+    expect(card.shadowRoot.innerHTML).toMatch(/Rate limited|Verisure servers/);
+  });
+
+  it("uses the Spanish locale when hass.language is es", () => {
+    const card = mountAlarmCard({
+      hass: makeHass({
+        language: "es",
+        states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+      }),
+    });
+    expect(card.shadowRoot.innerHTML).toContain("Desarmado");
+  });
+});

--- a/tests-js/integration/camera-card-editor.test.js
+++ b/tests-js/integration/camera-card-editor.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import "../../custom_components/securitas/www/verisure-owa-camera-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeCameraEntity } from "../fixtures/entities.js";
+
+describe("verisure-owa-camera-card-editor", () => {
+  it("registers as a custom element", () => {
+    expect(customElements.get("verisure-owa-camera-card-editor")).toBeDefined();
+  });
+
+  it("excludes full-image cameras from the entity picker via ha-form schema", () => {
+    // The editor delegates entity selection to HA's <ha-form> with an entity
+    // selector — the camera dropdown is resolved lazily by HA at runtime, not
+    // embedded in the editor's shadow DOM. We assert on the ha-form schema
+    // instead: the selector must scope to the camera domain and carry an
+    // exclude_entities list of the full-image variants from findFullImageEntityIds.
+    const editor = document.createElement("verisure-owa-camera-card-editor");
+    editor.setConfig({ entity: "camera.front_door" });
+    editor.hass = makeHass({
+      states: {
+        "camera.front_door": makeCameraEntity(),
+        "camera.front_door_full_image": makeCameraEntity(),
+        "camera.back_yard": makeCameraEntity(),
+        "camera.back_yard_full_image_2": makeCameraEntity(),
+      },
+      entities: {
+        "camera.front_door": { platform: "verisure_owa" },
+        "camera.front_door_full_image": { platform: "verisure_owa" },
+        "camera.back_yard": { platform: "securitas" },
+        "camera.back_yard_full_image_2": { platform: "securitas" },
+      },
+    });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm).not.toBeNull();
+    expect(entityForm.tagName.toLowerCase()).toBe("ha-form");
+    expect(entityForm.schema).toHaveLength(1);
+    const [field] = entityForm.schema;
+    expect(field.name).toBe("entity");
+    expect(field.selector.entity.domain).toBe("camera");
+    // Both full-image variants (one per supported platform alias) must be excluded.
+    expect(field.selector.entity.exclude_entities).toEqual(
+      expect.arrayContaining(["camera.front_door_full_image", "camera.back_yard_full_image_2"]),
+    );
+    expect(field.selector.entity.exclude_entities).toHaveLength(2);
+    expect(entityForm.data).toEqual({ entity: "camera.front_door" });
+  });
+
+  it("omits exclude_entities when no full-image cameras exist", () => {
+    // findFullImageEntityIds returns []; the editor must NOT add an empty
+    // exclude_entities key (would over-constrain HA's entity selector).
+    const editor = document.createElement("verisure-owa-camera-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "camera.front_door": makeCameraEntity() },
+      entities: { "camera.front_door": { platform: "verisure_owa" } },
+    });
+    document.body.appendChild(editor);
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    expect(entityForm.schema).toEqual([
+      { name: "entity", selector: { entity: { domain: "camera" } } },
+    ]);
+  });
+
+  it("dispatches config-changed when the entity ha-form emits value-changed", () => {
+    // The editor wires to ha-form's "value-changed" event (HA convention).
+    // happy-dom renders <ha-form> as a generic HTMLElement so we dispatch the
+    // event the editor actually listens for.
+    const editor = document.createElement("verisure-owa-camera-card-editor");
+    editor.setConfig({});
+    editor.hass = makeHass({
+      states: { "camera.front_door": makeCameraEntity() },
+      entities: { "camera.front_door": { platform: "verisure_owa" } },
+    });
+    document.body.appendChild(editor);
+
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+
+    const entityForm = editor.shadowRoot.getElementById("entity-form");
+    entityForm.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { entity: "camera.front_door" } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    expect(captured?.entity).toBe("camera.front_door");
+  });
+});

--- a/tests-js/integration/camera-card.test.js
+++ b/tests-js/integration/camera-card.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import "../../custom_components/securitas/www/verisure-owa-camera-card.js";
+import { TRANSLATIONS as CAMERA_TRANSLATIONS } from "../../custom_components/securitas/www/verisure-owa-camera-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeCameraEntity } from "../fixtures/entities.js";
+
+const ENTITY = "camera.test";
+
+function mountCameraCard({ config = {}, hass = makeHass() } = {}) {
+  const el = document.createElement("verisure-owa-camera-card");
+  el.setConfig({ type: "custom:verisure-owa-camera-card", entity: ENTITY, ...config });
+  el.hass = hass;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("verisure-owa-camera-card", () => {
+  it("registers", () => {
+    expect(customElements.get("verisure-owa-camera-card")).toBeDefined();
+  });
+
+  it("renders the camera image using entity_picture", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity({ accessToken: "tk1" }) },
+    });
+    const card = mountCameraCard({ hass });
+    const img = card.shadowRoot.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img.src).toContain("token=tk1");
+  });
+
+  it("re-renders when access_token rotates", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity({ accessToken: "tk1" }) },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector("img").src).toContain("token=tk1");
+
+    card.hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity({ accessToken: "tk2" }) },
+    });
+    expect(card.shadowRoot.querySelector("img").src).toContain("token=tk2");
+  });
+
+  it("renders entity-not-found when state is missing", () => {
+    const card = mountCameraCard({ hass: makeHass() });
+    expect(card.shadowRoot.innerHTML).toMatch(/Entity not found/);
+  });
+
+  it("clicking the capture button calls verisure_owa.capture_image", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity() },
+    });
+    const card = mountCameraCard({ hass });
+
+    // The capture trigger is the refresh button in the top-right corner
+    // (mdi:refresh icon, no text/aria-label) — identified by its id.
+    const captureBtn = card.shadowRoot.getElementById("refresh-btn");
+    expect(captureBtn).not.toBeNull();
+    captureBtn.click();
+    // capture_image is async — give the promise microtask a chance to settle
+    await Promise.resolve();
+    expect(hass.callService).toHaveBeenCalledWith(
+      "verisure_owa",
+      "capture_image",
+      expect.objectContaining({ entity_id: ENTITY }),
+    );
+  });
+
+  it("uses Spanish strings when hass.language is es", () => {
+    // The main card's _render path only emits translated strings on the
+    // entity-not-found branch and inside the relative-timestamp tooltip.
+    // The entity-not-found branch is the most reliable place to assert the
+    // locale is honoured, so render that branch with hass.language=es.
+    const card = mountCameraCard({ hass: makeHass({ language: "es" }) });
+    const esEntityNotFound = CAMERA_TRANSLATIONS.es.entity_not_found.split("{")[0];
+    expect(card.shadowRoot.innerHTML).toContain(esEntityNotFound);
+  });
+});

--- a/tests-js/integration/camera-card.test.js
+++ b/tests-js/integration/camera-card.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "../../custom_components/securitas/www/verisure-owa-camera-card.js";
 import { TRANSLATIONS as CAMERA_TRANSLATIONS } from "../../custom_components/securitas/www/verisure-owa-camera-card.js";
 import { makeHass } from "../fixtures/hass.js";
@@ -75,5 +75,385 @@ describe("verisure-owa-camera-card", () => {
     const card = mountCameraCard({ hass: makeHass({ language: "es" }) });
     const esEntityNotFound = CAMERA_TRANSLATIONS.es.entity_not_found.split("{")[0];
     expect(card.shadowRoot.innerHTML).toContain(esEntityNotFound);
+  });
+});
+
+describe("verisure-owa-camera-card setConfig", () => {
+  it("throws when entity is missing", () => {
+    const el = document.createElement("verisure-owa-camera-card");
+    expect(() => el.setConfig({})).toThrow(/entity/i);
+  });
+});
+
+describe("verisure-owa-camera-card overlay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-17T12:00:00"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("renders the relative-time pill in the overlay when image_timestamp is recent", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: {
+          ...makeCameraEntity({ accessToken: "tk" }),
+          attributes: {
+            ...makeCameraEntity({ accessToken: "tk" }).attributes,
+            image_timestamp: "2026-05-17T11:55:00",
+          },
+        },
+      },
+    });
+    const card = mountCameraCard({ hass });
+    const ts = card.shadowRoot.querySelector(".timestamp");
+    expect(ts).not.toBeNull();
+    // 5 minutes ago — must render the localized minute string.
+    expect(ts.textContent).toMatch(/min/);
+    // The absolute tooltip is the locale-formatted string.
+    expect(ts.getAttribute("title")).toContain("2026");
+  });
+
+  it("formats timestamps in hours when an hour or more old", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: {
+          ...makeCameraEntity({ accessToken: "tk" }),
+          attributes: {
+            ...makeCameraEntity({ accessToken: "tk" }).attributes,
+            image_timestamp: "2026-05-17T09:00:00",
+          },
+        },
+      },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector(".timestamp").textContent).toMatch(/h/);
+  });
+
+  it("formats timestamps in days when older than a day", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: {
+          ...makeCameraEntity({ accessToken: "tk" }),
+          attributes: {
+            ...makeCameraEntity({ accessToken: "tk" }).attributes,
+            image_timestamp: "2026-05-10T12:00:00",
+          },
+        },
+      },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector(".timestamp").textContent).toMatch(/d/);
+  });
+
+  it("formats timestamps in seconds when very recent", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: {
+          ...makeCameraEntity({ accessToken: "tk" }),
+          attributes: {
+            ...makeCameraEntity({ accessToken: "tk" }).attributes,
+            image_timestamp: "2026-05-17T11:59:50",
+          },
+        },
+      },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector(".timestamp").textContent).toMatch(/s/);
+  });
+
+  it("renders the raw timestamp when it cannot be parsed as a date", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: {
+          ...makeCameraEntity({ accessToken: "tk" }),
+          attributes: {
+            ...makeCameraEntity({ accessToken: "tk" }).attributes,
+            image_timestamp: "not-a-date",
+          },
+        },
+      },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector(".timestamp").textContent).toBe("not-a-date");
+  });
+});
+
+describe("verisure-owa-camera-card click → more-info", () => {
+  it("clicking the image dispatches hass-more-info for the thumbnail entity", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity() },
+    });
+    const card = mountCameraCard({ hass });
+    let captured = null;
+    card.addEventListener("hass-more-info", (e) => {
+      captured = e.detail.entityId;
+    });
+    card.shadowRoot.getElementById("img-wrapper").click();
+    expect(captured).toBe(ENTITY);
+  });
+
+  it("clicking the image dispatches hass-more-info for the full entity when configured and timestamped", () => {
+    const FULL = "camera.test_full_image";
+    const hass = makeHass({
+      states: {
+        [ENTITY]: makeCameraEntity(),
+        [FULL]: {
+          state: "idle",
+          attributes: { image_timestamp: "2026-05-17T11:59:50", access_token: "tk" },
+        },
+      },
+      entities: {
+        [ENTITY]: { device_id: "dev1", platform: "verisure_owa" },
+        [FULL]: { device_id: "dev1", platform: "verisure_owa" },
+      },
+    });
+    const card = mountCameraCard({ hass });
+    let captured = null;
+    card.addEventListener("hass-more-info", (e) => {
+      captured = e.detail.entityId;
+    });
+    card.shadowRoot.getElementById("img-wrapper").click();
+    expect(captured).toBe(FULL);
+  });
+
+  it("uses the device's name_by_user as display name when no config.name", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity() },
+      entities: { [ENTITY]: { device_id: "dev1", platform: "verisure_owa" } },
+      devices: { dev1: { name: "Camera", name_by_user: "Front Hall" } },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector(".name").textContent).toBe("Front Hall");
+  });
+
+  it("falls back to device.name when name_by_user is unset", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity() },
+      entities: { [ENTITY]: { device_id: "dev1", platform: "verisure_owa" } },
+      devices: { dev1: { name: "Hallway" } },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector(".name").textContent).toBe("Hallway");
+  });
+});
+
+describe("verisure-owa-camera-card refresh spinner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("clears the spinner when the access_token rotates to a new value", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity({ accessToken: "tk-old" }) },
+    });
+    const card = mountCameraCard({ hass });
+    card.shadowRoot.getElementById("refresh-btn").click();
+
+    expect(card._refreshing).toBe(true);
+    // New token via fresh hass push (and capturing=false to take the clear branch).
+    const newHass = makeHass({
+      states: {
+        [ENTITY]: {
+          state: "idle",
+          attributes: { access_token: "tk-new", capturing: false },
+        },
+      },
+    });
+    card.hass = newHass;
+
+    expect(card._refreshing).toBe(false);
+  });
+
+  it("the 15s fallback timer clears the spinner if no token rotation arrives", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity({ accessToken: "tk1" }) },
+    });
+    hass.callService.mockResolvedValueOnce(undefined);
+    const card = mountCameraCard({ hass });
+    card.shadowRoot.getElementById("refresh-btn").click();
+    // Let the awaited callService resolve so the finally-block schedules the timer.
+    await Promise.resolve();
+    await Promise.resolve();
+    vi.advanceTimersByTime(15001);
+
+    expect(card._refreshing).toBe(false);
+  });
+
+  it("guards against re-entrant clicks on the refresh button", async () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity({ accessToken: "tk1" }) },
+    });
+    let calls = 0;
+    hass.callService.mockImplementation(async () => {
+      calls += 1;
+    });
+    const card = mountCameraCard({ hass });
+    card.shadowRoot.getElementById("refresh-btn").click();
+    card.shadowRoot.getElementById("refresh-btn").click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls).toBe(1);
+  });
+});
+
+describe("verisure-owa-camera-card-editor name field", () => {
+  it("emits config-changed with name when the name textfield is typed into", () => {
+    const editor = document.createElement("verisure-owa-camera-card-editor");
+    editor.setConfig({ entity: "camera.front_door" });
+    editor.hass = makeHass({
+      states: { "camera.front_door": makeCameraEntity() },
+      entities: { "camera.front_door": { platform: "verisure_owa" } },
+    });
+    document.body.appendChild(editor);
+
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+
+    const nameTf = editor.shadowRoot.querySelector("ha-textfield");
+    expect(nameTf).not.toBeNull();
+    nameTf.value = "Main Door";
+    nameTf.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(captured?.name).toBe("Main Door");
+  });
+
+  it("removes the name key when the textfield is cleared", () => {
+    const editor = document.createElement("verisure-owa-camera-card-editor");
+    editor.setConfig({ entity: "camera.front_door", name: "Old" });
+    editor.hass = makeHass({
+      states: { "camera.front_door": makeCameraEntity() },
+      entities: { "camera.front_door": { platform: "verisure_owa" } },
+    });
+    document.body.appendChild(editor);
+
+    let captured = null;
+    editor.addEventListener("config-changed", (e) => {
+      captured = e.detail.config;
+    });
+
+    const nameTf = editor.shadowRoot.querySelector("ha-textfield");
+    nameTf.value = "   ";
+    nameTf.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(captured).not.toHaveProperty("name");
+  });
+
+  it("updates ha-form data on a second setConfig call without rebuilding the DOM", () => {
+    const editor = document.createElement("verisure-owa-camera-card-editor");
+    editor.setConfig({ entity: "camera.front_door" });
+    editor.hass = makeHass({
+      states: { "camera.front_door": makeCameraEntity() },
+      entities: { "camera.front_door": { platform: "verisure_owa" } },
+    });
+    document.body.appendChild(editor);
+
+    const firstForm = editor.shadowRoot.getElementById("entity-form");
+    editor.setConfig({ entity: "camera.back_yard" });
+    const secondForm = editor.shadowRoot.getElementById("entity-form");
+
+    expect(secondForm).toBe(firstForm);
+    expect(secondForm.data).toEqual({ entity: "camera.back_yard" });
+  });
+});
+
+describe("verisure-owa-camera-card defensive defaults", () => {
+  it("uses empty token when access_token is missing", () => {
+    const hass = makeHass({
+      states: {
+        [ENTITY]: { state: "idle", attributes: { friendly_name: "C" } },
+      },
+    });
+    const card = mountCameraCard({ hass });
+    expect(card.shadowRoot.querySelector("img").getAttribute("src")).toBe(
+      `/api/camera_proxy/${ENTITY}?token=`,
+    );
+  });
+
+  it("renders without a .timestamp overlay when image_timestamp is missing", () => {
+    const card = mountCameraCard({
+      hass: makeHass({ states: { [ENTITY]: makeCameraEntity() } }),
+    });
+    expect(card.shadowRoot.querySelector(".timestamp")).toBeNull();
+  });
+
+  it("uses config.name when both name and device entry are present", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity() },
+      entities: { [ENTITY]: { device_id: "dev1", platform: "verisure_owa" } },
+      devices: { dev1: { name: "Device" } },
+    });
+    const card = mountCameraCard({ config: { name: "Override" }, hass });
+    expect(card.shadowRoot.querySelector(".name").textContent).toBe("Override");
+  });
+
+  it("_findFullEntity returns null when the camera entry has no device_id", () => {
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity() },
+      entities: { [ENTITY]: { platform: "verisure_owa" } },
+    });
+    const card = mountCameraCard({ hass });
+    // Without a device_id the lookup returns null and the click goes to the thumbnail.
+    let captured = null;
+    card.addEventListener("hass-more-info", (e) => {
+      captured = e.detail.entityId;
+    });
+    card.shadowRoot.getElementById("img-wrapper").click();
+    expect(captured).toBe(ENTITY);
+  });
+
+  it("_entitiesByDeviceId reuses its cache when hass.entities is unchanged", () => {
+    const entities = {
+      [ENTITY]: { device_id: "dev1", platform: "verisure_owa" },
+      "camera.test_full_image": { device_id: "dev1", platform: "verisure_owa" },
+    };
+    const hass = makeHass({
+      states: { [ENTITY]: makeCameraEntity() },
+      entities,
+    });
+    const card = mountCameraCard({ hass });
+    // Force a re-render with the same hass.entities reference.
+    card.hass = hass;
+
+    expect(card._entitiesRef).toBe(entities);
+  });
+});
+
+describe("verisure-owa-camera-card static helpers", () => {
+  it("getCardSize returns 3", () => {
+    const card = mountCameraCard({
+      hass: makeHass({ states: { [ENTITY]: makeCameraEntity() } }),
+    });
+    expect(card.getCardSize()).toBe(3);
+  });
+
+  it("getConfigElement returns the matching editor element", () => {
+    const ctor = customElements.get("verisure-owa-camera-card");
+    const el = ctor.getConfigElement();
+    expect(el.tagName.toLowerCase()).toBe("securitas-camera-card-editor");
+  });
+
+  it("getStubConfig picks the first non-full-image camera entity", () => {
+    const ctor = customElements.get("verisure-owa-camera-card");
+    const hass = makeHass({
+      states: {
+        "camera.x_full_image": makeCameraEntity(),
+        "camera.front_door": makeCameraEntity(),
+        "light.kitchen": { state: "on", attributes: {} },
+      },
+      entities: {
+        "camera.x_full_image": { platform: "verisure_owa" },
+        "camera.front_door": { platform: "verisure_owa" },
+      },
+    });
+    const stub = ctor.getStubConfig(hass);
+    expect(stub.entity).toBe("camera.front_door");
+  });
+
+  it("getStubConfig returns empty entity when no eligible cameras exist", () => {
+    const ctor = customElements.get("verisure-owa-camera-card");
+    expect(ctor.getStubConfig(makeHass()).entity).toBe("");
   });
 });

--- a/tests-js/integration/legacy-shims.test.js
+++ b/tests-js/integration/legacy-shims.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import "../../custom_components/securitas/www/securitas-alarm-card.js";
+import "../../custom_components/securitas/www/securitas-camera-card.js";
+
+describe("legacy shim re-exports", () => {
+  it("loading securitas-alarm-card.js registers the verisure-owa custom elements", () => {
+    expect(customElements.get("verisure-owa-alarm-card")).toBeDefined();
+  });
+
+  it("loading securitas-camera-card.js registers the verisure-owa-camera-card element", () => {
+    expect(customElements.get("verisure-owa-camera-card")).toBeDefined();
+  });
+
+  it("legacy securitas-* aliases are also registered", () => {
+    expect(customElements.get("securitas-alarm-card")).toBeDefined();
+    expect(customElements.get("securitas-camera-card")).toBeDefined();
+  });
+});

--- a/tests-js/setup.js
+++ b/tests-js/setup.js
@@ -1,0 +1,5 @@
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});

--- a/tests-js/unit/activity-log-helpers.test.js
+++ b/tests-js/unit/activity-log-helpers.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  hassLang,
+  relativeTime,
+  formatActor,
+  renderExceptions,
+  renderRows,
+  DETAIL_FIELDS,
+} from "../../custom_components/securitas/www/verisure-owa-activity-log-card.js";
+
+describe("hassLang", () => {
+  it("prefers hass.locale.language", () => {
+    expect(hassLang({ locale: { language: "fr" }, language: "en" })).toBe("fr");
+  });
+
+  it("falls back to hass.language", () => {
+    expect(hassLang({ language: "it" })).toBe("it");
+  });
+
+  it("returns 'en' for null hass", () => {
+    expect(hassLang(null)).toBe("en");
+  });
+});
+
+describe("relativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-17T12:00:00"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("returns empty string for falsy / short input", () => {
+    expect(relativeTime("", "en")).toBe("");
+    expect(relativeTime("2026-05", "en")).toBe("");
+    expect(relativeTime(null, "en")).toBe("");
+  });
+
+  it("returns empty string for unparseable date", () => {
+    expect(relativeTime("not-a-date-string-XXX", "en")).toBe("");
+  });
+
+  it("formats a recent time in seconds", () => {
+    expect(relativeTime("2026-05-17 11:59:50", "en")).toMatch(/second/i);
+  });
+
+  it("formats minutes-ago", () => {
+    expect(relativeTime("2026-05-17 11:45:00", "en")).toMatch(/minute/i);
+  });
+
+  it("formats hours-ago", () => {
+    expect(relativeTime("2026-05-17 09:00:00", "en")).toMatch(/hour/i);
+  });
+
+  it("formats days-ago", () => {
+    expect(relativeTime("2026-05-10 12:00:00", "en")).toMatch(/day/i);
+  });
+});
+
+describe("formatActor", () => {
+  it("prefers verisure_user with 'by' label", () => {
+    expect(formatActor({ verisure_user: "Luci" }, "en")).toContain("Luci");
+  });
+
+  it("falls back to device_name in parentheses", () => {
+    expect(formatActor({ device_name: "Kitchen" }, "en")).toBe("(Kitchen)");
+  });
+
+  it("returns empty string when neither is present", () => {
+    expect(formatActor({}, "en")).toBe("");
+  });
+
+  it("escapes HTML in actor names", () => {
+    expect(formatActor({ device_name: "<x>" }, "en")).toBe("(&lt;x&gt;)");
+  });
+});
+
+describe("renderExceptions", () => {
+  it("returns empty string for empty / non-array input", () => {
+    expect(renderExceptions([], "en")).toBe("");
+    expect(renderExceptions(null, "en")).toBe("");
+  });
+
+  it("renders a list with alias and status", () => {
+    const html = renderExceptions([{ alias: "Door", status_key: "open" }], "en");
+    expect(html).toContain("<ul");
+    expect(html).toContain("Door");
+  });
+
+  it("escapes HTML in alias", () => {
+    const html = renderExceptions([{ alias: "<x>", status_key: "open" }], "en");
+    expect(html).toContain("&lt;x&gt;");
+    expect(html).not.toContain("<x>");
+  });
+});
+
+describe("renderRows", () => {
+  it("emits one <tr> per non-empty DETAIL_FIELDS entry", () => {
+    const html = renderRows({ time: "12:00", alias: "Door", type: "open" }, "en");
+    expect(html.match(/<tr>/g)?.length).toBe(3);
+  });
+
+  it("skips empty / null / 0 values", () => {
+    const html = renderRows({ time: "12:00", alias: "", type: null, device: 0 }, "en");
+    expect(html.match(/<tr>/g)?.length).toBe(1);
+  });
+
+  it("renders exceptions through renderExceptions", () => {
+    const html = renderRows({ exceptions: [{ alias: "Door", status_key: "open" }] }, "en");
+    expect(html).toContain("<ul");
+  });
+
+  it("stringifies objects/arrays as pretty JSON in <pre>", () => {
+    const html = renderRows({ media_platform: { kind: "snapshot" } }, "en");
+    expect(html).toContain("<pre>");
+    expect(html).toContain("snapshot");
+  });
+});
+
+describe("DETAIL_FIELDS", () => {
+  it("is a non-empty list of strings", () => {
+    expect(Array.isArray(DETAIL_FIELDS)).toBe(true);
+    expect(DETAIL_FIELDS.length).toBeGreaterThan(0);
+    DETAIL_FIELDS.forEach((f) => expect(typeof f).toBe("string"));
+  });
+});

--- a/tests-js/unit/alarm-card-helpers.test.js
+++ b/tests-js/unit/alarm-card-helpers.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  defaultArmState,
+  FEATURE,
+  ARM_ACTIONS,
+} from "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
+import { makeHass } from "../fixtures/hass.js";
+import { makeAlarmEntity } from "../fixtures/entities.js";
+
+describe("FEATURE bitmask", () => {
+  it("matches HA AlarmControlPanelEntityFeature values", () => {
+    expect(FEATURE).toEqual({
+      ARM_HOME: 1,
+      ARM_AWAY: 2,
+      ARM_NIGHT: 4,
+      ARM_CUSTOM_BYPASS: 16,
+      ARM_VACATION: 32,
+    });
+  });
+});
+
+describe("ARM_ACTIONS", () => {
+  it("contains arm_away as the first entry (default preference)", () => {
+    expect(ARM_ACTIONS[0].key).toBe("arm_away");
+    expect(ARM_ACTIONS[0].service).toBe("alarm_arm_away");
+  });
+
+  it("covers all five arm modes", () => {
+    const keys = ARM_ACTIONS.map((a) => a.key);
+    expect(keys).toEqual([
+      "arm_away",
+      "arm_home",
+      "arm_night",
+      "arm_vacation",
+      "arm_custom_bypass",
+    ]);
+  });
+});
+
+describe("defaultArmState", () => {
+  it("picks arm_away when entity supports it", () => {
+    const hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity({ supportedFeatures: FEATURE.ARM_AWAY }) },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x")).toBe("arm_away");
+  });
+
+  it("falls back to first supported feature when away is unavailable", () => {
+    const hass = makeHass({
+      states: {
+        "alarm_control_panel.x": makeAlarmEntity({ supportedFeatures: FEATURE.ARM_NIGHT }),
+      },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x")).toBe("arm_night");
+  });
+
+  it("returns 'arm_away' when entity is missing", () => {
+    expect(defaultArmState(makeHass(), "alarm_control_panel.missing")).toBe("arm_away");
+  });
+
+  it("returns 'arm_away' when supported_features is 0", () => {
+    const hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity({ supportedFeatures: 0 }) },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x")).toBe("arm_away");
+  });
+});

--- a/tests-js/unit/alarm-card-helpers.test.js
+++ b/tests-js/unit/alarm-card-helpers.test.js
@@ -64,4 +64,63 @@ describe("defaultArmState", () => {
     });
     expect(defaultArmState(hass, "alarm_control_panel.x")).toBe("arm_away");
   });
+
+  // PR #475 added the optional `configStates` 3rd arg — when the user has
+  // explicitly enabled only a subset via `states: [...]`, the default arm key
+  // must come from that subset (filtered ∩ supported), not from the entity's
+  // raw supported_features.
+
+  it("picks the first entry in configStates when all are supported", () => {
+    // All 5 features supported; configStates restricts to night only.
+    const hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x", ["arm_night"])).toBe("arm_night");
+  });
+
+  it("respects configStates ordering by ARM_ACTIONS (canonical), not user array order", () => {
+    // ARM_ACTIONS canonical order is away, home, night, vacation, custom — the
+    // helper iterates over that, intersected with configStates. So even if the
+    // user lists ["arm_night", "arm_home"], the first canonical hit wins.
+    const hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x", ["arm_night", "arm_home"])).toBe(
+      "arm_home",
+    );
+  });
+
+  it("falls back to entity-supported list when configStates intersection is empty", () => {
+    // User hid every mode (or listed only modes the entity doesn't support) —
+    // `filtered` collapses to []. The helper falls back to `supported` so the
+    // gesture isn't silently dropped.
+    const hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x", [])).toBe("arm_away");
+  });
+
+  it("uses configStates ∩ supported (drops modes the entity doesn't advertise)", () => {
+    // Entity supports only NIGHT; user listed both AWAY and NIGHT — only NIGHT
+    // is the intersection.
+    const hass = makeHass({
+      states: {
+        "alarm_control_panel.x": makeAlarmEntity({
+          supportedFeatures: FEATURE.ARM_NIGHT,
+        }),
+      },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x", ["arm_away", "arm_night"])).toBe(
+      "arm_night",
+    );
+  });
+
+  it("ignores a non-array configStates (treated as unset)", () => {
+    // Defensive: a malformed YAML `states: arm_away` (string, not list) should
+    // fall through the `Array.isArray` guard inside _filteredArmActions.
+    const hass = makeHass({
+      states: { "alarm_control_panel.x": makeAlarmEntity() },
+    });
+    expect(defaultArmState(hass, "alarm_control_panel.x", "arm_night")).toBe("arm_away");
+  });
 });

--- a/tests-js/unit/camera-card-helpers.test.js
+++ b/tests-js/unit/camera-card-helpers.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { findFullImageEntityIds } from "../../custom_components/securitas/www/verisure-owa-camera-card.js";
+import { makeHass } from "../fixtures/hass.js";
+
+describe("findFullImageEntityIds", () => {
+  it("returns empty array when hass has no entities", () => {
+    expect(findFullImageEntityIds(makeHass())).toEqual([]);
+  });
+
+  it("returns matching full-image cameras from our platforms", () => {
+    const hass = makeHass({
+      entities: {
+        "camera.front_door_full_image": { platform: "verisure_owa" },
+        "camera.garden_full_image_2": { platform: "securitas" },
+        "camera.kitchen": { platform: "verisure_owa" },
+        "camera.other_full_image": { platform: "generic" },
+      },
+    });
+    const ids = findFullImageEntityIds(hass);
+    expect(ids.sort()).toEqual(
+      ["camera.front_door_full_image", "camera.garden_full_image_2"].sort(),
+    );
+  });
+
+  it("ignores entries without a platform field", () => {
+    const hass = makeHass({
+      entities: { "camera.x_full_image": {} },
+    });
+    expect(findFullImageEntityIds(hass)).toEqual([]);
+  });
+
+  it("handles undefined hass.entities", () => {
+    expect(findFullImageEntityIds({ entities: undefined })).toEqual([]);
+  });
+});

--- a/tests-js/unit/card-utils-escHtml.test.js
+++ b/tests-js/unit/card-utils-escHtml.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { escHtml } from "../../custom_components/securitas/www/verisure-owa-card-utils.js";
+
+describe("escHtml", () => {
+  it("escapes <, >, &, double quote, single quote", () => {
+    expect(escHtml(`<script>alert("x")&'`)).toBe("&lt;script&gt;alert(&quot;x&quot;)&amp;&#39;");
+  });
+
+  it("escapes & before other entities to avoid double-escaping", () => {
+    expect(escHtml("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(escHtml("")).toBe("");
+  });
+
+  it("coerces non-string input to string", () => {
+    expect(escHtml(123)).toBe("123");
+    expect(escHtml(null)).toBe("null");
+    expect(escHtml(undefined)).toBe("undefined");
+    expect(escHtml(true)).toBe("true");
+  });
+
+  it("leaves unicode and plain characters alone", () => {
+    expect(escHtml("Hola — Buenos Días 🚨")).toBe("Hola — Buenos Días 🚨");
+  });
+});

--- a/tests-js/unit/card-utils-formatTranslation.test.js
+++ b/tests-js/unit/card-utils-formatTranslation.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { formatTranslation } from "../../custom_components/securitas/www/verisure-owa-card-utils.js";
+
+const T = {
+  en: {
+    hello: "Hello",
+    nested: { deep: "Deep EN" },
+    welcome: "Hi {name}, you have {count} items",
+  },
+  es: {
+    hello: "Hola",
+    nested: { deep: "Deep ES" },
+    // welcome intentionally missing — should fall back to EN
+  },
+};
+
+describe("formatTranslation", () => {
+  it("returns the requested locale string for a flat key", () => {
+    expect(formatTranslation("es", T, "hello")).toBe("Hola");
+  });
+
+  it("resolves dot-path keys", () => {
+    expect(formatTranslation("es", T, "nested.deep")).toBe("Deep ES");
+  });
+
+  it("falls back to English when the locale lacks the key", () => {
+    expect(formatTranslation("es", T, "welcome", { name: "Luci", count: 3 })).toBe(
+      "Hi Luci, you have 3 items",
+    );
+  });
+
+  it("falls back to language root when locale is a region tag", () => {
+    expect(formatTranslation("es-AR", T, "hello")).toBe("Hola");
+  });
+
+  it("returns the key itself when missing in both target and English", () => {
+    expect(formatTranslation("es", T, "missing.key")).toBe("missing.key");
+  });
+
+  it("interpolates {var} placeholders", () => {
+    expect(formatTranslation("en", T, "welcome", { name: "A", count: 7 })).toBe(
+      "Hi A, you have 7 items",
+    );
+  });
+
+  it("does not treat $& / $1 in interpolated values as regex back-refs", () => {
+    const T2 = { en: { msg: "Value: {v}" } };
+    expect(formatTranslation("en", T2, "msg", { v: "$&" })).toBe("Value: $&");
+    expect(formatTranslation("en", T2, "msg", { v: "$1$2" })).toBe("Value: $1$2");
+  });
+
+  it("handles null/undefined language by falling back to English", () => {
+    expect(formatTranslation(null, T, "hello")).toBe("Hello");
+    expect(formatTranslation(undefined, T, "hello")).toBe("Hello");
+  });
+});

--- a/tests-js/unit/fixtures.test.js
+++ b/tests-js/unit/fixtures.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { makeHass } from "../fixtures/hass.js";
+import { makeAlarmEntity, makeCameraEntity, makeActivityLogEntity } from "../fixtures/entities.js";
+
+describe("makeHass", () => {
+  it("returns a default English hass with empty registries and vi.fn spies", () => {
+    const hass = makeHass();
+    expect(hass.language).toBe("en");
+    expect(hass.states).toEqual({});
+    expect(hass.entities).toEqual({});
+    expect(hass.devices).toEqual({});
+    expect(vi.isMockFunction(hass.callService)).toBe(true);
+    expect(vi.isMockFunction(hass.callWS)).toBe(true);
+  });
+
+  it("merges overrides shallowly per top-level key", () => {
+    const hass = makeHass({
+      language: "es",
+      states: { "alarm_control_panel.x": { state: "armed_away", attributes: {} } },
+    });
+    expect(hass.language).toBe("es");
+    expect(hass.states["alarm_control_panel.x"].state).toBe("armed_away");
+    expect(hass.entities).toEqual({});
+  });
+
+  it("callService resolves by default", async () => {
+    const hass = makeHass();
+    await expect(hass.callService("x", "y", {})).resolves.toBeUndefined();
+  });
+});
+
+describe("makeAlarmEntity", () => {
+  it("returns a disarmed alarm with all supported features by default", () => {
+    const ent = makeAlarmEntity();
+    expect(ent.state).toBe("disarmed");
+    expect(ent.attributes.supported_features).toBe(1 | 2 | 4 | 16 | 32);
+    expect(ent.attributes.code_arm_required).toBe(false);
+    expect(ent.attributes.force_arm_available).toBe(false);
+    expect(ent.attributes.arm_exceptions).toEqual([]);
+  });
+
+  it("accepts overrides", () => {
+    const ent = makeAlarmEntity({
+      state: "armed_away",
+      supportedFeatures: 2,
+      codeArmRequired: true,
+      forceArmAvailable: true,
+      armExceptions: [{ alias: "Door", status_key: "open" }],
+    });
+    expect(ent.state).toBe("armed_away");
+    expect(ent.attributes.supported_features).toBe(2);
+    expect(ent.attributes.code_arm_required).toBe(true);
+    expect(ent.attributes.force_arm_available).toBe(true);
+    expect(ent.attributes.arm_exceptions).toHaveLength(1);
+  });
+});
+
+describe("makeCameraEntity", () => {
+  it("provides access_token + entity_picture defaults", () => {
+    const ent = makeCameraEntity();
+    expect(ent.state).toBe("idle");
+    expect(ent.attributes.access_token).toMatch(/^token-/);
+    expect(ent.attributes.entity_picture).toContain("token-");
+  });
+});
+
+describe("makeActivityLogEntity", () => {
+  it("defaults to empty events list", () => {
+    const ent = makeActivityLogEntity();
+    expect(ent.state).toBe("0");
+    expect(ent.attributes.events).toEqual([]);
+  });
+
+  it("uses events.length as state", () => {
+    const ent = makeActivityLogEntity({ events: [{ id_signal: "1" }, { id_signal: "2" }] });
+    expect(ent.state).toBe("2");
+    expect(ent.attributes.events).toHaveLength(2);
+  });
+});

--- a/tests-js/unit/smoke.test.js
+++ b/tests-js/unit/smoke.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+
+describe("smoke", () => {
+  it("runs in a DOM environment", () => {
+    const el = document.createElement("div");
+    el.textContent = "hello";
+    document.body.appendChild(el);
+    expect(document.body.querySelector("div").textContent).toBe("hello");
+  });
+});

--- a/tests-js/unit/translations.test.js
+++ b/tests-js/unit/translations.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { TRANSLATIONS as ALARM } from "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
+import { TRANSLATIONS as CAMERA } from "../../custom_components/securitas/www/verisure-owa-camera-card.js";
+import { TRANSLATIONS as ACTIVITY } from "../../custom_components/securitas/www/verisure-owa-activity-log-card.js";
+
+function flatKeys(obj, prefix = "") {
+  const out = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      out.push(...flatKeys(v, path));
+    } else {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function lookup(table, path) {
+  return path
+    .split(".")
+    .reduce((acc, k) => (acc != null && acc[k] !== undefined ? acc[k] : undefined), table);
+}
+
+describe.each([
+  ["alarm card", ALARM],
+  ["camera card", CAMERA],
+  ["activity-log card", ACTIVITY],
+])("%s translations", (_label, table) => {
+  const enKeys = flatKeys(table.en);
+  const locales = Object.keys(table).filter((l) => l !== "en");
+
+  it("English table is non-empty", () => {
+    expect(enKeys.length).toBeGreaterThan(0);
+  });
+
+  it.each(locales)("locale %s provides every English key as a non-empty string", (locale) => {
+    const missing = [];
+    for (const key of enKeys) {
+      const v = lookup(table[locale], key);
+      if (typeof v !== "string" || v.length === 0) missing.push(key);
+    }
+    // Compare a labelled string so failures surface the precise list of
+    // missing keys (e.g. "missing in es: foo, bar.baz").
+    expect(`missing in ${locale}: ${missing.join(", ")}`).toBe(`missing in ${locale}: `);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    globals: false,
+    setupFiles: ["./tests-js/setup.js"],
+    include: ["tests-js/**/*.test.js"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      include: ["custom_components/securitas/www/**/*.js"],
+      exclude: [
+        "custom_components/securitas/www/securitas-alarm-card.js",
+        "custom_components/securitas/www/securitas-camera-card.js",
+      ],
+      thresholds: {
+        lines: 90,
+        branches: 90,
+        functions: 90,
+        statements: 90,
+      },
+    },
+  },
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,8 +11,9 @@ export default defineConfig({
       reporter: ["text", "html", "lcov"],
       include: ["custom_components/securitas/www/**/*.js"],
       exclude: [
-        "custom_components/securitas/www/securitas-alarm-card.js",
-        "custom_components/securitas/www/securitas-camera-card.js",
+        // Legacy securitas-* shim files re-export the canonical verisure-owa-* cards.
+        // Globbed so future shims are excluded by convention.
+        "custom_components/securitas/www/securitas-*.js",
       ],
       thresholds: {
         lines: 90,


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR depends on #475 and must be merged after it.**
>
> This branch is rebased on top of #475 (`python`). #475 changes the alarm card's editor and gesture system; many of the tests in this PR cover those new behaviors. If this PR is merged before #475, the alarm card tests will fail. Once #475 lands, rebase this branch on `main` and re-push (or merge #475 first and let GitHub's auto-rebase handle it).

## Summary

Adds the first JS test infrastructure for the Lovelace cards under `custom_components/securitas/www/` — ~3,500 LOC that has been verified manually until now.

- **Tooling:** Vitest + happy-dom + `@vitest/coverage-v8` + ESLint 9 + Prettier 3. Dev-only — nothing ships via HACS.
- **286 tests** across 16 files (8 unit, 7 integration, 1 smoke).
- **90% coverage gate** (lines/branches/functions/statements) enforced via `.github/workflows/js-tests.yml`. Current numbers: `99.31 / 90.67 / 95.41 / 99.31`.
- **Translation meta-test** walks every locale × every key in each card's `TRANSLATIONS` table; fails loudly on half-translated entries.
- **Test coverage of #475:** card `states:` filter, editor arm-modes checkbox section, all-hidden hint, live gesture-dropdown refresh, stale arm_state scrubbing, external/internal setConfig re-render matrix, per-variant gesture defaults, reconnect gesture re-attach.

## Card source changes

Card sources have only two kinds of edit:
- `export` added to `TRANSLATIONS` (all three cards) and to pure helpers (`FEATURE`, `ARM_ACTIONS`, `defaultArmState`, `findFullImageEntityIds`, `hassLang`, `relativeTime`, `formatActor`, `renderExceptions`, `renderRows`, `DETAIL_FIELDS`).
- Mechanical rename: `_xxx` → `xxx` for each newly exported helper.

No behavior changes. The legacy `securitas-*` custom-element names remain registered (verified via `legacy-shims.test.js`).

## Test plan

- [ ] CI's `JS Tests` workflow passes on the PR.
- [ ] Locally: `npm ci && npm run lint && npm run test:coverage` all exit 0.
- [ ] Manual smoke-test of the three cards in the HACS dev instance — alarm, camera, activity-log — no visible regression.
- [ ] After #475 merges, rebase this branch on `main` and confirm the same 286 tests pass.

## Layout

```
tests-js/
  unit/                # pure helpers + translation meta-test
  integration/         # full custom-element behavior
  fixtures/            # makeHass(), makeAlarmEntity, etc.
  setup.js
package.json
vitest.config.js
eslint.config.js
.github/workflows/js-tests.yml
```

See the README "Frontend tests" section for the developer workflow.

---

## Follow-ups noted from review

- **`getConfigElement()` returns the legacy alias.** Both `verisure-owa-camera-card.js:476` and `verisure-owa-alarm-card.js` (and badge/chip) call `document.createElement("securitas-*-card-editor")` from their `getConfigElement` statics, even though the canonical `verisure-owa-*-card-editor` is registered first. Tests pin current behavior so the suite stays honest, but the inconsistency lives in the card source and predates this PR — worth a deliberate fix in a follow-up PR (either switch `getConfigElement` to the canonical tag, or drop the canonical registration and rely solely on the legacy alias). Flagged by Copilot review on this PR; deferred to a focused follow-up.
