### PR TITLE
fix(cards): getConfigElement returns the canonical editor tag

### DIFF
--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -1097,7 +1097,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
   }
 
   static getConfigElement() {
-    return document.createElement("securitas-alarm-card-editor");
+    return document.createElement("verisure-owa-alarm-card-editor");
   }
 
   static getStubConfig(hass) {
@@ -1932,7 +1932,7 @@ class VerisureOwaAlarmBadge extends HTMLElement {
   getCardSize() { return 1; }
 
   static getConfigElement() {
-    return document.createElement("securitas-alarm-card-editor");
+    return document.createElement("verisure-owa-alarm-card-editor");
   }
 
   static getStubConfig(hass) {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -473,7 +473,7 @@ class VerisureOwaCameraCard extends HTMLElement {
   getCardSize() { return 3; }
 
   static getConfigElement() {
-    return document.createElement("securitas-camera-card-editor");
+    return document.createElement("verisure-owa-camera-card-editor");
   }
 
   static getStubConfig(hass) {

--- a/tests-js/integration/alarm-card-extras.test.js
+++ b/tests-js/integration/alarm-card-extras.test.js
@@ -557,7 +557,7 @@ describe("verisure-owa-alarm-badge dialog and overlay", () => {
     expect(badge.getCardSize()).toBe(1);
     const ctor = customElements.get("verisure-owa-alarm-badge");
     const editor = ctor.getConfigElement();
-    expect(editor.tagName.toLowerCase()).toBe("securitas-alarm-card-editor");
+    expect(editor.tagName.toLowerCase()).toBe("verisure-owa-alarm-card-editor");
     const hass = makeHass({
       states: { [ENTITY]: makeAlarmEntity() },
     });

--- a/tests-js/integration/alarm-card.test.js
+++ b/tests-js/integration/alarm-card.test.js
@@ -813,7 +813,7 @@ describe("verisure-owa-alarm-card lifecycle and statics", () => {
   it("getConfigElement returns the matching editor element", () => {
     const ctor = customElements.get("verisure-owa-alarm-card");
     const el = ctor.getConfigElement();
-    expect(el.tagName.toLowerCase()).toBe("securitas-alarm-card-editor");
+    expect(el.tagName.toLowerCase()).toBe("verisure-owa-alarm-card-editor");
   });
 
   it("getStubConfig picks the first alarm_control_panel entity", () => {

--- a/tests-js/integration/camera-card.test.js
+++ b/tests-js/integration/camera-card.test.js
@@ -432,7 +432,7 @@ describe("verisure-owa-camera-card static helpers", () => {
   it("getConfigElement returns the matching editor element", () => {
     const ctor = customElements.get("verisure-owa-camera-card");
     const el = ctor.getConfigElement();
-    expect(el.tagName.toLowerCase()).toBe("securitas-camera-card-editor");
+    expect(el.tagName.toLowerCase()).toBe("verisure-owa-camera-card-editor");
   });
 
   it("getStubConfig picks the first non-full-image camera entity", () => {


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR depends on #475 and #476 and must be merged after both.**
>
> The branch is rebased on top of #476 (which is itself stacked on #475). The 3 test-side changes here update assertions added in #476 that pinned the old `securitas-*-card-editor` behavior. If merged before #476 lands, the test files those edits target won't exist; if merged before #475 lands, the rebase will conflict on the alarm-card helper renames.

## Summary

`VerisureOwaAlarmCard.getConfigElement()`, `VerisureOwaAlarmBadge.getConfigElement()`, and `VerisureOwaCameraCard.getConfigElement()` returned the **legacy** `securitas-*-card-editor` tag, even though the canonical `verisure-owa-*-card-editor` is registered first as the real class and the legacy tag is a shim alias only. This forced HA's lovelace editor through one extra hop on the shim's prototype chain and made the alarm + camera cards inconsistent with the activity-log card, which already returned the canonical name.

This PR switches all three to the canonical tag. The 3 integration tests in #476 that pinned the legacy behavior are updated to expect the canonical name.

**Why it matters:**
- Consistency across the three cards (activity-log already returns canonical).
- Faster: skips the legacy-shim's proxy chain (`Class.prototype._submitBadgePin.call(this, ...)` style proxies in the shim).
- Future-safe: if anyone ever drops the legacy `securitas-*` resource registration, `getConfigElement()` keeps working without code changes.

## What's NOT changed

The legacy custom-element registrations (`customElements.define("securitas-alarm-card-editor", ...)`) are untouched — existing dashboards that reference the legacy tag in their YAML keep rendering. Only the editor-lookup path inside the card classes changes.

## Test plan

- [ ] CI's `JS Tests` workflow passes on the PR.
- [ ] Locally: `npm ci && npm run lint && npm run test:coverage` all exit 0 (286/286 tests, ≥90% on all four metrics).
- [ ] Manual smoke-test: open a dashboard with each card (alarm, badge, camera), click the card's editor pencil — the editor opens and displays correctly.
- [ ] After #475 and #476 merge, rebase this branch on `main` and confirm the same 286 tests pass.

Flagged by Copilot review on #476.