### PR TITLE
docs(readme): fix Active Installations badge query

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![HACS Default](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/v/release/guerrerotook/securitas-direct-new-api)](https://github.com/guerrerotook/securitas-direct-new-api/releases)
 [![Active Installations](https://img.shields.io/badge/dynamic/json?url=https://analytics.home-assistant.io/custom_integrations.json&label=Active%20Installations&query=$.securitas.total&color=blue)](https://analytics.home-assistant.io/)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/github/license/guerrerotook/securitas-direct-new-api?color=blue)](LICENSE)
 
 A Home Assistant integration for **Verisure** (formerly Securitas Direct in some markets), supporting Argentina, Brazil, Chile, France, Ireland, Italy, Peru, Portugal, Spain, and the United Kingdom.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![HACS Default](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/v/release/guerrerotook/securitas-direct-new-api)](https://github.com/guerrerotook/securitas-direct-new-api/releases)
-[![Active Installations](https://img.shields.io/badge/dynamic/json?url=https://analytics.home-assistant.io/custom_integrations.json&label=Active%20Installations&query=$.verisure_owa.total&color=blue)](https://analytics.home-assistant.io/)
+[![Active Installations](https://img.shields.io/badge/dynamic/json?url=https://analytics.home-assistant.io/custom_integrations.json&label=Active%20Installations&query=$.securitas.total&color=blue)](https://analytics.home-assistant.io/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 A Home Assistant integration for **Verisure** (formerly Securitas Direct in some markets), supporting Argentina, Brazil, Chile, France, Ireland, Italy, Peru, Portugal, Spain, and the United Kingdom.


### PR DESCRIPTION
The Active Installations shields.io badge was pointing at \`\$.verisure_owa.total\` in the HA analytics JSON, which doesn't exist there.  HA analytics tracks this integration under its actual HA domain (\`securitas\`), so the badge was returning null and rendering blank.

Verified against \`https://analytics.home-assistant.io/custom_integrations.json\`:
- \`securitas\`: 469 active installs (version breakdown: 1.1.x predominantly, plus the v5.0.x pre-releases — and v5.1.0 will start appearing once HA analytics next refreshes).
- \`verisure_owa\`: doesn't exist.

The domain rename was deferred indefinitely (per \`docs/FUTURE_MIGRATION_PLAN.md\` and the v5.0.2 changelog), so \`securitas\` remains the correct key for the foreseeable future.

## Test plan

- [x] Confirmed the JSON path matches the actual analytics payload
- [ ] After merge, verify the badge on the README displays the correct count