### PR TITLE
fix(card): stop badge/chip popup icon from opening HA's more-info dialog

### DIFF
--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -335,7 +335,13 @@ function attachGesture(el, config, hass, entityId, srcEl, callbacks = {}, cardSt
   function onPointerCancel() { cancelHold(); }
 
   function onClick(e) {
-    if (holdFired) { holdFired = false; e.stopImmediatePropagation(); }
+    // Our gesture handler owns the click on this element. Always swallow
+    // the native click so it cannot bubble to a parent's tap_action handler
+    // (e.g. an HA tile-card wrapper or dashboard view default) — otherwise
+    // a single tap would fire both our action AND the parent's, opening
+    // duplicate dialogs.
+    if (holdFired) holdFired = false;
+    e.stopImmediatePropagation();
   }
 
   el.addEventListener("pointerdown",   onPointerDown);
@@ -1900,9 +1906,18 @@ class VerisureOwaAlarmBadge extends HTMLElement {
     overlay.appendChild(content);
     document.body.appendChild(overlay);
 
-    // Create the full alarm card inside the dialog
+    // Create the full alarm card inside the dialog.
+    //
+    // Strip the badge/chip's gesture config before passing it down. The same
+    // tap_action key means different things in different contexts: on a badge
+    // or chip, `more-info` is wired to open THIS popup; on the alarm-card,
+    // `more-info` dispatches `hass-more-info` and opens HA's standard dialog.
+    // Forwarding the badge's gestures verbatim would make a tap on the icon
+    // inside the popup open HA's dialog on top of our popup.
+    const innerConfig = { ...this._config };
+    for (const k of GESTURE_KEYS) delete innerConfig[k];
     this._dialogCard = document.createElement("securitas-alarm-card");
-    this._dialogCard.setConfig(this._config);
+    this._dialogCard.setConfig(innerConfig);
     this._dialogCard.hass = this._hass;
     content.appendChild(this._dialogCard);
 

--- a/tests-js/integration/alarm-card-extras.test.js
+++ b/tests-js/integration/alarm-card-extras.test.js
@@ -147,6 +147,100 @@ describe("verisure-owa-alarm-badge dialog and overlay", () => {
     expect(dialogCard).not.toBeNull();
   });
 
+  it("clicking the alarm-card icon inside the popup must NOT open HA's more-info dialog (default-tap config)", () => {
+    // User bug report: when our badge's popup is open and the user clicks the
+    // big shield icon in the embedded alarm-card, HA's standard more-info
+    // dialog appears. The embedded card's tap_action default is `none`, so
+    // tapping the icon should be a no-op. Listen on document for hass-more-info
+    // (the event HA's <home-assistant> root would catch to open the dialog).
+    const badge = mountBadge();
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+
+    const popupCard = document.body.querySelector("securitas-alarm-card");
+    expect(popupCard).not.toBeNull();
+
+    const moreInfoCalls = vi.fn();
+    document.addEventListener("hass-more-info", moreInfoCalls);
+
+    const iconWrap = popupCard.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    iconWrap.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    vi.advanceTimersByTime(301);
+
+    document.removeEventListener("hass-more-info", moreInfoCalls);
+    expect(moreInfoCalls).not.toHaveBeenCalled();
+  });
+
+  it("clicking the alarm-card icon inside the popup must NOT open HA's dialog when badge tap_action is more-info", () => {
+    // The badge's editor defaults tap_action to `more-info` (which means
+    // "open our popup" in badge context). That same config is passed
+    // wholesale to the popup's inner alarm-card via setConfig(this._config) —
+    // but in the alarm-card context, `more-info` means "open HA's dialog".
+    // So a user who configures their badge with the default tap action
+    // and then clicks the icon inside the popup gets HA's dialog. Bug.
+    const badge = mountBadge({ config: { tap_action: { action: "more-info" } } });
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+
+    const popupCard = document.body.querySelector("securitas-alarm-card");
+    expect(popupCard).not.toBeNull();
+
+    const moreInfoCalls = vi.fn();
+    document.addEventListener("hass-more-info", moreInfoCalls);
+
+    const iconWrap = popupCard.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    iconWrap.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    vi.advanceTimersByTime(301);
+
+    document.removeEventListener("hass-more-info", moreInfoCalls);
+    expect(moreInfoCalls).not.toHaveBeenCalled();
+  });
+
+  it("a tap on the badge stops the native click event from bubbling to parents", () => {
+    // When the badge sits inside a parent (e.g. an HA tile-card wrapper or a
+    // dashboard view that has its own tap_action default of `more-info`), the
+    // browser's native click event must NOT bubble past the badge — otherwise
+    // the user sees BOTH our custom popup AND the standard HA more-info dialog.
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const badge = document.createElement("verisure-owa-alarm-badge");
+    badge.setConfig({ entity: ENTITY });
+    badge.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    parent.appendChild(badge);
+    const parentClicks = vi.fn();
+    parent.addEventListener("click", parentClicks);
+
+    const badgeEl = badge.shadowRoot.getElementById("badge");
+    badgeEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    badgeEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    // Native click event follows pointerup in a real browser; jsdom doesn't
+    // synthesise it, so dispatch one explicitly.
+    badgeEl.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    vi.advanceTimersByTime(301);
+
+    expect(parentClicks).not.toHaveBeenCalled();
+  });
+
   it("closing the dialog via the close button removes the overlay", () => {
     const badge = mountBadge();
     const badgeEl = badge.shadowRoot.getElementById("badge");
@@ -587,6 +681,69 @@ describe("verisure-owa-alarm-chip dialog wiring", () => {
     chipEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
     vi.advanceTimersByTime(301);
     expect(document.body.querySelector("securitas-alarm-card")).not.toBeNull();
+  });
+
+  it("clicking the alarm-card icon inside the chip's popup must NOT open HA's dialog", () => {
+    // Same bug as the badge: the chip's tap_action (default `more-info`) is
+    // passed wholesale to the embedded alarm-card via _openDialog. In the
+    // alarm-card context, `more-info` dispatches `hass-more-info` and opens
+    // HA's standard dialog on top of our popup. The chip delegates to the
+    // badge's _openDialog so the same gesture-stripping fix protects it.
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY, tap_action: { action: "more-info" } });
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    document.body.appendChild(chip);
+    const chipEl = chip.shadowRoot.getElementById("chip");
+    chipEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    chipEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    vi.advanceTimersByTime(301);
+
+    const popupCard = document.body.querySelector("securitas-alarm-card");
+    expect(popupCard).not.toBeNull();
+
+    const moreInfoCalls = vi.fn();
+    document.addEventListener("hass-more-info", moreInfoCalls);
+
+    const iconWrap = popupCard.shadowRoot.querySelector(".icon-wrap");
+    iconWrap.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    iconWrap.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    iconWrap.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    vi.advanceTimersByTime(301);
+
+    document.removeEventListener("hass-more-info", moreInfoCalls);
+    expect(moreInfoCalls).not.toHaveBeenCalled();
+  });
+
+  it("a tap on the chip stops the native click event from bubbling to parents", () => {
+    // Same concern as the badge: when the chip is placed inside a wrapper
+    // (mushroom chips card, generic container with its own tap handler, etc.),
+    // the native click must not escape and trigger the parent's tap_action.
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const chip = document.createElement("verisure-owa-alarm-chip");
+    chip.setConfig({ entity: ENTITY });
+    chip.hass = makeHass({
+      states: { [ENTITY]: makeAlarmEntity({ state: "disarmed" }) },
+    });
+    parent.appendChild(chip);
+    const parentClicks = vi.fn();
+    parent.addEventListener("click", parentClicks);
+
+    const chipEl = chip.shadowRoot.getElementById("chip");
+    chipEl.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }),
+    );
+    chipEl.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    chipEl.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    vi.advanceTimersByTime(301);
+
+    expect(parentClicks).not.toHaveBeenCalled();
   });
 
   it("setting hass before setConfig is a no-op (renders only after config arrives)", () => {


### PR DESCRIPTION
## Summary

Fixes a user report: opening the alarm badge/chip popup and tapping the big shield icon inside it pops up HA's standard more-info dialog on top of our popup. Two distinct causes, both fixed in this PR.

### 1. Gesture-config leak from badge/chip into the embedded alarm-card (root cause)

`_openDialog` mounted a `securitas-alarm-card` inside the overlay and forwarded the badge/chip's whole `_config` to it via `setConfig(this._config)`. The same `tap_action` key has different meanings in each context:

- On a **badge/chip**: `more-info` is wired through the gesture handler's `onMoreInfo` callback to call `_openDialog()` — opens **our** popup.
- On the **alarm-card**: `onMoreInfo` dispatches `hass-more-info` — opens **HA's** standard dialog.

The badge/chip editor's default tap_action is `more-info`, so a user who hadn't overridden it would inherit `more-info` into the embedded card. Tapping the icon inside the popup fired that inherited tap_action and surfaced HA's dialog.

Fix: strip `GESTURE_KEYS` (`tap_action` / `hold_action` / `double_tap_action`) from the config before passing it to the embedded card. The embedded card now uses its own defaults (all `none`), so the icon inside the popup is inert — which matches user expectation.

### 2. Native click bubbling past the gesture handler

`attachGesture`'s capture-phase click handler only stopped propagation when a long-press fired. On a normal tap the native click bubbled to whatever wrapped the badge/chip — which, on a dashboard where the element sits inside a tile-card / container with its own default `tap_action: more-info`, fired the parent's handler too and opened a second, parallel dialog. Now always swallow the native click since our gesture handler owns interaction on this element.

## Test plan

- [x] `npm test` — 358/358 vitest cases passing (5 new)
- [x] `npm run lint` — clean (2 pre-existing warnings, untouched)
- [x] New tests went RED on `main`, GREEN with the fix:
  - icon-tap inside badge popup (default config) — verifies `hass-more-info` is NOT dispatched
  - icon-tap inside badge popup with explicit `tap_action: more-info` — the failing scenario from the user report
  - icon-tap inside chip popup with explicit `tap_action: more-info` — chip delegates to badge's `_openDialog` so the same fix protects it
  - native click stops at the badge (does not reach a wrapping parent's click listener)
  - same for the chip