### PR TITLE
fix(autolock): options flow waits for lock discovery to complete

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -964,7 +964,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
         # Store per-entry data
-        hass.data[DOMAIN][entry.entry_id] = {
+        entry_data: dict[str, Any] = {
             "hub": client,
             "devices": devices,
             "alarm_coordinator": alarm_coord,
@@ -974,6 +974,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "activity_listener_unsub": activity_listener_unsub,
             "config_entry": entry,
         }
+        # Signalled by _async_discover_devices once lock discovery has either
+        # populated registered_locks or definitively failed. The options-flow
+        # Lock Automation step awaits this so it doesn't render before
+        # discovery knows the actual device_ids. Only created when a lock
+        # coordinator exists — installations without a lock service skip the
+        # step unconditionally and never look at the event.
+        if lock_coord is not None:
+            entry_data["lock_discovery_complete"] = asyncio.Event()
+        hass.data[DOMAIN][entry.entry_id] = entry_data
 
         # Schedule non-blocking first refresh for each coordinator
         for coord in filter(

--- a/custom_components/securitas/config_flow.py
+++ b/custom_components/securitas/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -81,6 +82,13 @@ from .verisure_owa_api.capabilities import detect_annex, detect_peri
 VERSION = 4
 
 _LOGGER = logging.getLogger(__name__)
+
+# Max seconds the Lock Automation options step waits for background lock
+# discovery to finish before falling through. Sized to cover the worst case
+# we've observed in production logs (~12s for an SDVFAST panel that needs
+# the Danalock GraphQL fallback), with a small safety margin. Module-level
+# so tests can monkeypatch it down.
+LOCK_DISCOVERY_WAIT_TIMEOUT: float = 15.0
 
 # Services that should not appear in the Notify-service dropdown.
 # - `notify` / `send_message`: aliases of the legacy generic notify service;
@@ -1106,7 +1114,7 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
         unlock_disarms: [...]}}) is unchanged — the handler converts between
         per-circuit booleans (UI) and circuit-name lists (storage).
         """
-        registered_locks = self._get_registered_locks()
+        registered_locks = await self._get_registered_locks()
         if not registered_locks:
             return self.async_create_entry(title="", data=self._general_data)
 
@@ -1168,11 +1176,40 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
             description_placeholders=placeholders,
         )
 
-    def _get_registered_locks(self) -> list[dict[str, str]]:
-        """Return [{device_id, alias}] for each lock registered for this entry."""
+    async def _get_registered_locks(self) -> list[dict[str, str]]:
+        """Return [{device_id, alias}] for each lock registered for this entry.
+
+        If the in-memory list is empty but the entry has a pending
+        ``lock_discovery_complete`` event (i.e. the installation has a lock
+        service and background discovery is still running), wait up to
+        ``LOCK_DISCOVERY_WAIT_TIMEOUT`` seconds for discovery to finish, then
+        re-read the list. Without this wait, opening options immediately
+        after adding an installation silently skips the Lock Automation step
+        even though a lock exists.
+        """
         domain_entry = self.hass.data.get(DOMAIN, {}).get(
             self.config_entry.entry_id, {}
         )
+        registered = list(domain_entry.get("registered_locks", []))
+        if registered:
+            return registered
+
+        event = domain_entry.get("lock_discovery_complete")
+        if event is None or event.is_set():
+            return registered
+
+        try:
+            async with asyncio.timeout(LOCK_DISCOVERY_WAIT_TIMEOUT):
+                await event.wait()
+        except TimeoutError:
+            _LOGGER.warning(
+                "Lock discovery did not complete within %.1fs for entry %s; "
+                "skipping Lock Automation step",
+                LOCK_DISCOVERY_WAIT_TIMEOUT,
+                self.config_entry.entry_id,
+            )
+            return list(domain_entry.get("registered_locks", []))
+
         return list(domain_entry.get("registered_locks", []))
 
     def _get_enabled_circuits(self) -> set[str]:

--- a/custom_components/securitas/discovery.py
+++ b/custom_components/securitas/discovery.py
@@ -197,7 +197,9 @@ async def _discover_locks(
         return
 
     try:
-        lock_modes: list[SmartLockMode] = await hub.get_lock_modes(installation)
+        lock_modes: list[SmartLockMode] = await hub.get_lock_modes(
+            installation, priority=hub.api_queue.FOREGROUND
+        )
     except Exception:  # pylint: disable=broad-exception-caught  # background discovery must not crash
         _LOGGER.warning("Failed to get lock modes for %s", installation.number)
         lock_modes = []
@@ -245,6 +247,11 @@ async def _discover_locks(
                 }
             )
         lock_add(locks, False)
+        _LOGGER.info(
+            "Lock discovery for %s registered %d lock(s)",
+            installation.number,
+            len(locks),
+        )
 
         # Schedule deferred config retry for locks without config.
         for lk in locks:
@@ -253,15 +260,29 @@ async def _discover_locks(
 
 
 async def _async_discover_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Discover cameras and locks in the background after setup."""
+    """Discover cameras and locks in the background after setup.
+
+    Locks run before cameras so a user opening the Lock Automation options
+    step doesn't wait on the camera-device query in between. The shared
+    ApiQueue still serializes all calls, so this is purely a reorder, not a
+    parallelization — request rate is unchanged.
+    """
     entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
     if entry_data is None:
         return
 
     client: VerisureHub = entry_data["hub"]
     devices: list[VerisureDevice] = entry_data["devices"]
+    lock_event = entry_data.get("lock_discovery_complete")
 
-    for device in devices:
-        installation = device.installation
-        await _discover_cameras(hass, client, installation, entry_data, entry)
-        await _discover_locks(hass, client, installation, entry_data, entry)
+    try:
+        for device in devices:
+            installation = device.installation
+            await _discover_locks(hass, client, installation, entry_data, entry)
+            await _discover_cameras(hass, client, installation, entry_data, entry)
+    finally:
+        # Always signal completion so the options-flow await unblocks even
+        # when discovery raised mid-way. Only set when the entry actually
+        # has a lock service — otherwise the event was never created.
+        if lock_event is not None:
+            lock_event.set()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2115,8 +2115,16 @@ def _make_entry_with_locks(
     registered_locks: list[dict],
     enabled_circuits: set[str] | None = None,
     entry_options: dict | None = None,
+    lock_discovery_event=None,
+    has_lock_coordinator: bool = False,
 ):
-    """Create MockConfigEntry and inject registered_locks + circuit options into hass.data."""
+    """Create MockConfigEntry and inject registered_locks + circuit options into hass.data.
+
+    Optional ``lock_discovery_event`` (asyncio.Event) is stored under
+    ``lock_discovery_complete`` so the options flow can await it. Optional
+    ``has_lock_coordinator`` mirrors what __init__.async_setup_entry would
+    place there when the installation has a lock service.
+    """
     from custom_components.securitas.const import (
         CONF_ENABLE_ANNEX_PANEL,
         CONF_ENABLE_INTERIOR_PANEL,
@@ -2136,9 +2144,12 @@ def _make_entry_with_locks(
         options=options,
     )
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        "registered_locks": registered_locks,
-    }
+    entry_data: dict = {"registered_locks": registered_locks}
+    if lock_discovery_event is not None:
+        entry_data["lock_discovery_complete"] = lock_discovery_event
+    if has_lock_coordinator:
+        entry_data["lock_coordinator"] = MagicMock()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
     return entry
 
 
@@ -2351,6 +2362,145 @@ async def test_lock_automations_skipped_when_no_locks_discovered(hass):
     )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_lock_automations_does_not_wait_when_no_event_present(hass):
+    """No event in entry_data => skip immediately, no hang.
+
+    Covers installations with no lock service (no lock_coordinator created,
+    so no lock_discovery_complete event is registered).
+    """
+    import asyncio as _asyncio
+
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[],
+        enabled_circuits={"interior"},
+    )
+    flow_id = await _advance_to_mappings(hass, entry)
+
+    # If the options flow naively awaits a missing event, this would hang
+    # past the wait_for window. Bound it tightly to fail fast.
+    async with _asyncio.timeout(2.0):
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                CONF_MAP_HOME: STD_DEFAULTS[CONF_MAP_HOME],
+                CONF_MAP_AWAY: STD_DEFAULTS[CONF_MAP_AWAY],
+                CONF_MAP_NIGHT: STD_DEFAULTS[CONF_MAP_NIGHT],
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_lock_automations_waits_for_discovery_event(hass):
+    """Empty registered_locks + pending event => wait, then render once signalled.
+
+    Simulates the user opening options before background discovery completes.
+    A helper task signals the event and populates registered_locks while the
+    flow is awaiting the mappings -> lock_automations transition.
+    """
+    import asyncio as _asyncio
+
+    event = _asyncio.Event()
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[],
+        enabled_circuits={"interior"},
+        lock_discovery_event=event,
+        has_lock_coordinator=True,
+    )
+    flow_id = await _advance_to_mappings(hass, entry)
+
+    async def _populate_and_signal():
+        # Yield once so the flow task starts awaiting the event first.
+        await _asyncio.sleep(0)
+        hass.data[DOMAIN][entry.entry_id]["registered_locks"] = [
+            {"device_id": "01", "alias": "Front Door"}
+        ]
+        event.set()
+
+    populate_task = _asyncio.create_task(_populate_and_signal())
+
+    try:
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                CONF_MAP_HOME: STD_DEFAULTS[CONF_MAP_HOME],
+                CONF_MAP_AWAY: STD_DEFAULTS[CONF_MAP_AWAY],
+                CONF_MAP_NIGHT: STD_DEFAULTS[CONF_MAP_NIGHT],
+            },
+        )
+    finally:
+        await populate_task
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_automations"
+    assert "lock__01" in _section_keys(result["data_schema"])
+
+
+async def test_lock_automations_times_out_when_event_never_signalled(hass):
+    """Event never set + empty registered_locks => fall through after timeout.
+
+    Discovery may legitimately fail; we must not hang the options flow.
+    Patches the wait timeout to a small value so the test stays fast.
+    """
+    import asyncio as _asyncio
+
+    event = _asyncio.Event()  # never set
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[],
+        enabled_circuits={"interior"},
+        lock_discovery_event=event,
+        has_lock_coordinator=True,
+    )
+    flow_id = await _advance_to_mappings(hass, entry)
+
+    with patch(
+        "custom_components.securitas.config_flow.LOCK_DISCOVERY_WAIT_TIMEOUT",
+        0.1,
+    ):
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                CONF_MAP_HOME: STD_DEFAULTS[CONF_MAP_HOME],
+                CONF_MAP_AWAY: STD_DEFAULTS[CONF_MAP_AWAY],
+                CONF_MAP_NIGHT: STD_DEFAULTS[CONF_MAP_NIGHT],
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_lock_automations_no_wait_when_event_already_set(hass):
+    """Event already set + populated registered_locks => render immediately."""
+    import asyncio as _asyncio
+
+    event = _asyncio.Event()
+    event.set()
+    entry = _make_entry_with_locks(
+        hass,
+        registered_locks=[{"device_id": "01", "alias": "Front Door"}],
+        enabled_circuits={"interior"},
+        lock_discovery_event=event,
+        has_lock_coordinator=True,
+    )
+    flow_id = await _advance_to_mappings(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(
+        flow_id,
+        user_input={
+            CONF_MAP_HOME: STD_DEFAULTS[CONF_MAP_HOME],
+            CONF_MAP_AWAY: STD_DEFAULTS[CONF_MAP_AWAY],
+            CONF_MAP_NIGHT: STD_DEFAULTS[CONF_MAP_NIGHT],
+        },
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_automations"
+    assert "lock__01" in _section_keys(result["data_schema"])
 
 
 # ===========================================================================

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1859,6 +1859,135 @@ class TestDiscoverCameras:
 
 
 # ===========================================================================
+# _async_discover_devices tests — ordering + completion signalling
+# ===========================================================================
+
+
+class TestAsyncDiscoverDevices:
+    """Tests for _async_discover_devices() ordering and event signalling."""
+
+    @pytest.mark.asyncio
+    async def test_locks_discovered_before_cameras(self):
+        """Locks must submit to the queue before cameras (options-flow latency).
+
+        Locks gate the Lock Automation options step; cameras don't. Order the
+        sequential awaits so a user opening options waits only on lock work.
+        """
+        import asyncio
+
+        from custom_components.securitas import _async_discover_devices
+        from custom_components.securitas.const import DOMAIN
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+
+        call_order: list[str] = []
+
+        async def fake_discover_cameras(*_args, **_kwargs):
+            call_order.append("cameras")
+
+        async def fake_discover_locks(*_args, **_kwargs):
+            call_order.append("locks")
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        hass.data[DOMAIN][entry.entry_id] = {
+            "hub": MagicMock(),
+            "devices": [VerisureDevice(make_installation())],
+            "lock_discovery_complete": asyncio.Event(),
+        }
+
+        with (
+            patch(
+                "custom_components.securitas.discovery._discover_cameras",
+                new=fake_discover_cameras,
+            ),
+            patch(
+                "custom_components.securitas.discovery._discover_locks",
+                new=fake_discover_locks,
+            ),
+        ):
+            await _async_discover_devices(hass, entry)
+
+        assert call_order == ["locks", "cameras"], (
+            f"Expected locks before cameras, got {call_order}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lock_discovery_event_is_set_on_completion(self):
+        """The lock_discovery_complete event must be set once discovery returns."""
+        import asyncio
+
+        from custom_components.securitas import _async_discover_devices
+        from custom_components.securitas.const import DOMAIN
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+        event = asyncio.Event()
+        entry = MagicMock()
+        entry.entry_id = "entry-2"
+        hass.data[DOMAIN][entry.entry_id] = {
+            "hub": MagicMock(),
+            "devices": [VerisureDevice(make_installation())],
+            "lock_discovery_complete": event,
+        }
+
+        with (
+            patch(
+                "custom_components.securitas.discovery._discover_cameras",
+                new=AsyncMock(),
+            ),
+            patch(
+                "custom_components.securitas.discovery._discover_locks",
+                new=AsyncMock(),
+            ),
+        ):
+            await _async_discover_devices(hass, entry)
+
+        assert event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_lock_discovery_event_is_set_even_when_discovery_raises(self):
+        """The event must be set even if _discover_locks raises — never hang options."""
+        import asyncio
+
+        from custom_components.securitas import _async_discover_devices
+        from custom_components.securitas.const import DOMAIN
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+        event = asyncio.Event()
+        entry = MagicMock()
+        entry.entry_id = "entry-3"
+        hass.data[DOMAIN][entry.entry_id] = {
+            "hub": MagicMock(),
+            "devices": [VerisureDevice(make_installation())],
+            "lock_discovery_complete": event,
+        }
+
+        async def boom(*_args, **_kwargs):
+            raise RuntimeError("discovery exploded")
+
+        with (
+            patch(
+                "custom_components.securitas.discovery._discover_cameras",
+                new=AsyncMock(),
+            ),
+            patch(
+                "custom_components.securitas.discovery._discover_locks",
+                new=boom,
+            ),
+        ):
+            # Whether or not the function re-raises, the event must be set.
+            try:
+                await _async_discover_devices(hass, entry)
+            except RuntimeError:
+                pass
+
+        assert event.is_set()
+
+
+# ===========================================================================
 # Phase F3: Static-URL alias
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- The Lock Automation options step silently skipped itself when the user opened options before background lock discovery had populated `registered_locks` — even though the installation actually has a lock. Reported in #447 by @jmrevuelta with debug log showing discovery completing ~12s after entry setup.
- Setup now creates an `asyncio.Event` (`lock_discovery_complete`) when a lock coordinator exists. `_async_discover_devices` sets it in a `finally` so the options-flow await unblocks even when discovery raises.
- `_get_registered_locks` is async and waits up to `LOCK_DISCOVERY_WAIT_TIMEOUT` (15s) for the event when `registered_locks` is empty, then re-reads. Times out gracefully into the existing skip path so the flow never hangs.
- Discovery runs locks before cameras within each installation — the shared `ApiQueue` still serializes everything, so this is a pure reorder, not parallelization. `get_lock_modes` is bumped to FOREGROUND in discovery so it preempts any background poll already queued (`get_lock_config` was already FOREGROUND). With locks-first ordering, lock work goes through the queue ~4s sooner on installations with cameras.
- Added INFO log `"Lock discovery for <num> registered N lock(s)"` so future bug reports show whether discovery actually finished.

## Test plan

- [x] 4 new options-flow tests: immediate-skip when no event present, wait-then-render when event fires, timeout fall-through, no-wait when event already set
- [x] 3 new discovery tests: locks-before-cameras ordering, event set on success, event set in `finally` on exception
- [x] Full unit suite (1555 tests) passes
- [x] Ruff / Pylint (10.00) / Pyright (0 errors) clean on changed files
- [ ] Field validation by @jmrevuelta on issue #447 — confirm Lock Automation page now appears after adding a new installation

Closes part of #447.