### PR TITLE
fix(auth): serialize token renewal & stop empty-password fallback — release 5.1.2 (#499)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
+## v5.1.2
+
+A bugfix release for Spain (and any market) hitting repeated re-authentication failures since v5.1.0.
+
+### Fixed
+
+**Session drops every few hours ([#499](https://github.com/guerrerotook/securitas-direct-new-api/issues/499)).**  Since v5.1.0 the password is used once to mint a long-lived refresh token and then dropped from storage.  Two problems combined to break that on Spanish accounts: when the short-lived session token expired, the several entity coordinators that share one connection would all try to refresh at the same instant, racing each other over the single-use refresh token — the first won, the rest were rejected.  A rejected refresh then fell back to a password login, but the password was already gone, so the integration sent an empty one and the server replied "el usuario o la contraseña son incorrectos" — which also counts toward the three-strikes account lock.  Token renewal is now serialized so only one refresh runs at a time, and a refresh failure with no stored password now triggers a clean re-auth prompt instead of an empty-password login.
+
 ## v5.1.1
 
 Bugfix release.

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.1.1"
+    "version": "5.1.2"
 }

--- a/custom_components/securitas/verisure_owa_api/client/_auth.py
+++ b/custom_components/securitas/verisure_owa_api/client/_auth.py
@@ -28,7 +28,19 @@ class _AuthMixin(_ClientBase):
     """Login, refresh, logout, and 2FA validation."""
 
     async def login(self) -> None:
-        """Login to the Verisure OWA API and set auth tokens."""
+        """Login to the Verisure OWA API and set auth tokens.
+
+        Once a refresh token has been minted the password is scrubbed from
+        storage (v5.1.0). Sending an empty password to the API only earns a
+        credential error and burns an attempt toward Verisure's 3-strikes
+        account lock, so refuse it here and signal reauth instead — this guards
+        every fallback path that reaches login() after a rejected refresh (#499).
+        """
+        if not self.password:
+            raise AuthenticationError(
+                "Cannot login: no password available (refresh token rejected). "
+                "Re-authentication required."
+            )
         content = {
             "operationName": "mkLoginToken",
             "variables": {

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -119,6 +119,12 @@ class _ClientBase:
         self.protom_response: str = ""
         self.authentication_otp_challenge_value: tuple[str, str] | None = None
 
+        # Serializes token renewal. All coordinators share one client, so when
+        # the short-lived auth JWT expires their polls would otherwise fire
+        # concurrent RefreshLogin calls with the same one-time-use refresh
+        # token — the server rotates on the first and rejects the rest. See #499.
+        self._auth_lock = asyncio.Lock()
+
         # Device configuration
         self.device_id: str = device_id
         self.uuid: str = uuid
@@ -412,11 +418,27 @@ class _ClientBase:
         if installation is not None:
             await self._ensure_capabilities(installation)
 
-    async def _check_authentication_token(self) -> None:
-        """Check expiration of the authentication token and get a new one if needed."""
-        if (self.authentication_token is None) or (
+    def _token_needs_renewal(self) -> bool:
+        """True when the auth token is missing or within a minute of expiry."""
+        return (self.authentication_token is None) or (
             datetime.now() + timedelta(minutes=1) > self._authentication_token_exp
-        ):
+        )
+
+    async def _check_authentication_token(self) -> None:
+        """Check expiration of the authentication token and get a new one if needed.
+
+        Renewal is serialized behind ``_auth_lock`` with a double-check inside:
+        when several coordinators hit an expired token at once, the first
+        renews and the rest reuse that result instead of racing concurrent
+        RefreshLogin calls against a one-time-use refresh token (issue #499).
+        """
+        if not self._token_needs_renewal():
+            return
+        async with self._auth_lock:
+            # Re-check under the lock: a coroutine we queued behind may have
+            # already minted a fresh token while we were waiting.
+            if not self._token_needs_renewal():
+                return
             if self.refresh_token_value:
                 _LOGGER.debug("[auth] Auth token expired, refreshing")
                 try:

--- a/tests/test_client_auth.py
+++ b/tests/test_client_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -373,6 +374,85 @@ class TestRefreshToken:
         result = await client.refresh_token()
 
         assert result is False
+
+
+# ── Concurrent renewal tests ─────────────────────────────────────────────────
+
+
+class TestConcurrentRenewal:
+    """Renewal must be serialized: all coordinators share one client (issue #499)."""
+
+    async def test_concurrent_check_auth_triggers_single_refresh(
+        self, client, transport
+    ):
+        """Concurrent token renewals must not race the (rotating) refresh token.
+
+        Every coordinator shares one VerisureOwaClient. When the short-lived
+        auth JWT expires, several coordinator polls call
+        _check_authentication_token at the same instant. Without serialization
+        each fires its own RefreshLogin with the same one-time-use refresh
+        token; the server rotates on the first and rejects the rest, which then
+        fall through to a (passwordless) login and surface a credential error.
+        Only one refresh must actually reach the wire.
+        """
+        new_jwt = make_jwt(exp_minutes=15)
+        call_ops: list[str] = []
+
+        async def slow_execute(content, _headers):
+            call_ops.append(content["operationName"])
+            # Yield so the other gathered coroutines get a chance to interleave
+            # before this refresh completes — reproduces the real race.
+            await asyncio.sleep(0)
+            return refresh_response(hash_token=new_jwt)
+
+        transport.execute.side_effect = slow_execute
+
+        client.authentication_token = FAKE_JWT_EXPIRED
+        client._authentication_token_exp = datetime.now() - timedelta(minutes=5)
+        client.refresh_token_value = "some-refresh-token"
+
+        await asyncio.gather(*[client._check_authentication_token() for _ in range(5)])
+
+        assert call_ops.count("RefreshLogin") == 1
+
+
+# ── Empty-password fallback tests ────────────────────────────────────────────
+
+
+class TestEmptyPasswordFallback:
+    """A rejected refresh must never trigger an empty-password login (issue #499)."""
+
+    async def test_refresh_failure_without_password_does_not_login(self, transport):
+        """When refresh is rejected and no password is stored, never POST a login.
+
+        v5.1.0 drops the password after minting a refresh token. If the refresh
+        is later rejected, falling back to login() would send user + "" — which
+        the API answers with "usuario o contraseña incorrectos" and which counts
+        toward Verisure's 3-strikes account lock. The client must instead raise
+        AuthenticationError so HA triggers a clean reauth.
+        """
+        client = VerisureOwaClient(
+            transport=transport,
+            country="ES",
+            language="es",
+            username="test@example.com",
+            password="",
+            device_id="test-device-id",
+            uuid="test-uuid",
+            id_device_indigitall="test-indigitall",
+            refresh_token="stale-refresh-token",
+        )
+        client.authentication_token = FAKE_JWT_EXPIRED
+        client._authentication_token_exp = datetime.now() - timedelta(minutes=5)
+        transport.execute.return_value = refresh_response(res="ERROR")
+
+        with pytest.raises(AuthenticationError):
+            await client._check_authentication_token()
+
+        ops = [
+            call.args[0]["operationName"] for call in transport.execute.call_args_list
+        ]
+        assert "mkLoginToken" not in ops
 
 
 # ── Typed execute tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #499.

## Symptom
Spain (Verisure OWA) users see `El usuario o la contraseña son incorrectos. Recuerda que deberás desbloquear tu cuenta tras 3 intentos de acceso inválido` every few hours since v5.1.0 — the release that mints a long-lived refresh token from the password once, then scrubs the password from storage. The reporter's logs show three coordinators (`alarm`, `sentinel`, `camera`) failing at the same instant.

Two independent defects combined to produce this.

## Defect 1 — concurrent-refresh race (the trigger)
All coordinators share a single `VerisureOwaClient`. When the short-lived auth JWT expires, several coordinator polls call `_check_authentication_token` simultaneously. With no serialization, each fired its own `RefreshLogin` using the **same** one-time-use refresh token; the server rotates on the first call and rejects the rest — exactly matching the 3-simultaneous-failure fingerprint in the logs.

**Fix:** a per-client `asyncio.Lock` with double-checked locking. The first caller renews; the others queue, re-check, and reuse the freshly minted token.

## Defect 2 — empty-password fallback (the surfaced error + account-lock risk)
Every renewal fallback funnels into the raw `client.login()`, which sent `user + ""` once the password had been scrubbed. The API answers with the credential error above **and** counts the attempt toward Verisure's 3-strikes account lock — so the integration could lock the user's account.

**Fix:** `client.login()` now refuses an empty password and raises `AuthenticationError` (a `VerisureOwaError` subclass), so a rejected refresh produces a clean `ConfigEntryAuthFailed` reauth signal instead of blank-credential POSTs. This is the single chokepoint shared by the client-internal renewal and the coordinator's `_handle_session_expired`.

## Tests (TDD — written and watched fail first)
- `TestConcurrentRenewal::test_concurrent_check_auth_triggers_single_refresh` — 5 concurrent `_check_authentication_token` calls produce exactly **1** `RefreshLogin` (was 5).
- `TestEmptyPasswordFallback::test_refresh_failure_without_password_does_not_login` — a rejected refresh with no stored password raises `AuthenticationError` and never sends `mkLoginToken`.

## Verification
- Full suite: **1629 passed**
- Pyright: 0 errors · Pylint: 10.00/10 · Ruff: clean

## Caveat
Defect 1 is the most probable trigger (shared client + no mutex + rotating tokens + simultaneous failures) but I couldn't prove the ES endpoint uses one-time-use refresh tokens without the live API. Both fixes are correct regardless: the race was a real defect, and even if the refresh token genuinely expires server-side, the integration now fails gracefully into reauth rather than risking an account lock.