### PR TITLE
feat(lock): surface manual lock/unlock failure via notification + HomeAssistantError

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 The most recent release is at the top; append new entries above the previous one with each release.
 
+## Unreleased
+
+### Behaviour changes
+
+- **Manual lock / unlock / open now surface failure to the caller.** Previously, `lock.lock` / `lock.unlock` / `lock.open` service calls from the HA UI, scripts, or automations swallowed both API-level errors (e.g. the backend's `alarm-manager.error_no_response_to_request`) and verify-confirmed wrong-state outcomes (the verify loop confirmed the door stayed at the wrong state) — the script saw success and the user got no feedback. Both layers now fire a persistent notification ("Lock failed" / "Unlock failed", including the underlying reason for diagnosis) and raise `HomeAssistantError` so scripts and automations see the actual failure. The bias-to-false-negative is preserved: if every verify read returned an unreadable status (UNKNOWN), we still fall back to the optimistic target state without firing. Auto-lock-on-arm continues to use its existing post-state check (it must not raise — it's a background task — and must not fire on a no-op redundant lock against an already-locked door).
+
 ## v5.0.5
 
 ### Bug fixes

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -317,18 +317,24 @@ class VerisureLock(  # type: ignore[override]
         if self.hass is not None:
             self.hass.async_create_task(self._auto_lock())
 
-    def _autolock_notification_id(self) -> str:
-        return f"verisure_owa_autolock_{self._installation.number}_{self._device_id}"
+    def _lock_notification_id(self) -> str:
+        return f"verisure_owa_lock_{self._installation.number}_{self._device_id}"
 
-    async def _fire_autolock_notification(self, *, title: str, message: str) -> None:
-        """Create / replace a persistent notification for an autolock event."""
+    async def _fire_lock_notification(self, *, title: str, message: str) -> None:
+        """Create / replace a persistent notification for a lock-related event.
+
+        Single shared notification_id per-lock — auto-lock-on-arm,
+        auto-disarm-on-unlock, manual lock/unlock/open failures all dedupe
+        through the same notification card (the latest event is what the
+        user cares about).
+        """
         if self.hass is None:
             return
         await self.hass.services.async_call(
             "persistent_notification",
             "create",
             {
-                "notification_id": self._autolock_notification_id(),
+                "notification_id": self._lock_notification_id(),
                 "title": title,
                 "message": message,
             },
@@ -353,7 +359,7 @@ class VerisureLock(  # type: ignore[override]
             operation="Auto-lock",
         )
         if self._state == LOCK_STATUS_UNLOCKED:
-            await self._fire_autolock_notification(
+            await self._fire_lock_notification(
                 title="Auto-lock failed",
                 message=(
                     f"Could not lock {self._attr_name} when arming. "
@@ -455,11 +461,19 @@ class VerisureLock(  # type: ignore[override]
         the backend's ~2s acknowledgement), then polls until a real, fresh
         status reading lands or the verify window exhausts.
 
-        Returns ``None`` on success or on a bias-to-false-negative fallback
-        (verify window exhausted with no readable status → optimistic state).
-        Returns a short error reason string on definitive failure: a
-        ``VerisureOwaError`` from the command itself, OR the verify loop
-        confirming a fresh post-command state that is not the target.
+        Returns ``None`` on success — either the verify loop saw the target
+        state, or it exhausted with no readable status (UNKNOWN →
+        bias-to-false-negative optimistic fallback), or it exhausted with
+        the last stale read sitting at the target (quiet-success-on-no-op).
+
+        Returns a short error reason string on definitive failure:
+          * a ``VerisureOwaError`` from the command itself, OR
+          * the verify loop returning a non-target ``lockStatus`` — whether
+            from a fresh authoritative read (e.g. lock blocked, device
+            snapped back) OR from window-exhaust with the last stale read
+            still on the wrong state (device never re-stamped its
+            ``statusTimestamp`` AND the value never reached the target).
+
         Callers decide how to surface failure (notification, raise, both).
         """
         self._operation_in_progress = True
@@ -619,7 +633,7 @@ class VerisureLock(  # type: ignore[override]
         """
         title = f"{action} failed"
         message = f"Could not {action.lower()} {self._attr_name}: {error_reason}"
-        await self._fire_autolock_notification(title=title, message=message)
+        await self._fire_lock_notification(title=title, message=message)
         raise HomeAssistantError(message)
 
     async def async_lock(self, **kwargs: Any) -> None:
@@ -652,7 +666,7 @@ class VerisureLock(  # type: ignore[override]
             return None
         ok = await self._combined_alarm_panel.execute_partial_disarm(targets)
         if not ok:
-            await self._fire_autolock_notification(
+            await self._fire_lock_notification(
                 title="Auto-disarm failed",
                 message=(
                     f"Could not disarm before unlocking {self._attr_name}. "
@@ -687,14 +701,18 @@ class VerisureLock(  # type: ignore[override]
         if unlock_error is None:
             return
         if disarm_result is True:
+            # Disarm-succeeded-but-unlock-failed: the asymmetric outcome
+            # needs its own wording — the helper's generic "Could not
+            # unlock X: Y" would understate the half-success.
             message = (
                 f"{self._attr_name}: alarm has been disarmed but the door "
                 f"is still locked ({unlock_error})."
             )
-        else:
-            message = f"Could not unlock {self._attr_name}: {unlock_error}"
-        await self._fire_autolock_notification(title="Unlock failed", message=message)
-        raise HomeAssistantError(message)
+            await self._fire_lock_notification(title="Unlock failed", message=message)
+            raise HomeAssistantError(message)
+        await self._notify_and_raise_on_failure(
+            action="Unlock", error_reason=unlock_error
+        )
 
     async def async_unlock(self, **kwargs: Any) -> None:
         await self._perform_user_unlock("Unlock")

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -87,6 +87,24 @@ LOCK_STATUS_LOCKED = "2"
 LOCK_STATUS_UNLOCKING = "3"
 LOCK_STATUS_LOCKING = "4"
 
+# Human-readable names for the API codes above.  Used in user-facing
+# error messages (persistent notifications, raised HomeAssistantError);
+# the raw numeric codes are an internal protocol detail and should not
+# leak into anything an end user reads.
+_LOCK_STATUS_NAMES: dict[str, str] = {
+    LOCK_STATUS_UNKNOWN: "unknown",
+    LOCK_STATUS_UNLOCKED: "unlocked",
+    LOCK_STATUS_LOCKED: "locked",
+    LOCK_STATUS_UNLOCKING: "unlocking",
+    LOCK_STATUS_LOCKING: "locking",
+}
+
+
+def _lock_status_name(status: str) -> str:
+    """Return a human-readable name for a Verisure lockStatus code."""
+    return _LOCK_STATUS_NAMES.get(status, f"unknown ({status!r})")
+
+
 # Verification poll: the Verisure backend acks a lock/unlock command BEFORE the
 # device physically actuates (and its status is eventually-consistent), so a
 # single immediate read-back races ahead of reality.  We re-read the status up
@@ -528,8 +546,9 @@ class VerisureLock(  # type: ignore[override]
             # success per the bias-to-false-negative contract.
             if real_state not in (LOCK_STATUS_UNKNOWN, optimistic_state):
                 return (
-                    f"door reports lockStatus={real_state} after "
-                    f"{operation.lower()} command (expected {optimistic_state})"
+                    f"door reports {_lock_status_name(real_state)} after "
+                    f"{operation.lower()} command (expected "
+                    f"{_lock_status_name(optimistic_state)})"
                 )
             return None
         finally:

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components import lock
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -337,8 +338,13 @@ class VerisureLock(  # type: ignore[override]
     async def _auto_lock(self) -> None:
         """Perform an auto-lock-on-arm action.
 
-        On failure (VerisureOwaError or post-call state still unlocked),
-        creates a persistent notification.
+        On a definitive failure (post-call state still unlocked), creates a
+        persistent notification.  Never raises — this runs as a background
+        task with no caller waiting on its result.  The post-state check
+        (not the ``_change_lock_mode`` return) preserves the
+        bias-to-false-negative: a redundant lock command that errors on an
+        already-locked door produces a notification-worthy error reason but
+        the door is in the right state, so we stay quiet here.
         """
         await self._change_lock_mode(
             lock_state=True,
@@ -346,11 +352,6 @@ class VerisureLock(  # type: ignore[override]
             optimistic_state=LOCK_STATUS_LOCKED,
             operation="Auto-lock",
         )
-        # Bias to a false-negative: only warn when the settled state is
-        # *definitively* unlocked.  An UNKNOWN/unreadable status falls back to
-        # the optimistic LOCKED in _change_lock_mode and must not cry wolf —
-        # most "failures" were just the verification racing ahead of a lock
-        # that actuated a few seconds later.
         if self._state == LOCK_STATUS_UNLOCKED:
             await self._fire_autolock_notification(
                 title="Auto-lock failed",
@@ -446,13 +447,20 @@ class VerisureLock(  # type: ignore[override]
         transitional_state: str,
         optimistic_state: str,
         operation: str,
-    ) -> None:
+    ) -> str | None:
         """Send lock command, then poll for real status.
 
         Sets a transitional state (e.g. LOCKING) immediately, reads a fresh
         pre-command baseline timestamp, sends the command (which waits for
         the backend's ~2s acknowledgement), then polls until a real, fresh
         status reading lands or the verify window exhausts.
+
+        Returns ``None`` on success or on a bias-to-false-negative fallback
+        (verify window exhausted with no readable status → optimistic state).
+        Returns a short error reason string on definitive failure: a
+        ``VerisureOwaError`` from the command itself, OR the verify loop
+        confirming a fresh post-command state that is not the target.
+        Callers decide how to surface failure (notification, raise, both).
         """
         self._operation_in_progress = True
         self._force_state(transitional_state)
@@ -484,7 +492,7 @@ class VerisureLock(  # type: ignore[override]
                     self._device_id,
                     err.log_detail(),
                 )
-                return
+                return err.message
 
             # Verify by polling the real status until it reaches the target
             # with a fresh timestamp.  The backend acks before the device
@@ -499,6 +507,17 @@ class VerisureLock(  # type: ignore[override]
             else:
                 self._state = optimistic_state
             self.async_write_ha_state()
+
+            # Definite failure: the verify loop got a fresh post-command read
+            # that is neither the target nor UNKNOWN — the device reported a
+            # real, wrong state (e.g. bolt blocked).  UNKNOWN stays a quiet
+            # success per the bias-to-false-negative contract.
+            if real_state not in (LOCK_STATUS_UNKNOWN, optimistic_state):
+                return (
+                    f"door reports lockStatus={real_state} after "
+                    f"{operation.lower()} command (expected {optimistic_state})"
+                )
+            return None
         finally:
             self._operation_in_progress = False
             # Nudge the coordinator so other lock entities on the same
@@ -587,13 +606,31 @@ class VerisureLock(  # type: ignore[override]
                 return mode
         return None
 
+    async def _notify_and_raise_on_failure(
+        self, *, action: str, error_reason: str
+    ) -> None:
+        """Surface a service-call failure: persistent notification + raise.
+
+        The notification gives UI users a record after the toast disappears;
+        the raise propagates the failure to scripts/automations via the HA
+        service call.  Title is "{Action} failed" (e.g. "Lock failed",
+        "Unlock failed"); message includes the underlying reason for
+        diagnosis.
+        """
+        title = f"{action} failed"
+        message = f"Could not {action.lower()} {self._attr_name}: {error_reason}"
+        await self._fire_autolock_notification(title=title, message=message)
+        raise HomeAssistantError(message)
+
     async def async_lock(self, **kwargs: Any) -> None:
-        await self._change_lock_mode(
+        error = await self._change_lock_mode(
             lock_state=True,
             transitional_state=LOCK_STATUS_LOCKING,
             optimistic_state=LOCK_STATUS_LOCKED,
             operation="Lock",
         )
+        if error is not None:
+            await self._notify_and_raise_on_failure(action="Lock", error_reason=error)
 
     async def _dispatch_unlock_disarm(self) -> bool | None:
         """Disarm configured circuits before unlocking.
@@ -627,15 +664,18 @@ class VerisureLock(  # type: ignore[override]
     async def _perform_user_unlock(self, operation: str) -> None:
         """Concurrent disarm + unlock used by both async_unlock and async_open.
 
-        Both branches each handle their own errors internally (disarm fires an
-        "Auto-disarm failed" notification on failure; unlock rolls back the
-        entity state) so neither raises from gather. Running them in parallel
-        halves the user-perceived latency without changing the semantics:
-        the post-call check still fires "Unlock failed" only when the disarm
-        succeeded but the lock state stayed LOCKED.
+        Disarm and unlock are kicked off in parallel for latency.  Each path
+        handles errors independently so neither raises from ``gather``:
+        ``_dispatch_unlock_disarm`` fires "Auto-disarm failed" on its own
+        failure, and ``_change_lock_mode`` rolls entity state back + returns
+        a reason string on its own failure.  After gather completes we
+        inspect both results and surface unlock failure to the HA service
+        caller: fire "Unlock failed" notification AND raise
+        HomeAssistantError so scripts/automations see it.  If the parallel
+        disarm succeeded, the message is enriched to point out the
+        asymmetric outcome ("alarm disarmed but door still locked").
         """
-        pre_state = self._state
-        disarm_result, _ = await asyncio.gather(
+        disarm_result, unlock_error = await asyncio.gather(
             self._dispatch_unlock_disarm(),
             self._change_lock_mode(
                 lock_state=False,
@@ -644,19 +684,17 @@ class VerisureLock(  # type: ignore[override]
                 operation=operation,
             ),
         )
-        if (
-            disarm_result is True
-            and self._state == pre_state
-            and self._state == LOCK_STATUS_LOCKED
-        ):
-            # Disarm succeeded but the unlock itself failed — state reverted.
-            await self._fire_autolock_notification(
-                title="Unlock failed",
-                message=(
-                    f"{self._attr_name}: alarm has been disarmed but the door "
-                    f"is still locked."
-                ),
+        if unlock_error is None:
+            return
+        if disarm_result is True:
+            message = (
+                f"{self._attr_name}: alarm has been disarmed but the door "
+                f"is still locked ({unlock_error})."
             )
+        else:
+            message = f"Could not unlock {self._attr_name}: {unlock_error}"
+        await self._fire_autolock_notification(title="Unlock failed", message=message)
+        raise HomeAssistantError(message)
 
     async def async_unlock(self, **kwargs: Any) -> None:
         await self._perform_user_unlock("Unlock")

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1554,7 +1554,7 @@ class TestVerisureLockAutoLockFailure:
         ]
         assert len(notification_calls) == 1
         payload = notification_calls[0].args[2]
-        assert payload["notification_id"].startswith("verisure_owa_autolock_")
+        assert payload["notification_id"].startswith("verisure_owa_lock_")
         assert "Auto-lock failed" in payload["title"]
 
     async def test_no_notification_on_successful_auto_lock(self):

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1,7 +1,11 @@
 """Tests for sensor and lock platform entities."""
 
+import contextlib
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.securitas.verisure_owa_api.models import (
     ActivityEvent,
@@ -988,8 +992,10 @@ class TestVerisureLockActions:
         lock._client.change_lock_mode = AsyncMock(
             side_effect=VerisureOwaError("API error")
         )
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_lock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_lock()
 
         # On error, state is restored from _last_state (initial "2" = locked)
         assert lock._state == "2"
@@ -999,8 +1005,10 @@ class TestVerisureLockActions:
         lock._client.change_lock_mode = AsyncMock(
             side_effect=VerisureOwaError("API error")
         )
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_unlock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_unlock()
 
         # On error, state is restored from _last_state (initial "2" = locked)
         assert lock._state == "2"
@@ -1055,8 +1063,10 @@ class TestVerisureLockActions:
         lock._client.change_lock_mode = AsyncMock(
             side_effect=VerisureOwaError("API error")
         )
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_open()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_open()
 
         assert lock._state == "2"
 
@@ -1087,23 +1097,28 @@ class TestVerisureLockActions:
         assert lock._state == "1"
 
     async def test_async_lock_stale_poll_trusts_api(self):
-        """When API still returns pre-command state, we trust it."""
+        """When API still returns pre-command state, we trust it and report failure."""
         # Lock starts open ("1"), we lock it, but the API still returns "1".
         # After the min wait the API should normally have the new state, but
-        # if it doesn't, we trust what the API says rather than guess.
+        # if it doesn't, we trust what the API says rather than guess — and
+        # surface that as a failure to the service caller (raise + notify).
         lock = make_lock(initial_status="1", poll_status="1")
         lock._client.change_lock_mode = AsyncMock(return_value=None)
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_lock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_lock()
 
         assert lock._state == "1"
 
     async def test_async_unlock_stale_poll_trusts_api(self):
-        """When API still returns pre-command state, we trust it."""
+        """When API still returns pre-command state, we trust it and report failure."""
         lock = make_lock(initial_status="2", poll_status="2")
         lock._client.change_lock_mode = AsyncMock(return_value=None)
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_unlock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_unlock()
 
         assert lock._state == "2"
 
@@ -1159,8 +1174,10 @@ class TestVerisureLockActions:
         """_operation_in_progress is cleared even when the command fails."""
         lock = make_lock()
         lock._client.change_lock_mode = AsyncMock(side_effect=VerisureOwaError("fail"))
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_lock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_lock()
 
         assert lock._operation_in_progress is False
 
@@ -1631,6 +1648,208 @@ class TestVerisureLockAutoLockFailure:
 
 
 # ===========================================================================
+# Manual lock/unlock/open failure notification tests
+# ===========================================================================
+
+
+def _persistent_notification_calls(lock):
+    return [
+        c
+        for c in lock.hass.services.async_call.await_args_list
+        if c.args[:2] == ("persistent_notification", "create")
+    ]
+
+
+class TestVerisureLockManualFailureNotification:
+    """async_lock / async_unlock / async_open must surface failure.
+
+    Both via a persistent notification (for UI users) AND by raising
+    HomeAssistantError (for scripts/automations / HA service callers).
+    Auto-lock-on-arm's behaviour is intentionally separate — see
+    TestVerisureLockAutoLockFailure — because its bias-to-false-negative
+    must be preserved.
+    """
+
+    # --- VerisureOwaError (command-status step) ---------------------------
+
+    async def test_async_lock_raises_HomeAssistantError_on_api_error(self):
+        lock = make_lock(initial_status="1", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("network down")
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="network down"):
+            await lock.async_lock()
+
+    async def test_async_lock_fires_notification_on_api_error(self):
+        lock = make_lock(initial_status="1", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("network down")
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with contextlib.suppress(HomeAssistantError):
+            await lock.async_lock()
+
+        calls = _persistent_notification_calls(lock)
+        assert len(calls) == 1
+        payload = calls[0].args[2]
+        assert "Lock failed" in payload["title"]
+        assert "network down" in payload["message"]
+
+    async def test_async_unlock_raises_HomeAssistantError_on_api_error(self):
+        lock = make_lock(initial_status="2", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("network down")
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="network down"):
+            await lock.async_unlock()
+
+    async def test_async_unlock_fires_notification_on_api_error(self):
+        lock = make_lock(initial_status="2", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("network down")
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with contextlib.suppress(HomeAssistantError):
+            await lock.async_unlock()
+
+        calls = _persistent_notification_calls(lock)
+        assert len(calls) == 1
+        assert "Unlock failed" in calls[0].args[2]["title"]
+
+    async def test_async_open_raises_HomeAssistantError_on_api_error(self):
+        lock = make_lock(initial_status="2", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("network down")
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="network down"):
+            await lock.async_open()
+
+    async def test_async_open_fires_notification_on_api_error(self):
+        lock = make_lock(initial_status="2", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(
+            side_effect=VerisureOwaError("network down")
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with contextlib.suppress(HomeAssistantError):
+            await lock.async_open()
+
+        calls = _persistent_notification_calls(lock)
+        assert len(calls) == 1
+        assert "Unlock failed" in calls[0].args[2]["title"]
+
+    # --- Verify-confirmed wrong state (post-command poll) -----------------
+
+    async def test_async_lock_raises_when_verify_confirms_unlocked(self):
+        """Fresh verify read of UNLOCKED after a LOCK command = definite failure."""
+        lock = make_lock(initial_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._client.get_lock_modes = AsyncMock(
+            side_effect=[
+                [
+                    SmartLockMode(
+                        lock_status="1", device_id="01", status_timestamp="100"
+                    )
+                ],  # baseline
+                [
+                    SmartLockMode(
+                        lock_status="1", device_id="01", status_timestamp="200"
+                    )
+                ],  # fresh, wrong state
+            ]
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await lock.async_lock()
+
+        calls = _persistent_notification_calls(lock)
+        assert len(calls) == 1
+        assert "Lock failed" in calls[0].args[2]["title"]
+
+    async def test_async_unlock_raises_when_verify_confirms_locked(self):
+        """Fresh verify read of LOCKED after an UNLOCK command = definite failure."""
+        lock = make_lock(initial_status="2")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._client.get_lock_modes = AsyncMock(
+            side_effect=[
+                [
+                    SmartLockMode(
+                        lock_status="2", device_id="01", status_timestamp="100"
+                    )
+                ],  # baseline
+                [
+                    SmartLockMode(
+                        lock_status="2", device_id="01", status_timestamp="200"
+                    )
+                ],  # fresh, wrong state
+            ]
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await lock.async_unlock()
+
+        calls = _persistent_notification_calls(lock)
+        assert len(calls) == 1
+        assert "Unlock failed" in calls[0].args[2]["title"]
+
+    # --- Bias-to-false-negative (UNKNOWN → optimistic) --------------------
+
+    async def test_async_lock_no_raise_when_window_exhausts_with_unknown(self):
+        """All verify reads return no readable status → optimistic fallback, no raise."""
+        lock = make_lock(initial_status="1")  # poll_status=None → empty list
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock.hass.services.async_call = AsyncMock()
+
+        # Must not raise.
+        await lock.async_lock()
+
+        assert lock._state == "2"  # optimistic LOCKED
+        assert _persistent_notification_calls(lock) == []
+
+    async def test_async_unlock_no_raise_when_window_exhausts_with_unknown(self):
+        lock = make_lock(initial_status="2")  # poll_status=None → empty list
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock.hass.services.async_call = AsyncMock()
+
+        await lock.async_unlock()
+
+        assert lock._state == "1"  # optimistic UNLOCKED
+        assert _persistent_notification_calls(lock) == []
+
+    # --- Success path -----------------------------------------------------
+
+    async def test_async_lock_no_raise_no_notification_on_success(self):
+        lock = make_lock(initial_status="1", poll_status="2")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock.hass.services.async_call = AsyncMock()
+
+        await lock.async_lock()
+
+        assert lock._state == "2"
+        assert _persistent_notification_calls(lock) == []
+
+    async def test_async_unlock_no_raise_no_notification_on_success(self):
+        lock = make_lock(initial_status="2", poll_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock.hass.services.async_call = AsyncMock()
+
+        await lock.async_unlock()
+
+        assert lock._state == "1"
+        assert _persistent_notification_calls(lock) == []
+
+
+# ===========================================================================
 # Lock verification poll (poll-until-target) tests
 # ===========================================================================
 
@@ -1706,6 +1925,8 @@ class TestVerisureLockVerifyPoll:
     async def test_gives_up_after_max_attempts_when_target_never_reached(self):
         # A lock attempt whose status never flips: all reads return the same
         # stale timestamp so no read is ever "fresh" — the window exhausts.
+        # The exhausted-stale-wrong-state case is a definitive failure and
+        # raises (caller wanted LOCKED, last read says UNLOCKED).
         lock = make_lock(initial_status="1")
         lock._client.change_lock_mode = AsyncMock(return_value=SmartLockModeStatus())
         # All reads return ts="100" — identical to baseline, never fresh.
@@ -1714,8 +1935,10 @@ class TestVerisureLockVerifyPoll:
                 SmartLockMode(lock_status="1", device_id="01", status_timestamp="100")
             ]
         )
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_lock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_lock()
 
         assert lock._state == "1"
         # 1 baseline read + _verify_attempts verify reads (never fresh → exhausts).
@@ -2000,8 +2223,10 @@ class TestVerisureLockTimestampConfirmation:
                 ],
             ]
         )
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_lock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_lock()
 
         # 1 baseline + 2 verify reads (stale, then fresh-wrong-state) = 3 total.
         assert lock._client.get_lock_modes.await_count == 3
@@ -2069,8 +2294,12 @@ class TestVerisureLockTimestampConfirmation:
                 ],
             ]
         )
+        lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_lock()
+        # Window exhausts with the last read being stale-wrong-state ("1" when
+        # target was "2") — a definitive failure that raises to the caller.
+        with pytest.raises(HomeAssistantError):
+            await lock.async_lock()
 
         # Every verify attempt must run — empty ts is not authoritative.
         assert lock._client.get_lock_modes.await_count == 1 + lock._verify_attempts
@@ -2303,7 +2532,8 @@ class TestVerisureLockUnlockDisarmFailure:
         lock._combined_alarm_panel = panel
         lock.hass.services.async_call = AsyncMock()
 
-        await lock.async_unlock()
+        with pytest.raises(HomeAssistantError):
+            await lock.async_unlock()
 
         # The unlock failed — notification with "Unlock failed" wording.
         notif_calls = [

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1802,6 +1802,47 @@ class TestVerisureLockManualFailureNotification:
         assert len(calls) == 1
         assert "Unlock failed" in calls[0].args[2]["title"]
 
+    async def test_failure_message_uses_readable_state_names_not_raw_codes(self):
+        """The notification + raised exception are read by a non-technical user.
+
+        The verify-confirmed-wrong-state failure path must not leak the
+        backend's numeric ``lockStatus`` codes (``"1"``, ``"2"``) into the
+        user-facing message — that's an internal protocol detail.  Render
+        them as human-readable state names instead.
+        """
+        lock = make_lock(initial_status="1")
+        lock._client.change_lock_mode = AsyncMock(return_value=MagicMock())
+        lock._client.get_lock_modes = AsyncMock(
+            side_effect=[
+                [
+                    SmartLockMode(
+                        lock_status="1", device_id="01", status_timestamp="100"
+                    )
+                ],  # baseline
+                [
+                    SmartLockMode(
+                        lock_status="1", device_id="01", status_timestamp="200"
+                    )
+                ],  # fresh, still unlocked → confirmed failure
+            ]
+        )
+        lock.hass.services.async_call = AsyncMock()
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await lock.async_lock()
+
+        # Message goes into both the raised exception AND the persistent
+        # notification — neither must contain the raw API codes.
+        raised = str(exc_info.value)
+        notif_message = _persistent_notification_calls(lock)[0].args[2]["message"]
+        for text in (raised, notif_message):
+            assert "unlocked" in text.lower()
+            assert "locked" in text.lower()
+            # The raw codes are protocol noise — must not surface.
+            assert "lockStatus=1" not in text
+            assert "lockStatus=2" not in text
+            assert "(expected 2)" not in text
+
     # --- Bias-to-false-negative (UNKNOWN → optimistic) --------------------
 
     async def test_async_lock_no_raise_when_window_exhausts_with_unknown(self):


### PR DESCRIPTION
## Problem

`lock.lock` / `lock.unlock` / `lock.open` service calls (HA UI taps, scripts, automations) swallowed two distinct failure modes:

1. **API-level errors** — e.g. the backend returning `alarm-manager.error_no_response_to_request` from `xSChangeSmartlockModeStatus`, the case we just hit in the v5.0.5 smoke tests. The integration logged ERROR and rolled state back; the service call returned success.
2. **Verify-confirmed wrong state** — the verify loop saw a fresh post-command read that didn't match the target (lock physically blocked, device snapped back, exhausted stale window). Entity state was updated to the wrong value, but no notification fired and the caller had no idea anything went wrong.

Result: scripts saw `lock.lock` succeed when the door was still open; UI users got nothing beyond an ERROR line in the log.

Auto-lock-on-arm already handled this correctly via the existing post-state check + `_fire_autolock_notification`. The manual paths just didn't.

## Changes

### `lock.py`

- **`_change_lock_mode` now returns `Optional[str]`** — `None` on success or bias-to-false-negative fallback (UNKNOWN reads → optimistic target); the error reason string on definite failure (VerisureOwaError OR `_poll_lock_until` returning fresh non-target state). Callers decide how to surface failure.
- **`async_lock`** — fires `persistent_notification` ('Lock failed', includes reason) AND raises `HomeAssistantError` on failure.
- **`_perform_user_unlock`** (called by both `async_unlock` and `async_open`) — same: notify + raise. Subsumes the prior special-case 'Unlock failed' branch (disarm-succeeded-but-lock-stayed-locked), enriching the message in that scenario.
- **`_auto_lock`** — unchanged behaviour. Still uses the post-state check (`self._state == LOCK_STATUS_UNLOCKED`) rather than the new return value: it must not raise (background task), and it must not fire on a redundant lock against an already-locked door (no-op).
- New helper `_notify_and_raise_on_failure(action, error_reason)` keeps the manual paths tight.

### Bias-to-false-negative preserved

If every verify read returned an unreadable status (`UNKNOWN`), we still fall back to the optimistic target state without firing anything. Most "failures" in the historical bug reports were just the verify racing ahead of a lock that actuated a few seconds later — that case stays quiet.

A redundant lock command against an already-locked door that errors at the API level does now fire on the manual paths (the caller's command genuinely failed), but stays quiet on auto-lock-on-arm (the door is in the right state — no point crying wolf).

## Tests

`tests/test_ha_platforms.py` — new class `TestVerisureLockManualFailureNotification` (12 tests):
- VerisureOwaError on each of `async_lock` / `async_unlock` / `async_open`: raises + notifies (6 tests)
- Verify-confirmed wrong state on lock and unlock: raises + notifies (2 tests)
- UNKNOWN-only verify window: bias-to-false-negative — no raise, no notification (2 tests)
- Success: no raise, no notification (2 tests)

Existing tests adjusted: 10 tests that exercised the failure paths now wrap the entry-point call in `pytest.raises(HomeAssistantError)` and supply `lock.hass.services.async_call = AsyncMock()` for the notification path. Underlying state assertions preserved (state is still restored from `_last_state` on API error, the verify loop still trusts the API on stale-poll, etc.).

\`\`\`
1626 passed; ruff format + check clean; pylint 10.00/10; pyright 0 errors.
\`\`\`

## Test plan

- [x] All Python tests pass locally
- [ ] Smoke test: trigger \`alarm-manager.error_no_response_to_request\` (or any backend reject) via \`lock.lock\` from a script — confirm script sees failure AND persistent notification appears
- [ ] Smoke test: manual \`lock.unlock\` while a wedge keeps the bolt from moving — confirm fresh-wrong-state read raises + notifies
- [ ] Smoke test: auto-lock-on-arm against an already-locked door with a transient API error — confirm NO notification fires (bias-to-false-negative preserved on the auto-lock-on-arm path)