### PR TITLE
fix(auth): reauth only on genuine auth failures, retry transient backend errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
+## v5.2.0
+
+Re-authentication is now reserved for genuine credential problems, and transient Verisure backend hiccups no longer drag you to the login screen.
+
+### Fixed
+
+**Spurious re-auth prompts during backend wobbles ([#502](https://github.com/guerrerotook/securitas-direct-new-api/pull/502)).**  A short Verisure-side outage — an "Invalid session, try again later" (HTTP 403), a 500 on the zones endpoint, or even a server-side crash in the token-refresh call — used to surface as a Home Assistant re-authentication request, even though your username and password were perfectly fine.  The integration now classifies failures: only a genuine auth problem (wrong credentials, a blocked account, 2-factor required, or an explicitly revoked token) triggers a re-auth prompt.  Everything else — server errors, timeouts, WAF blocks, transient session drops — is treated as temporary and simply retried on the next poll, so the integration heals itself once Verisure recovers, with no clicking required.  The password is still never stored on disk; the fix does not reintroduce it.
+
+### Added
+
+**Visible, reportable diagnostics when recovery stalls.**  Because ambiguous failures are now retried indefinitely rather than forcing a re-auth, the logs make it obvious when something is genuinely stuck: after several consecutive transient auth-recovery failures the integration logs an escalating warning — stating that re-auth is being deliberately withheld, how long the trouble has lasted, the exact server response, and a link to file an issue — so a misclassified, truly-dead session can be spotted and reported instead of silently retrying forever.
+
 ## v5.1.2
 
 A bugfix release for Spain (and any market) hitting repeated re-authentication failures since v5.1.0.

--- a/custom_components/securitas/coordinators.py
+++ b/custom_components/securitas/coordinators.py
@@ -36,6 +36,7 @@ from .verisure_owa_api.exceptions import (
     VerisureOwaError,
     SessionExpiredError,
     WAFBlockedError,
+    is_genuine_auth_failure,
 )
 from .verisure_owa_api.models import (
     ActivityEvent,
@@ -127,14 +128,20 @@ class ActivityData:
 
 
 async def _handle_session_expired(client: VerisureOwaClient) -> None:
-    """Attempt to re-login after a SessionExpiredError.
+    """Re-login after a SessionExpiredError, routing by failure type.
 
-    Raises ConfigEntryAuthFailed if re-login fails.
+    Genuine auth failures (bad credentials, account blocked, 2FA, revoked
+    token) raise ConfigEntryAuthFailed to trigger the HA reauth flow. Transient
+    server-side failures raise UpdateFailed so the coordinator retries on the
+    next interval — we never force a reauth prompt for a backend wobble.
     """
     try:
         await client.login()
     except VerisureOwaError as err:
-        raise ConfigEntryAuthFailed(f"Re-authentication failed: {err}") from err
+        if is_genuine_auth_failure(err):
+            raise ConfigEntryAuthFailed(f"Re-authentication failed: {err}") from err
+        client.record_auth_recovery_failure(err)
+        raise UpdateFailed(f"Transient auth error, will retry: {err}") from err
 
 
 async def _fetch_with_session_recovery[T](
@@ -147,6 +154,10 @@ async def _fetch_with_session_recovery[T](
     On SessionExpiredError, re-login then retry once. WAFBlockedError and any
     remaining VerisureOwaError are wrapped as UpdateFailed messages keyed on
     *label* — the human-readable subject for the failure.
+
+    Re-login (on SessionExpiredError) may itself raise ConfigEntryAuthFailed
+    for a genuine credential failure, or UpdateFailed for a transient relogin
+    error — both propagate uncaught.
     """
     try:
         return await fetcher()

--- a/custom_components/securitas/coordinators.py
+++ b/custom_components/securitas/coordinators.py
@@ -137,11 +137,16 @@ async def _handle_session_expired(client: VerisureOwaClient) -> None:
     """
     try:
         await client.login()
-    except VerisureOwaError as err:
-        if is_genuine_auth_failure(err):
-            raise ConfigEntryAuthFailed(f"Re-authentication failed: {err}") from err
-        client.record_auth_recovery_failure(err)
-        raise UpdateFailed(f"Transient auth error, will retry: {err}") from err
+    except (VerisureOwaError, asyncio.TimeoutError) as err:
+        owa_err = (
+            err
+            if isinstance(err, VerisureOwaError)
+            else VerisureOwaError(f"Login timed out: {err!r}")
+        )
+        if is_genuine_auth_failure(owa_err):
+            raise ConfigEntryAuthFailed(f"Re-authentication failed: {owa_err}") from err
+        client.record_auth_recovery_failure(owa_err)
+        raise UpdateFailed(f"Transient auth error, will retry: {owa_err}") from err
 
 
 async def _fetch_with_session_recovery[T](

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.1.2"
+    "version": "5.2.0"
 }

--- a/custom_components/securitas/verisure_owa_api/client/_auth.py
+++ b/custom_components/securitas/verisure_owa_api/client/_auth.py
@@ -117,6 +117,8 @@ class _AuthMixin(_ClientBase):
         else:
             self.login_timestamp = int(datetime.now().timestamp() * 1000)
 
+        self.note_auth_success()
+
     async def refresh_token(self) -> bool:
         """Refresh the authentication token. Returns True on success."""
         content = {
@@ -158,6 +160,7 @@ class _AuthMixin(_ClientBase):
         if refresh_data.get("refreshToken"):
             self._update_refresh_token(refresh_data["refreshToken"])
 
+        self.note_auth_success()
         return True
 
     async def logout(self) -> None:

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -65,6 +65,14 @@ API_CALLBY = "OWA_10"
 API_ID_PREFIX = "OWA_______________"
 ALARM_STATUS_SERVICE_ID = "11"
 
+# Auth-recovery observability. A transient failure on the refresh/login path
+# increments a streak counter; once it reaches the threshold we emit a louder,
+# throttled WARNING so a misclassified dead session stays visible despite HA's
+# UpdateFailed repeat-suppression.
+_AUTH_ESCALATION_THRESHOLD = 3
+_AUTH_ESCALATION_INTERVAL = timedelta(minutes=30)
+_ISSUES_URL = "https://github.com/guerrerotook/securitas-direct-new-api/issues"
+
 # Operations that ARE the authentication — never require auth before calling
 _AUTH_OPERATIONS = frozenset(
     {
@@ -124,6 +132,13 @@ class _ClientBase:
         # concurrent RefreshLogin calls with the same one-time-use refresh
         # token — the server rotates on the first and rejects the rest. See #499.
         self._auth_lock = asyncio.Lock()
+
+        # Auth-recovery streak: consecutive transient failures on the auth
+        # path (refresh/login). Reset on any successful auth. Shared across all
+        # coordinators because they share one client.
+        self.consecutive_auth_recovery_failures: int = 0
+        self._auth_streak_started: datetime | None = None
+        self._last_auth_escalation: datetime | None = None
 
         # Device configuration
         self.device_id: str = device_id
@@ -456,6 +471,58 @@ class _ClientBase:
             _LOGGER.debug("[auth] Auth token expired, logging in again")
             # pylint: disable=no-member  # provided by _AuthMixin
             await self.login()  # type: ignore[attr-defined]
+
+    def note_auth_success(self) -> None:
+        """Reset the auth-recovery streak after a successful authentication."""
+        if self.consecutive_auth_recovery_failures:
+            _LOGGER.info(
+                "Verisure authentication recovered after %d transient failure(s)",
+                self.consecutive_auth_recovery_failures,
+            )
+        self.consecutive_auth_recovery_failures = 0
+        self._auth_streak_started = None
+        self._last_auth_escalation = None
+
+    def record_auth_recovery_failure(self, err: VerisureOwaError) -> None:
+        """Record a transient auth-recovery failure and log it.
+
+        The first failure in a streak logs a WARNING. Once the streak reaches
+        ``_AUTH_ESCALATION_THRESHOLD`` a louder, throttled WARNING explains that
+        reauth is being deliberately withheld and how to report a wrong call.
+        """
+        now = datetime.now()
+        is_first = self.consecutive_auth_recovery_failures == 0
+        if is_first:
+            self._auth_streak_started = now
+        self.consecutive_auth_recovery_failures += 1
+        count = self.consecutive_auth_recovery_failures
+
+        if is_first:
+            _LOGGER.warning(
+                "Verisure auth recovery failed with a transient server error "
+                "(%s); credentials look valid, will retry next poll. NOT forcing "
+                "reauthentication.",
+                err.log_detail(),
+            )
+        elif count >= _AUTH_ESCALATION_THRESHOLD:
+            last = self._last_auth_escalation
+            if last is None or now - last >= _AUTH_ESCALATION_INTERVAL:
+                self._last_auth_escalation = now
+                # _auth_streak_started is always set on the first failure above,
+                # so it is non-None here; `or now` only narrows the Optional type.
+                started = self._auth_streak_started or now
+                minutes = int((now - started).total_seconds() // 60)
+                _LOGGER.warning(
+                    "Verisure session has failed to recover %d times over %d "
+                    "minutes. The errors look transient/server-side so we are "
+                    "deliberately NOT forcing reauthentication. If your Verisure "
+                    "devices remain unavailable, please report this at %s and "
+                    "include this line. Last response: %s",
+                    count,
+                    minutes,
+                    _ISSUES_URL,
+                    err.log_detail(),
+                )
 
     async def _ensure_capabilities(self, installation: Installation) -> None:
         """Check the capabilities token and get a new one if needed."""

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -24,6 +24,7 @@ from ..exceptions import (
     OperationTimeoutError,
     SessionExpiredError,
     VerisureOwaError,
+    _error_code_from_body,
     is_genuine_auth_failure,
 )
 from ..http_transport import HttpTransport
@@ -354,12 +355,7 @@ class _ClientBase:
     @staticmethod
     def _is_account_blocked(result_json: dict[str, Any]) -> bool:
         """Check if a login response indicates the account is blocked (error 60052)."""
-        errors = result_json.get("errors")
-        if isinstance(errors, list) and errors:
-            first = errors[0]
-            if isinstance(first, dict) and isinstance(first.get("data"), dict):
-                return first["data"].get("err") == "60052"
-        return False
+        return _error_code_from_body(result_json) == "60052"
 
     def _extract_otp_data(self, data: Any) -> tuple[str | None, list[OtpPhone]]:
         """Extract OTP hash and phone list from error data."""

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -141,6 +141,7 @@ class _ClientBase:
         self.consecutive_auth_recovery_failures: int = 0
         self._auth_streak_started: datetime | None = None
         self._last_auth_escalation: datetime | None = None
+        self._last_auth_failure: datetime | None = None
 
         # Device configuration
         self.device_id: str = device_id
@@ -496,6 +497,7 @@ class _ClientBase:
         self.consecutive_auth_recovery_failures = 0
         self._auth_streak_started = None
         self._last_auth_escalation = None
+        self._last_auth_failure = None
 
     def record_auth_recovery_failure(self, err: VerisureOwaError) -> None:
         """Record a transient auth-recovery failure and log it.
@@ -505,6 +507,17 @@ class _ClientBase:
         reauth is being deliberately withheld and how to report a wrong call.
         """
         now = datetime.now()
+        # A streak represents *continuous* failures. If the previous failure was
+        # longer ago than the escalation interval, the problem cleared in between
+        # (e.g. polls succeeded on a still-valid token), so start a fresh streak
+        # rather than reporting a count that spans a long idle gap.
+        last_failure = self._last_auth_failure
+        if last_failure is not None and now - last_failure >= _AUTH_ESCALATION_INTERVAL:
+            self.consecutive_auth_recovery_failures = 0
+            self._auth_streak_started = None
+            self._last_auth_escalation = None
+        self._last_auth_failure = now
+
         is_first = self.consecutive_auth_recovery_failures == 0
         if is_first:
             self._auth_streak_started = now

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -24,6 +24,7 @@ from ..exceptions import (
     OperationTimeoutError,
     SessionExpiredError,
     VerisureOwaError,
+    is_genuine_auth_failure,
 )
 from ..http_transport import HttpTransport
 from ..models import Installation, OtpPhone
@@ -465,8 +466,25 @@ class _ClientBase:
                     VerisureOwaError,
                     asyncio.TimeoutError,
                 ) as err:
+                    owa_err = (
+                        err
+                        if isinstance(err, VerisureOwaError)
+                        else VerisureOwaError(str(err))
+                    )
+                    # Genuine token rejection (e.g. err 60067): the refresh
+                    # token is dead -> fall through to login() so a missing
+                    # password surfaces as a clean reauth signal. Transient
+                    # server error (5xx, the xSRefreshLogin crash, a timeout):
+                    # the token is probably fine -> do NOT burn a login attempt;
+                    # record it and propagate so the coordinator retries.
+                    if not is_genuine_auth_failure(owa_err):
+                        self.record_auth_recovery_failure(owa_err)
+                        if isinstance(err, VerisureOwaError):
+                            raise
+                        raise owa_err from err
                     _LOGGER.warning(
-                        "Refresh token error, falling back to login: %s", err
+                        "Refresh token genuinely rejected, falling back to login: %s",
+                        err,
                     )
             _LOGGER.debug("[auth] Auth token expired, logging in again")
             # pylint: disable=no-member  # provided by _AuthMixin

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -466,7 +466,7 @@ class _ClientBase:
                     owa_err = (
                         err
                         if isinstance(err, VerisureOwaError)
-                        else VerisureOwaError(str(err))
+                        else VerisureOwaError(f"Token refresh failed: {err!r}")
                     )
                     # Genuine token rejection (e.g. err 60067): the refresh
                     # token is dead -> fall through to login() so a missing

--- a/custom_components/securitas/verisure_owa_api/exceptions.py
+++ b/custom_components/securitas/verisure_owa_api/exceptions.py
@@ -132,9 +132,14 @@ class UnexpectedStateError(VerisureOwaError):
 _GENUINE_AUTH_ERROR_CODES: frozenset[str] = frozenset({"60052", "60067"})
 
 
-def _error_code(err: VerisureOwaError) -> str | None:
-    """Best-effort extraction of the vendor ``err`` code from a response body."""
-    body = err.response_body
+def _error_code_from_body(body: object) -> str | None:
+    """Extract the vendor ``err`` code from a GraphQL response-body dict.
+
+    Walks ``body["errors"][0]["data"]["err"]`` defensively, returning the code
+    as a string (the server sends strings) or ``None`` if absent/malformed.
+    Shared by ``_error_code`` (error-object form) and the auth client's
+    account-blocked check (raw-response form).
+    """
     if not isinstance(body, dict):
         return None
     errors = body.get("errors")
@@ -144,6 +149,11 @@ def _error_code(err: VerisureOwaError) -> str | None:
             code = data.get("err")
             return str(code) if code is not None else None
     return None
+
+
+def _error_code(err: VerisureOwaError) -> str | None:
+    """Best-effort extraction of the vendor ``err`` code from an error object."""
+    return _error_code_from_body(err.response_body)
 
 
 def is_genuine_auth_failure(err: VerisureOwaError) -> bool:

--- a/custom_components/securitas/verisure_owa_api/exceptions.py
+++ b/custom_components/securitas/verisure_owa_api/exceptions.py
@@ -125,3 +125,38 @@ class UnexpectedStateError(VerisureOwaError):
     def __init__(self, proto_code: str) -> None:
         self.proto_code = proto_code
         super().__init__(f"Unexpected protocol code: {proto_code!r}")
+
+
+# Vendor error codes that genuinely require re-authentication:
+# 60052 = account blocked; 60067 = invalid/expired session on refresh.
+_GENUINE_AUTH_ERROR_CODES: frozenset[str] = frozenset({"60052", "60067"})
+
+
+def _error_code(err: VerisureOwaError) -> str | None:
+    """Best-effort extraction of the vendor ``err`` code from a response body."""
+    body = err.response_body
+    if not isinstance(body, dict):
+        return None
+    errors = body.get("errors")
+    if isinstance(errors, list) and errors and isinstance(errors[0], dict):
+        data = errors[0].get("data")
+        if isinstance(data, dict):
+            code = data.get("err")
+            return str(code) if code is not None else None
+    return None
+
+
+def is_genuine_auth_failure(err: VerisureOwaError) -> bool:
+    """True only for failures that genuinely require re-authentication.
+
+    Genuine (-> reauth): credential rejection, account blocked, 2FA required,
+    or an explicitly invalid/revoked token (err 60052 / 60067).
+
+    Everything else -- 5xx, 409, network/timeout, WAF blocks, a bare HTTP 403
+    "try again later" session error, and unrecognised null-data GraphQL errors
+    such as the xSRefreshLogin server crash -- is transient and must NOT trigger
+    a reauth prompt. Unknown failures default to transient (retry forever).
+    """
+    if isinstance(err, (AuthenticationError, TwoFactorRequiredError)):
+        return True
+    return _error_code(err) in _GENUINE_AUTH_ERROR_CODES

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -476,3 +476,50 @@ class TestRefreshTokenEdgeCases:
 
         api.refresh_token.assert_awaited_once()
         api.login.assert_awaited_once()
+
+
+# ── Auth-recovery streak counter ─────────────────────────────────────────────
+
+
+class TestAuthRecoveryStreak:
+    def test_starts_at_zero(self, api):
+        assert api.consecutive_auth_recovery_failures == 0
+
+    def test_record_increments_and_warns_first_time(self, api, caplog):
+        with caplog.at_level("WARNING"):
+            api.record_auth_recovery_failure(VerisureOwaError("boom", http_status=500))
+        assert api.consecutive_auth_recovery_failures == 1
+        assert "NOT forcing reauthentication" in caplog.text
+
+    def test_escalates_at_threshold_with_report_url(self, api, caplog):
+        with caplog.at_level("WARNING"):
+            for _ in range(3):
+                api.record_auth_recovery_failure(
+                    VerisureOwaError("boom", http_status=500)
+                )
+        assert api.consecutive_auth_recovery_failures == 3
+        assert "github.com/guerrerotook/securitas-direct-new-api/issues" in caplog.text
+        assert "3 times" in caplog.text
+
+    def test_escalation_is_throttled(self, api, caplog):
+        with caplog.at_level("WARNING"):
+            for _ in range(10):
+                api.record_auth_recovery_failure(
+                    VerisureOwaError("boom", http_status=500)
+                )
+        escalations = caplog.text.count("deliberately NOT forcing")
+        assert escalations == 1
+
+    def test_note_success_resets_and_logs_recovery(self, api, caplog):
+        for _ in range(3):
+            api.record_auth_recovery_failure(VerisureOwaError("boom", http_status=500))
+        with caplog.at_level("INFO"):
+            api.note_auth_success()
+        assert api.consecutive_auth_recovery_failures == 0
+        assert "recovered after 3 transient" in caplog.text
+
+    def test_note_success_noop_when_no_streak(self, api, caplog):
+        with caplog.at_level("INFO"):
+            api.note_auth_success()
+        assert api.consecutive_auth_recovery_failures == 0
+        assert "recovered after" not in caplog.text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -266,6 +266,21 @@ class TestCheckAuthenticationToken:
         api.login.assert_not_called()
         assert api.consecutive_auth_recovery_failures == 1
 
+    async def test_timeout_wrapped_with_descriptive_message(self, api):
+        """A bare asyncio.TimeoutError is wrapped with a non-empty, descriptive
+        message so the propagated error and streak log are actionable."""
+        api.authentication_token = FAKE_JWT
+        api.authentication_token_exp = datetime.min
+        api.refresh_token_value = "has-refresh-token"
+        api.refresh_token = AsyncMock(side_effect=asyncio.TimeoutError())
+        api.login = AsyncMock()
+
+        with pytest.raises(VerisureOwaError) as exc_info:
+            await api._check_authentication_token()
+
+        assert str(exc_info.value)  # non-empty
+        assert "TimeoutError" in str(exc_info.value)
+
     async def test_expired_token_no_refresh_value_calls_login(self, api):
         api.authentication_token = FAKE_JWT
         api.authentication_token_exp = datetime.min

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for VerisureOwaClient authentication flow."""
 
+import asyncio
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock
 
@@ -8,6 +9,7 @@ import pytest
 from custom_components.securitas.verisure_owa_api.exceptions import (
     AccountBlockedError,
     AuthenticationError,
+    SessionExpiredError,
     VerisureOwaError,
     TwoFactorRequiredError,
 )
@@ -215,17 +217,54 @@ class TestCheckAuthenticationToken:
         api.refresh_token.assert_awaited_once()
         api.login.assert_awaited_once()
 
-    async def test_expired_token_refresh_exception_falls_back_to_login(self, api):
+    async def test_transient_refresh_exception_propagates_no_login(self, api):
+        """A transient server error during refresh must NOT fall back to login
+        (which would launder it into a 'no password' credential failure).
+        It propagates so the coordinator retries next poll."""
         api.authentication_token = FAKE_JWT
         api.authentication_token_exp = datetime.min
         api.refresh_token_value = "has-refresh-token"
-        api.refresh_token = AsyncMock(side_effect=VerisureOwaError("boom"))
+        api.refresh_token = AsyncMock(
+            side_effect=VerisureOwaError("boom", http_status=500)
+        )
+        api.login = AsyncMock()
+
+        with pytest.raises(VerisureOwaError):
+            await api._check_authentication_token()
+
+        api.login.assert_not_called()
+        assert api.consecutive_auth_recovery_failures == 1
+
+    async def test_genuine_refresh_exception_falls_back_to_login(self, api):
+        """A genuine token rejection (err 60067) falls back to login so a dead
+        token surfaces as a clean reauth signal."""
+        api.authentication_token = FAKE_JWT
+        api.authentication_token_exp = datetime.min
+        api.refresh_token_value = "has-refresh-token"
+        genuine = SessionExpiredError("Invalid Session", http_status=403)
+        genuine.response_body = {"errors": [{"data": {"err": "60067"}}]}
+        api.refresh_token = AsyncMock(side_effect=genuine)
         api.login = AsyncMock()
 
         await api._check_authentication_token()
 
-        api.refresh_token.assert_awaited_once()
         api.login.assert_awaited_once()
+        assert api.consecutive_auth_recovery_failures == 0
+
+    async def test_timeout_refresh_exception_propagates_as_owa_error(self, api):
+        """A raw asyncio.TimeoutError during refresh is wrapped as a
+        VerisureOwaError and propagated (transient), not funneled into login."""
+        api.authentication_token = FAKE_JWT
+        api.authentication_token_exp = datetime.min
+        api.refresh_token_value = "has-refresh-token"
+        api.refresh_token = AsyncMock(side_effect=asyncio.TimeoutError())
+        api.login = AsyncMock()
+
+        with pytest.raises(VerisureOwaError):
+            await api._check_authentication_token()
+
+        api.login.assert_not_called()
+        assert api.consecutive_auth_recovery_failures == 1
 
     async def test_expired_token_no_refresh_value_calls_login(self, api):
         api.authentication_token = FAKE_JWT
@@ -464,18 +503,20 @@ class TestValidateDeviceEdgeCases:
 
 
 class TestRefreshTokenEdgeCases:
-    async def test_refresh_token_after_expired_calls_login(self, api):
-        """When refresh fails and token is expired, falls back to login."""
+    async def test_transient_refresh_error_propagates_no_login(self, api):
+        """A bare VerisureOwaError from refresh (no err code) is transient —
+        must propagate instead of falling back to login."""
         api.authentication_token = FAKE_JWT
         api.authentication_token_exp = datetime.min  # expired
         api.refresh_token_value = "some-refresh-token"
         api.refresh_token = AsyncMock(side_effect=VerisureOwaError("Refresh failed"))
         api.login = AsyncMock()
 
-        await api._check_authentication_token()
+        with pytest.raises(VerisureOwaError):
+            await api._check_authentication_token()
 
         api.refresh_token.assert_awaited_once()
-        api.login.assert_awaited_once()
+        api.login.assert_not_called()
 
 
 # ── Auth-recovery streak counter ─────────────────────────────────────────────

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -565,6 +565,31 @@ class TestAuthRecoveryStreak:
         assert api.consecutive_auth_recovery_failures == 0
         assert "recovered after" not in caplog.text
 
+    def test_stale_streak_decays_to_fresh(self, api, caplog, monkeypatch):
+        """A new failure long after the previous one starts a fresh streak,
+        not a misleading high count spanning the idle gap."""
+        # Seed a partial streak as if 2 failures happened, last one ~hours ago.
+        api.consecutive_auth_recovery_failures = 2
+        api._auth_streak_started = datetime.now() - timedelta(hours=3)
+        api._last_auth_failure = datetime.now() - timedelta(hours=3)
+
+        with caplog.at_level("WARNING"):
+            api.record_auth_recovery_failure(VerisureOwaError("boom", http_status=500))
+
+        # Treated as a fresh first failure, not count==3 escalation.
+        assert api.consecutive_auth_recovery_failures == 1
+        assert "deliberately NOT forcing" not in caplog.text
+
+    def test_continuous_failures_still_escalate(self, api, caplog):
+        """Back-to-back failures (no idle gap) still accumulate and escalate."""
+        with caplog.at_level("WARNING"):
+            for _ in range(3):
+                api.record_auth_recovery_failure(
+                    VerisureOwaError("boom", http_status=500)
+                )
+        assert api.consecutive_auth_recovery_failures == 3
+        assert "deliberately NOT forcing" in caplog.text
+
 
 class TestStreakResetOnSuccess:
     async def test_refresh_success_resets_streak(self, api, mock_execute):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -523,3 +523,22 @@ class TestAuthRecoveryStreak:
             api.note_auth_success()
         assert api.consecutive_auth_recovery_failures == 0
         assert "recovered after" not in caplog.text
+
+
+class TestStreakResetOnSuccess:
+    async def test_refresh_success_resets_streak(self, api, mock_execute):
+        api.consecutive_auth_recovery_failures = 4
+        mock_execute.return_value = refresh_response()
+
+        ok = await api.refresh_token()
+
+        assert ok is True
+        assert api.consecutive_auth_recovery_failures == 0
+
+    async def test_login_success_resets_streak(self, api, mock_execute):
+        api.consecutive_auth_recovery_failures = 4
+        mock_execute.return_value = login_response()
+
+        await api.login()
+
+        assert api.consecutive_auth_recovery_failures == 0

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -280,6 +280,25 @@ class TestAlarmCoordinator:
         assert result.status is status
         client.login.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_session_expired_login_timeout_raises_update_failed(self):
+        """A raw asyncio.TimeoutError from relogin is treated as transient
+        (UpdateFailed + recorded), not an uncaught traceback or reauth."""
+        import asyncio as _asyncio
+
+        hass = _make_hass()
+        client = _make_client()
+        queue = _make_queue()
+        installation = _make_installation()
+
+        client.get_general_status.side_effect = SessionExpiredError("expired")
+        client.login.side_effect = _asyncio.TimeoutError()
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        with pytest.raises(UpdateFailed):
+            await coord._async_update_data()
+        client.record_auth_recovery_failure.assert_called_once()
+
 
 # ── SentinelCoordinator ──────────────────────────────────────────────────────
 

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -29,6 +29,7 @@ from custom_components.securitas.verisure_owa_api.client import (
     VerisureOwaClient,
 )
 from custom_components.securitas.verisure_owa_api.exceptions import (
+    AuthenticationError,
     VerisureOwaError,
     SessionExpiredError,
     WAFBlockedError,
@@ -135,21 +136,40 @@ class TestAlarmCoordinator:
             await coord._async_update_data()
 
     @pytest.mark.asyncio
-    async def test_session_expired_retries_login_then_auth_failed(self):
-        """SessionExpiredError retries login; if login fails, raises ConfigEntryAuthFailed."""
+    async def test_session_expired_genuine_login_failure_raises_auth_failed(self):
+        """A genuine auth failure on relogin raises ConfigEntryAuthFailed (reauth)."""
         hass = _make_hass()
         client = _make_client()
         queue = _make_queue()
         installation = _make_installation()
 
         client.get_general_status.side_effect = SessionExpiredError("expired")
-        client.login.side_effect = VerisureOwaError("login failed")
+        client.login.side_effect = AuthenticationError("credentials rejected")
 
         coord = self._make_coordinator(hass, client, queue, installation)
         with pytest.raises(ConfigEntryAuthFailed):
             await coord._async_update_data()
-
         client.login.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_session_expired_transient_login_failure_raises_update_failed(self):
+        """A transient server error on relogin raises UpdateFailed, NOT reauth,
+        and records the failure on the client for visibility."""
+        hass = _make_hass()
+        client = _make_client()
+        queue = _make_queue()
+        installation = _make_installation()
+
+        client.get_general_status.side_effect = SessionExpiredError("expired")
+        client.login.side_effect = VerisureOwaError(
+            "server crash", http_status=500
+        )  # any non-genuine (transient) error -> retry, not reauth
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        with pytest.raises(UpdateFailed):
+            await coord._async_update_data()
+        client.login.assert_awaited_once()
+        client.record_auth_recovery_failure.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_session_expired_retry_succeeds(self):
@@ -422,14 +442,14 @@ class TestLockCoordinator:
 
     @pytest.mark.asyncio
     async def test_session_expired_retries_login_then_auth_failed(self):
-        """SessionExpiredError retries login; login failure raises ConfigEntryAuthFailed."""
+        """SessionExpiredError retries login; genuine auth failure raises ConfigEntryAuthFailed."""
         hass = _make_hass()
         client = _make_client()
         queue = _make_queue()
         installation = _make_installation()
 
         client.get_lock_modes.side_effect = SessionExpiredError("expired")
-        client.login.side_effect = VerisureOwaError("login failed")
+        client.login.side_effect = AuthenticationError("credentials rejected")
 
         coord = self._make_coordinator(hass, client, queue, installation)
         with pytest.raises(ConfigEntryAuthFailed):
@@ -1360,7 +1380,7 @@ class TestActivityCoordinator:
         installation = _make_installation()
 
         client.get_activity.side_effect = SessionExpiredError("expired")
-        client.login.side_effect = VerisureOwaError("login failed")
+        client.login.side_effect = AuthenticationError("credentials rejected")
 
         coord = self._make_coordinator(hass, client, queue, installation)
         with pytest.raises(ConfigEntryAuthFailed):

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -230,6 +230,56 @@ class TestAlarmCoordinator:
 
         assert "WAF blocked" in str(exc_info.value)
 
+    @pytest.mark.asyncio
+    async def test_2026_06_02_outage_signals_do_not_force_reauth(self):
+        """Replay the production outage: a 403 'try again later' on the fetch,
+        then a transient xSRefreshLogin JS-crash on relogin. Must be UpdateFailed
+        (retry), never ConfigEntryAuthFailed."""
+        hass = _make_hass()
+        client = _make_client()
+        queue = _make_queue()
+        installation = _make_installation()
+
+        client.get_general_status.side_effect = SessionExpiredError(
+            "Invalid session. Please, try again later.", http_status=403
+        )
+        js_crash = VerisureOwaError(
+            "Cannot read properties of undefined (reading 'it')"
+        )
+        js_crash.response_body = {
+            "errors": [
+                {"message": "Cannot read properties of undefined (reading 'it')"}
+            ],
+            "data": {"xSRefreshLogin": None},
+        }
+        client.login.side_effect = js_crash
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        with pytest.raises(UpdateFailed):
+            await coord._async_update_data()
+        client.record_auth_recovery_failure.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_outage_then_recovery_succeeds(self):
+        """After a transient relogin failure, the next poll recovers cleanly."""
+        hass = _make_hass()
+        client = _make_client()
+        queue = _make_queue()
+        installation = _make_installation()
+
+        status = SStatus(status="0")
+        client.get_general_status.side_effect = [
+            SessionExpiredError("expired"),  # poll 1: triggers recovery
+            status,  # poll 1 retry after successful login
+        ]
+        client.login.return_value = None  # login succeeds this time
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        result = await coord._async_update_data()
+
+        assert result.status is status
+        client.login.assert_awaited_once()
+
 
 # ── SentinelCoordinator ──────────────────────────────────────────────────────
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.securitas.verisure_owa_api.exceptions import (
     APIConnectionError,
     APIResponseError,
+    AccountBlockedError,
     ArmingExceptionError,
     AuthenticationError,
     ImageCaptureError,
@@ -17,6 +18,7 @@ from custom_components.securitas.verisure_owa_api.exceptions import (
     TwoFactorRequiredError,
     UnexpectedStateError,
     WAFBlockedError,
+    is_genuine_auth_failure,
 )
 
 
@@ -215,3 +217,59 @@ class TestLogDetail:
         assert err.log_detail() == "late body"
         err.response_body = {"raw": "data"}
         assert "raw" in err.log_detail()
+
+
+# ── is_genuine_auth_failure ───────────────────────────────────────────────────
+
+
+def _with_err_code(err: VerisureOwaError, code: str) -> VerisureOwaError:
+    err.response_body = {"errors": [{"message": "x", "data": {"err": code}}]}
+    return err
+
+
+class TestIsGenuineAuthFailure:
+    def test_authentication_error_is_genuine(self):
+        assert is_genuine_auth_failure(AuthenticationError("bad creds")) is True
+
+    def test_account_blocked_is_genuine(self):
+        assert is_genuine_auth_failure(AccountBlockedError("blocked")) is True
+
+    def test_two_factor_required_is_genuine(self):
+        assert is_genuine_auth_failure(TwoFactorRequiredError("2fa")) is True
+
+    def test_err_60052_account_blocked_code_is_genuine(self):
+        err = _with_err_code(VerisureOwaError("blocked"), "60052")
+        assert is_genuine_auth_failure(err) is True
+
+    def test_err_60067_invalid_session_code_is_genuine(self):
+        err = _with_err_code(
+            SessionExpiredError("Invalid Session", http_status=403), "60067"
+        )
+        assert is_genuine_auth_failure(err) is True
+
+    def test_bare_403_session_expired_is_transient(self):
+        err = SessionExpiredError(
+            "Invalid session. Please, try again later.", http_status=403
+        )
+        assert is_genuine_auth_failure(err) is False
+
+    def test_500_server_error_is_transient(self):
+        assert (
+            is_genuine_auth_failure(VerisureOwaError("boom", http_status=500)) is False
+        )
+
+    def test_waf_block_is_transient(self):
+        assert is_genuine_auth_failure(WAFBlockedError("blocked")) is False
+
+    def test_js_crash_null_data_is_transient(self):
+        err = VerisureOwaError("Cannot read properties of undefined (reading 'it')")
+        err.response_body = {
+            "errors": [
+                {"message": "Cannot read properties of undefined (reading 'it')"}
+            ],
+            "data": {"xSRefreshLogin": None},
+        }
+        assert is_genuine_auth_failure(err) is False
+
+    def test_unknown_error_defaults_to_transient(self):
+        assert is_genuine_auth_failure(VerisureOwaError("mystery")) is False

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,6 +18,7 @@ from custom_components.securitas.verisure_owa_api.exceptions import (
     TwoFactorRequiredError,
     UnexpectedStateError,
     WAFBlockedError,
+    _error_code_from_body,
     is_genuine_auth_failure,
 )
 
@@ -273,3 +274,14 @@ class TestIsGenuineAuthFailure:
 
     def test_unknown_error_defaults_to_transient(self):
         assert is_genuine_auth_failure(VerisureOwaError("mystery")) is False
+
+
+# ── _error_code_from_body ─────────────────────────────────────────────────────
+
+
+def test_error_code_from_body_extracts_and_stringifies():
+    assert _error_code_from_body({"errors": [{"data": {"err": "60052"}}]}) == "60052"
+    assert _error_code_from_body({"errors": [{"data": {"err": 60052}}]}) == "60052"
+    assert _error_code_from_body({"errors": []}) is None
+    assert _error_code_from_body("nope") is None
+    assert _error_code_from_body({"errors": [{"message": "x"}]}) is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -229,35 +229,33 @@ class TestPollOperation:
 
 
 class TestCheckAuthenticationTokenErrorHandling:
-    async def test_falls_back_to_login_on_verisure_owa_error(self, api):
-        """Should fall back to login() when refresh raises VerisureOwaError."""
+    async def test_transient_refresh_error_propagates_no_login(self, api):
+        """A transient refresh error (bare VerisureOwaError) propagates instead
+        of falling back to login(), and is recorded for visibility."""
         api.authentication_token = None
         api.refresh_token_value = "some-refresh-token"
         api.refresh_token = AsyncMock(side_effect=VerisureOwaError("refresh failed"))
         api.login = AsyncMock()
 
-        await api._check_authentication_token()
-        api.login.assert_called_once()
+        with pytest.raises(VerisureOwaError):
+            await api._check_authentication_token()
 
-    async def test_falls_back_to_login_on_timeout(self, api):
-        """Should fall back to login() when refresh raises asyncio.TimeoutError."""
+        api.login.assert_not_called()
+        assert api.consecutive_auth_recovery_failures == 1
+
+    async def test_timeout_refresh_error_propagates_no_login(self, api):
+        """A raw asyncio.TimeoutError during refresh is wrapped as a
+        VerisureOwaError and propagated (transient), not funneled into login."""
         api.authentication_token = None
         api.refresh_token_value = "some-refresh-token"
         api.refresh_token = AsyncMock(side_effect=asyncio.TimeoutError())
         api.login = AsyncMock()
 
-        await api._check_authentication_token()
-        api.login.assert_called_once()
+        with pytest.raises(VerisureOwaError):
+            await api._check_authentication_token()
 
-    async def test_falls_back_to_login_on_timeout_error(self, api):
-        """Should fall back to login() when refresh raises asyncio.TimeoutError."""
-        api.authentication_token = None
-        api.refresh_token_value = "some-refresh-token"
-        api.refresh_token = AsyncMock(side_effect=asyncio.TimeoutError("timeout"))
-        api.login = AsyncMock()
-
-        await api._check_authentication_token()
-        api.login.assert_called_once()
+        api.login.assert_not_called()
+        assert api.consecutive_auth_recovery_failures == 1
 
     async def test_does_not_catch_unexpected_exceptions(self, api):
         """Should NOT catch unexpected exceptions like ValueError."""


### PR DESCRIPTION
## Summary

Stops the integration from forcing a Home Assistant reauth prompt when Verisure's backend has a transient wobble. Reauth is now triggered **only** for positively-identified genuine auth failures; every transient/ambiguous error is retried on the next poll and self-heals.

Motivated by a production incident (2026-06-02): an ~8-minute backend disturbance — HTTP 403 `"Invalid session. Please, try again later."`, 500s on `sbn_get_zones`, and a server-side JS crash (`Cannot read properties of undefined (reading 'it')`) on the refresh-login mutation — forced two separate manual reauths even though credentials were valid. Once the backend recovered, the integration ran cleanly with no config change.

## What changed

- **New classifier** `is_genuine_auth_failure(err)` (single source of truth): genuine = `AuthenticationError` / `AccountBlockedError` / `TwoFactorRequiredError` or vendor err code `60052`/`60067`; everything else (5xx, 409, network/timeout, WAF, bare 403 "try again later", JS-crash null-data, unknown) is transient. Unknown defaults to transient.
- **`_check_authentication_token`** no longer launders a transient refresh error into a fake "no password" credential failure — transient refresh errors are recorded and propagated (retry), genuine token rejections still fall back to `login()`.
- **`_handle_session_expired`** routes by classification: genuine → `ConfigEntryAuthFailed` (reauth), transient → `UpdateFailed` (retry next poll).
- **Observability** (so a *misclassification* stays visible despite HA's `UpdateFailed` repeat-suppression): a shared client streak counter with a first-failure WARNING, a throttled escalation WARNING (≥3 consecutive, ≤once/30min, includes the issues URL + last server response) that explicitly states reauth is being withheld, a recovery INFO, reset on successful auth, and time-decay so the escalation copy never spans an idle gap.
- Kept refresh-token-only storage (no password persisted; no "encrypted password" — an on-disk key would defeat the minimize-secrets principle and re-expose the reusable credential).
- Refactor: shared `_error_code_from_body` extractor between the classifier and the account-blocked check (removes duplication).

## Test plan

- [x] New TDD tests: classifier taxonomy (`test_exceptions.py`), streak counter + escalation + decay (`test_auth.py`), transient-propagation (`test_auth.py`), coordinator routing (`test_coordinators.py`).
- [x] Regression test replaying the exact 2026-06-02 signals → asserts `UpdateFailed`, never `ConfigEntryAuthFailed`, then clean recovery.
- [x] Updated stale tests that encoded the old login-fallback / any-error-reauth behavior.
- [x] Full suite: **1658 passed, 0 failed**. Ruff clean, Pyright 0 errors, Pylint 10.00/10.