### PR TITLE
fix(sentinel): skip coordinator when CONFORT service has no zone (#498)

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -941,10 +941,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     alarm_coord.has_annex,
                 )
 
-            # Sentinel coordinator — needs a sentinel service and its zone
+            # Sentinel coordinator — needs a sentinel service AND a zone.
+            # An account can subscribe to CONFORT without a Sentinel device
+            # installed (issue #498): the API then returns null attributes and
+            # an empty xSComfort device list, so no zone exists anywhere. With
+            # an empty zone the air-quality query 500s on every poll and the
+            # coordinator fails forever, so skip it unless a zone is present.
             for service in services:
-                if service.request in SENTINEL_SERVICE_NAMES:
-                    zone = service.attributes[0].value if service.attributes else ""
+                if service.request in SENTINEL_SERVICE_NAMES and service.attributes:
+                    zone = service.attributes[0].value
                     sentinel_coord = SentinelCoordinator(
                         hass,
                         client.client,

--- a/tests/mock_graphql.py
+++ b/tests/mock_graphql.py
@@ -679,11 +679,19 @@ def make_doorlock_service() -> dict:
     )
 
 
-def make_sentinel_service(zone: str = "1") -> dict:
-    """Return a CONFORT (sentinel) service dict for use in graphql_services."""
+def make_sentinel_service(zone: str | None = "1") -> dict:
+    """Return a CONFORT (sentinel) service dict for use in graphql_services.
+
+    Passing ``zone=None`` returns a CONFORT service with no attributes —
+    mirroring issue #498, where the account subscribes to CONFORT but has
+    no Sentinel device installed, so the API returns null attributes and no
+    zone.
+    """
     return _make_service_dict(
         id_service=20,
         request="CONFORT",
         description="Sentinel",
-        attributes=[{"name": "zone", "value": zone, "active": True}],
+        attributes=(
+            None if zone is None else [{"name": "zone", "value": zone, "active": True}]
+        ),
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -534,6 +534,38 @@ async def test_services_with_sentinel(
     assert len(sentinel_services) == 1
 
 
+async def test_sentinel_coordinator_created_when_zone_present(
+    hass: HomeAssistant, mock_server: MockGraphQLServer
+):
+    """A CONFORT service with a zone attribute produces a sentinel coordinator."""
+    sentinel = make_sentinel_service(zone="1")
+    queue_standard_setup(mock_server, extra_services=[sentinel])
+    entry, result = await _setup(hass, mock_server)
+    assert result is True
+
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    assert entry_data["sentinel_coordinator"] is not None
+
+
+async def test_sentinel_coordinator_skipped_when_no_zone(
+    hass: HomeAssistant, mock_server: MockGraphQLServer
+):
+    """A CONFORT service with no attributes must not create a sentinel coordinator.
+
+    Regression test for issue #498: an account can subscribe to CONFORT
+    without a Sentinel device installed. The API then returns null
+    attributes and no zone, and the air-quality query 500s on every poll.
+    Without a resolvable zone we skip the coordinator entirely.
+    """
+    sentinel = make_sentinel_service(zone=None)
+    queue_standard_setup(mock_server, extra_services=[sentinel])
+    entry, result = await _setup(hass, mock_server)
+    assert result is True
+
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    assert entry_data["sentinel_coordinator"] is None
+
+
 # ── Arm / Disarm via VerisureOwaClient ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

Fixes #498.

An account can subscribe to the **CONFORT** service without an actual Sentinel device installed. The reporter's debug log confirms the exact shape:

- Service 68 / `CONFORT` is `active`/`visible` but `attributes: null` **and** `genericConfig: null`
- `xSComfort` succeeds but returns `devices: []` — no hardware, so no zone anywhere
- `xSAirQuality` returns a GraphQL 500 (`Internal Server Error`)

The old discovery code defaulted the zone to an empty string and created the `SentinelCoordinator` regardless. On every poll that coordinator then:

1. called `xSAirQuality` with an empty zone → guaranteed GraphQL 500 → coordinator update fails → all climate entities (Temperature, Humidity, Air Quality, Air Quality Status) go **unavailable**; and
2. logged `No attributes found for sentinel service 68`.

The integration otherwise kept working (alarm/lock/activity coordinators are independent), so this was noisy-but-harmless — but it spammed the log and left four permanently-unavailable entities.

## Fix

Only create the `SentinelCoordinator` when the CONFORT service actually has attributes (a resolvable zone). With no zone, no coordinator and no sentinel/air-quality entities are created — the account behaves like one that never had CONFORT. No empty-zone air-quality call, no failing poll, no warning.

There's no fallback source for the zone: it isn't in `attributes`, isn't in `genericConfig`, and `xSComfort.devices` is empty — so skipping is the only correct option for this account shape.

## Tests

- `test_sentinel_coordinator_skipped_when_no_zone` — regression test for #498 (RED before the fix: the coordinator was created).
- `test_sentinel_coordinator_created_when_zone_present` — locks in the positive case.
- Extended `make_sentinel_service(zone=None)` to reproduce the issue-498 payload (no attributes).

Full suite: 1633 passed. Ruff (lint + format), Pyright (0 errors), Pylint (10.00/10) all clean.