### PR TITLE
fix(disarm): treat panel 404 as command-unsupported, fall through to next alternative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
+## v5.1.1
+
+Bugfix release.
+
+**Disarm fallback restored.**  Some panels — observed on Spanish installations in night+perimeter mode — reject the combined `DARM1DARMPERI` disarm command with an HTTP 404 ("Requested data not found") instead of the more usual 400.  Pre-v5 code fell back to plain `DARM1` on any non-busy error, but the v5 resolver/executor only fell back on 400, so on these panels the disarm appeared to silently fail.  The executor now treats 404 the same as 400 — a permanent panel-side rejection of *this* specific command — and falls through to `DARM1`, restoring the v4 behaviour.
+
 ## v5.1.0
 
 This is the first stable v5 release, and the first major update since v4.0.9 in April.

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -570,12 +570,20 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                     raise
                 if err.http_status == 409:
                     raise  # Server busy — don't try alternatives
-                if err.http_status == 400:
-                    # 400 BAD_USER_INPUT ("command not valid for panel") is
-                    # the *only* HTTP status the Verisure OWA API uses to
-                    # signal "this command is not in the panel's enum".
-                    # Mark this specific command unsupported, persist, and
-                    # try the next alternative in the step.
+                if err.http_status in (400, 404):
+                    # The Verisure OWA API uses two HTTP statuses for
+                    # "this command is not in the panel's enum":
+                    #   - 400 BAD_USER_INPUT — surfaced when the panel's
+                    #     ArmCodeRequest / DisarmCodeRequest enum doesn't
+                    #     include the requested code at all (the GraphQL
+                    #     server validates the variable up front).
+                    #   - 404 "Requested data not found" — surfaced by the
+                    #     panel itself when it doesn't recognise the
+                    #     compound disarm command (e.g. Spanish panels that
+                    #     don't accept DARM1DARMPERI from night+perimeter).
+                    # Both are permanent panel-side rejections of *this*
+                    # specific command. Mark unsupported, persist, and try
+                    # the next alternative in the step.
                     #
                     # We deliberately do NOT blacklist for other 4xx
                     # (401 auth-blip, 422 validation hiccup, 429 rate-limit,
@@ -586,22 +594,23 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                     # the error so the caller sees the transient failure
                     # without polluting unsupported_commands.
                     _LOGGER.info(
-                        "Command %s not supported by panel (status 400),"
+                        "Command %s not supported by panel (status %s),"
                         " trying next alternative: %s",
                         command,
+                        err.http_status,
                         err.log_detail(),
                     )
                     self._resolver.mark_unsupported(command)
                     self._persist_unsupported()
                 else:
                     # Any other 4xx (transient auth, rate-limit, etc.) or
-                    # 5xx server error / panel-level error — not a "command
-                    # not valid" case. Don't blacklist; don't try
-                    # alternatives (they'll likely also fail the same way).
+                    # 5xx server error — not a "command not valid" case.
+                    # Don't blacklist; don't try alternatives (they'll
+                    # likely also fail the same way).
                     raise
                 last_err = err
 
-        if last_err and last_err.http_status == 400:
+        if last_err and last_err.http_status in (400, 404):
             # Sub-panels have no user-editable mapping — point the user at
             # the auto-disabled feature; mappable Main panel still points
             # them at the mappings UI.

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.1.0"
+    "version": "5.1.1"
 }

--- a/custom_components/securitas/verisure_owa_api/exceptions.py
+++ b/custom_components/securitas/verisure_owa_api/exceptions.py
@@ -9,7 +9,13 @@ class VerisureOwaError(Exception):
     """Base class for all Verisure OWA errors."""
 
     # http_status values that are well-understood and need no extra context.
-    _KNOWN_STATUSES: frozenset[int] = frozenset({400, 403, 409})
+    # 400 = command not in panel's GraphQL enum (BAD_USER_INPUT).
+    # 403 = session expired / WAF block.
+    # 404 = panel-side rejection of a specific command (e.g. compound
+    #       disarm not recognised by panel firmware); the message already
+    #       carries the panel's error code so the body is duplicative.
+    # 409 = server busy (transient).
+    _KNOWN_STATUSES: frozenset[int] = frozenset({400, 403, 404, 409})
 
     def __init__(self, message: str, *, http_status: int | None = None) -> None:
         super().__init__(message)
@@ -25,7 +31,7 @@ class VerisureOwaError(Exception):
     def log_detail(self) -> str:
         """Return a log string: concise for known errors, verbose otherwise.
 
-        Known HTTP statuses (400, 403, 409) return just the message.
+        Known HTTP statuses (400, 403, 404, 409) return just the message.
         Unknown errors append the response body so we can diagnose them.
         """
         if self.http_status in self._KNOWN_STATUSES:

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -4184,7 +4184,16 @@ class TestDynamicDisarm:
         assert alarm._state == AlarmControlPanelState.DISARMED
 
     async def test_peri_armed_falls_back_to_darm1(self):
-        """When DARM1DARMPERI fails, falls back to DARM1."""
+        """When DARM1DARMPERI fails with 404 (panel rejects from current state),
+        falls back to DARM1.
+
+        Real Spanish panels reject DARM1DARMPERI with a GraphQL ApiError whose
+        inner ``data.status`` is 404 ("Requested data not found error") when the
+        panel is in a state where the combined disarm isn't supported. The
+        executor must treat 404 the same way it treats 400 BAD_USER_INPUT —
+        as a panel-side rejection that should fall through to the next
+        alternative in the step.
+        """
         alarm = make_alarm(has_peri=True)
         alarm._last_proto_code = "A"  # total_peri = peri armed
         alarm._state = AlarmControlPanelState.ARMED_AWAY
@@ -4194,7 +4203,9 @@ class TestDynamicDisarm:
         async def disarm_side_effect(installation, command):
             calls.append(command)
             if command == "DARM1DARMPERI":
-                raise VerisureOwaError("404 not found", http_status=400)
+                raise VerisureOwaError(
+                    "4: Requested data not found error.", http_status=404
+                )
             return OperationStatus(
                 operation_status="OK",
                 message="",
@@ -4210,6 +4221,47 @@ class TestDynamicDisarm:
 
         assert calls == ["DARM1DARMPERI", "DARM1"]
         assert alarm._state == AlarmControlPanelState.DISARMED
+        # 404 is a permanent panel-side rejection, same as 400 — the resolver
+        # should have blacklisted the combined command for the session.
+        assert "DARM1DARMPERI" in alarm._resolver.unsupported
+
+    async def test_peri_armed_falls_back_to_darm1_on_400(self):
+        """When DARM1DARMPERI fails with 400 BAD_USER_INPUT, falls back to DARM1.
+
+        Parallel of ``test_peri_armed_falls_back_to_darm1`` covering the
+        original 400 case (command not in panel's ArmCodeRequest enum) — kept
+        as a separate test so future refactors can't conflate the two status
+        codes and lose coverage of either path.
+        """
+        alarm = make_alarm(has_peri=True)
+        alarm._last_proto_code = "A"  # total_peri = peri armed
+        alarm._state = AlarmControlPanelState.ARMED_AWAY
+
+        calls = []
+
+        async def disarm_side_effect(installation, command):
+            calls.append(command)
+            if command == "DARM1DARMPERI":
+                raise VerisureOwaError(
+                    'Variable "$request" got invalid value "DARM1DARMPERI"',
+                    http_status=400,
+                )
+            return OperationStatus(
+                operation_status="OK",
+                message="",
+                status="",
+                numinst="123456",
+                protom_response="D",
+                protom_response_date="",
+            )
+
+        alarm.client.disarm_alarm = disarm_side_effect
+
+        await alarm.async_alarm_disarm()
+
+        assert calls == ["DARM1DARMPERI", "DARM1"]
+        assert alarm._state == AlarmControlPanelState.DISARMED
+        assert "DARM1DARMPERI" in alarm._resolver.unsupported
 
     async def test_peri_not_armed_uses_darm1(self):
         """With peri configured but not currently armed, resolver uses DARM1.
@@ -4350,7 +4402,9 @@ class TestDynamicDisarm:
         async def track_disarm(installation, command):
             disarm_calls.append(command)
             if command == "DARM1DARMPERI":
-                raise VerisureOwaError("404 not found", http_status=400)
+                raise VerisureOwaError(
+                    "4: Requested data not found error.", http_status=404
+                )
             return OperationStatus(protom_response="D", operation_status="OK")
 
         alarm.client.disarm_alarm = track_disarm

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -185,7 +185,7 @@ class TestUnexpectedStateError:
 class TestLogDetail:
     """log_detail() returns brief output for known statuses, verbose otherwise."""
 
-    KNOWN_STATUSES = [400, 403, 409]
+    KNOWN_STATUSES = [400, 403, 404, 409]
     UNKNOWN_STATUSES = [500, 502, 429, None]
 
     @pytest.mark.parametrize("status", KNOWN_STATUSES)


### PR DESCRIPTION
## Summary

Some panels (observed on a Spanish installation with a Verisure OWA panel running v5.1.0 of this integration) reject `DARM1DARMPERI` from night+perimeter (proto code `C`) with a GraphQL `ApiError` whose inner `data.status` is **404** (`"Requested data not found error"`) on the `xSDisarmPanel` mutation:

```
ERROR Disarm failed for 1743124: 4: Requested data not found error. | response:
{'errors': [{'message': '4: Requested data not found error.', 'name': 'ApiError',
 'data': {'res': 'ERROR', 'err': '4', 'status': 404}, 'path': ['xSDisarmPanel']}]}
```

The expected behaviour is that `DARM1DARMPERI` failures fall back to plain `DARM1` (which disarms both axes on panels that don't accept the combined code) — and that's how the pre-refactor code in monolithic `alarm_control_panel.py` worked: it caught any non-409 `SecuritasDirectError` and tried `DARM1` next.

The resolver+executor refactor in `0c65cb4` narrowed the "try next alternative" branch in `_execute_step` to **HTTP 400 only**. Real panels return 404 for this scenario, so the executor now re-raises immediately and the disarm fails permanently — `DARM1` is never attempted.

## What changed

`alarm_control_panel/_base.py` — extend the panel-side-rejection branch in `_execute_step` to fire for both 400 and 404:

```python
if err.http_status in (400, 404):
    # 400 BAD_USER_INPUT — code not in panel's GraphQL enum
    # 404 "Requested data not found" — panel firmware doesn't recognise
    #     the combined code (e.g. Spanish panels + DARM1DARMPERI)
    # Both are permanent panel-side rejections of *this* command.
    ...
    self._resolver.mark_unsupported(command)
    self._persist_unsupported()
```

These commands are only ever issued by the resolver from one specific state transition (e.g. `DARM1DARMPERI` only when both interior and perimeter are armed), so a rejection observed once means the panel will never accept it from anywhere we'd send it. Persistent blacklisting is the right behaviour — same as the existing 400 handling.

Other 4xx (401 auth blip, 422 validation, 429 rate-limit, 451 legal-block) and 5xx continue to propagate without blacklisting, unchanged.

## Why this regression hid in the test suite

The two existing fallback tests at `test_alarm_panel.py:4197` and `:4353` looked like they covered the 404 case:

```python
if command == "DARM1DARMPERI":
    raise VerisureOwaError("404 not found", http_status=400)  # ← bug
```

The *message string* says `"404 not found"` but the `http_status` argument is **400**, so the test was actually exercising the 400 path. Updated both to use `http_status=404` (matching what real panels send), confirmed they fail under the unfixed code, then implemented the fix. Added a parallel `test_peri_armed_falls_back_to_darm1_on_400` so future refactors can't conflate the two status codes again.

## Test plan

- [x] `pytest tests/` — 1628 passed, 0 failed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pyright` — 0 errors
- [x] `pylint custom_components/securitas/alarm_control_panel/_base.py` — 10.00/10
- [x] Confirmed RED: existing fallback tests fail with `http_status=404` against unfixed code, with the exact symptom from the bug report (`calls == ['DARM1DARMPERI']` — never tries `DARM1`)
- [x] Confirmed GREEN: same tests + new `_on_400` test pass with the fix applied

## Related commits / context

- `0c65cb4 refactor: overhaul alarm control panel` introduced the resolver+executor pattern (March 10) and narrowed the fallback path
- `c5d2c9e fix: always try DARM1DARMPERI when perimeter is configured` (pre-refactor) is the load-bearing commit whose semantics this PR restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)