### PR TITLE
chore: release 5.0.3

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.0.2"
+    "version": "5.0.3"
 }


### PR DESCRIPTION
## Summary

Bump manifest to 5.0.3 so the release workflow can tag HEAD.

## Changes since v5.0.2

- fix(autolock): options flow waits for lock discovery to complete (#482)
- chore(deps): bump happy-dom 15→20, vitest 2→4, @vitest/coverage-v8 2→4 (#481)
- fix(cards): getConfigElement returns the canonical editor tag (#477)
- test: add JS test infrastructure for Lovelace cards (Vitest + 90% coverage gate) (#476)
- ci: split unit/integration tests with combined 90% coverage gate (#475)
- feat(alarm-card): configurable arm-state buttons via 'states' config (#474)
- fix: humanize bare alarm-manager panel-rejection codes (#473)
- fix: alarm panel entity_id healer respects user renames (#472)
- fix: card URLs embed integration version so every release busts the browser cache

## Test plan

- [x] Workflow needs manifest at 5.0.3 to tag HEAD without pushing to main