### PR TITLE
feat: suggest cards in HA 2026.6 card picker via getEntitySuggestion

### DIFF
--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -316,6 +316,23 @@ export function hassLang(hass) {
   return hass?.locale?.language || hass?.language || "en";
 }
 
+// Entity registry platform this integration registers entities under. The
+// domain is `securitas` (a rename to `verisure_owa` was reversed before
+// release, so no install ever uses it).
+const _OUR_PLATFORMS = new Set(["securitas"]);
+
+// Card-picker suggestion hook: offer this card when the user selects one of our
+// activity-log sensors (identified by their `events` attribute array, the same
+// shape the editor detects).
+export function activityLogEntitySuggestion(hass, entityId) {
+  if (!entityId.startsWith("sensor.")) return null;
+  if (!_OUR_PLATFORMS.has(hass?.entities?.[entityId]?.platform)) return null;
+  if (!Array.isArray(hass?.states?.[entityId]?.attributes?.events)) return null;
+  return {
+    config: { type: "custom:verisure-owa-activity-log-card", entity: entityId },
+  };
+}
+
 const _RTF_CACHE = new Map();
 function _rtf(lang) {
   let f = _RTF_CACHE.get(lang);
@@ -1150,6 +1167,7 @@ if (!window.customCards.find((c) => c.type === "verisure-owa-activity-log-card")
     name: "Verisure OWA Activity Log Card",
     description: "Shows recent activity log entries from a Verisure OWA installation.",
     preview: false,
+    getEntitySuggestion: activityLogEntitySuggestion,
     documentationURL:
       "https://github.com/guerrerotook/securitas-direct-new-api",
   });

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -255,6 +255,22 @@ export function defaultArmState(hass, entityId, configStates) {
   return pool.length > 0 ? pool[0].key : "arm_away";
 }
 
+// Entity registry platform this integration registers entities under. The
+// domain is `securitas` (a rename to `verisure_owa` was reversed before
+// release, so no install ever uses it).
+const _OUR_PLATFORMS = new Set(["securitas"]);
+
+// Card-picker suggestion hook: when the user selects one of our alarm panels,
+// offer both the full card and the compact chip as variants.
+export function alarmEntitySuggestion(hass, entityId) {
+  if (!entityId.startsWith("alarm_control_panel.")) return null;
+  if (!_OUR_PLATFORMS.has(hass?.entities?.[entityId]?.platform)) return null;
+  return [
+    { config: { type: "custom:verisure-owa-alarm-card", entity: entityId } },
+    { config: { type: "custom:verisure-owa-alarm-chip", entity: entityId } },
+  ];
+}
+
 /**
  * Attaches pointer-based gesture listeners to `el`.
  *
@@ -714,7 +730,7 @@ class VerisureOwaAlarmCard extends HTMLElement {
 
     // Arm / Disarm / Refresh buttons
     this.shadowRoot.querySelectorAll("[data-action]").forEach(btn => {
-      btn.addEventListener("click", (e) => {
+      btn.addEventListener("click", () => {
         const action = btn.dataset.action;
         this._handleAction(action, stateObj, codeFormat, codeArmRequired, hasCode, isArmed, entity);
       });
@@ -1703,7 +1719,6 @@ class VerisureOwaAlarmBadge extends HTMLElement {
   _renderBadge() {
     if (!this._hass || !this._config) return;
 
-    const lang = this._hass.language || "en";
     const stateObj = this._hass.states[this._config.entity];
     if (!stateObj) {
       this.shadowRoot.innerHTML = `<ha-icon icon="mdi:shield-alert" style="color:var(--error-color)"></ha-icon>`;
@@ -2141,6 +2156,7 @@ if (!window.customCards.find(c => c.type === "verisure-owa-alarm-card")) {
     name:        TRANSLATIONS.en.card_name,
     description: TRANSLATIONS.en.card_description,
     preview:     false,
+    getEntitySuggestion: alarmEntitySuggestion,
   });
 }
 if (!window.customCards.find(c => c.type === "verisure-owa-alarm-chip")) {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -115,7 +115,9 @@ const _t = (lang, key, vars) => formatTranslation(lang, TRANSLATIONS, key, vars)
 // The (_\d+)? captures HA's auto-disambiguation suffix (_2, _3, ...)
 // when multiple installations produce the same default entity_id.
 const _FULL_IMAGE_ENTITY_ID_RE = /^camera\..*_full_image(_\d+)?$/;
-const _OUR_PLATFORMS = new Set(["securitas", "verisure_owa"]);
+// The integration domain is `securitas` (a rename to `verisure_owa` was
+// considered but reversed before release, so no install ever uses it).
+const _OUR_PLATFORMS = new Set(["securitas"]);
 
 export function findFullImageEntityIds(hass) {
   const ids = [];
@@ -124,6 +126,15 @@ export function findFullImageEntityIds(hass) {
     if (_FULL_IMAGE_ENTITY_ID_RE.test(eid)) ids.push(eid);
   }
   return ids;
+}
+
+// Card-picker suggestion hook: offer this card when the user selects one of our
+// camera entities (excluding the internal `_full_image` snapshot cameras).
+export function cameraEntitySuggestion(hass, entityId) {
+  if (!entityId.startsWith("camera.")) return null;
+  if (!_OUR_PLATFORMS.has(hass?.entities?.[entityId]?.platform)) return null;
+  if (_FULL_IMAGE_ENTITY_ID_RE.test(entityId)) return null;
+  return { config: { type: "custom:verisure-owa-camera-card", entity: entityId } };
 }
 
 class VerisureOwaCameraCardEditor extends HTMLElement {
@@ -521,6 +532,7 @@ if (!window.customCards.find(c => c.type === "verisure-owa-camera-card")) {
     name: TRANSLATIONS.en.card_name,
     description: TRANSLATIONS.en.card_description,
     preview: false,
+    getEntitySuggestion: cameraEntitySuggestion,
   });
 }
 /* v8 ignore stop */

--- a/tests-js/integration/camera-card-editor.test.js
+++ b/tests-js/integration/camera-card-editor.test.js
@@ -24,10 +24,13 @@ describe("verisure-owa-camera-card-editor", () => {
         "camera.back_yard_full_image_2": makeCameraEntity(),
       },
       entities: {
-        "camera.front_door": { platform: "verisure_owa" },
-        "camera.front_door_full_image": { platform: "verisure_owa" },
+        "camera.front_door": { platform: "securitas" },
+        "camera.front_door_full_image": { platform: "securitas" },
         "camera.back_yard": { platform: "securitas" },
         "camera.back_yard_full_image_2": { platform: "securitas" },
+        // A full-image camera from another integration must NOT be excluded —
+        // only entities on our domain (securitas) count.
+        "camera.neighbour_full_image": { platform: "generic" },
       },
     });
     document.body.appendChild(editor);
@@ -39,7 +42,7 @@ describe("verisure-owa-camera-card-editor", () => {
     const [field] = entityForm.schema;
     expect(field.name).toBe("entity");
     expect(field.selector.entity.domain).toBe("camera");
-    // Both full-image variants (one per supported platform alias) must be excluded.
+    // Both of our full-image variants must be excluded; the foreign one must not.
     expect(field.selector.entity.exclude_entities).toEqual(
       expect.arrayContaining(["camera.front_door_full_image", "camera.back_yard_full_image_2"]),
     );
@@ -54,7 +57,7 @@ describe("verisure-owa-camera-card-editor", () => {
     editor.setConfig({});
     editor.hass = makeHass({
       states: { "camera.front_door": makeCameraEntity() },
-      entities: { "camera.front_door": { platform: "verisure_owa" } },
+      entities: { "camera.front_door": { platform: "securitas" } },
     });
     document.body.appendChild(editor);
 
@@ -72,7 +75,7 @@ describe("verisure-owa-camera-card-editor", () => {
     editor.setConfig({});
     editor.hass = makeHass({
       states: { "camera.front_door": makeCameraEntity() },
-      entities: { "camera.front_door": { platform: "verisure_owa" } },
+      entities: { "camera.front_door": { platform: "securitas" } },
     });
     document.body.appendChild(editor);
 

--- a/tests-js/integration/camera-card.test.js
+++ b/tests-js/integration/camera-card.test.js
@@ -203,8 +203,8 @@ describe("verisure-owa-camera-card click → more-info", () => {
         },
       },
       entities: {
-        [ENTITY]: { device_id: "dev1", platform: "verisure_owa" },
-        [FULL]: { device_id: "dev1", platform: "verisure_owa" },
+        [ENTITY]: { device_id: "dev1", platform: "securitas" },
+        [FULL]: { device_id: "dev1", platform: "securitas" },
       },
     });
     const card = mountCameraCard({ hass });
@@ -219,7 +219,7 @@ describe("verisure-owa-camera-card click → more-info", () => {
   it("uses the device's name_by_user as display name when no config.name", () => {
     const hass = makeHass({
       states: { [ENTITY]: makeCameraEntity() },
-      entities: { [ENTITY]: { device_id: "dev1", platform: "verisure_owa" } },
+      entities: { [ENTITY]: { device_id: "dev1", platform: "securitas" } },
       devices: { dev1: { name: "Camera", name_by_user: "Front Hall" } },
     });
     const card = mountCameraCard({ hass });
@@ -229,7 +229,7 @@ describe("verisure-owa-camera-card click → more-info", () => {
   it("falls back to device.name when name_by_user is unset", () => {
     const hass = makeHass({
       states: { [ENTITY]: makeCameraEntity() },
-      entities: { [ENTITY]: { device_id: "dev1", platform: "verisure_owa" } },
+      entities: { [ENTITY]: { device_id: "dev1", platform: "securitas" } },
       devices: { dev1: { name: "Hallway" } },
     });
     const card = mountCameraCard({ hass });
@@ -303,7 +303,7 @@ describe("verisure-owa-camera-card-editor name field", () => {
     editor.setConfig({ entity: "camera.front_door" });
     editor.hass = makeHass({
       states: { "camera.front_door": makeCameraEntity() },
-      entities: { "camera.front_door": { platform: "verisure_owa" } },
+      entities: { "camera.front_door": { platform: "securitas" } },
     });
     document.body.appendChild(editor);
 
@@ -325,7 +325,7 @@ describe("verisure-owa-camera-card-editor name field", () => {
     editor.setConfig({ entity: "camera.front_door", name: "Old" });
     editor.hass = makeHass({
       states: { "camera.front_door": makeCameraEntity() },
-      entities: { "camera.front_door": { platform: "verisure_owa" } },
+      entities: { "camera.front_door": { platform: "securitas" } },
     });
     document.body.appendChild(editor);
 
@@ -346,7 +346,7 @@ describe("verisure-owa-camera-card-editor name field", () => {
     editor.setConfig({ entity: "camera.front_door" });
     editor.hass = makeHass({
       states: { "camera.front_door": makeCameraEntity() },
-      entities: { "camera.front_door": { platform: "verisure_owa" } },
+      entities: { "camera.front_door": { platform: "securitas" } },
     });
     document.body.appendChild(editor);
 
@@ -382,7 +382,7 @@ describe("verisure-owa-camera-card defensive defaults", () => {
   it("uses config.name when both name and device entry are present", () => {
     const hass = makeHass({
       states: { [ENTITY]: makeCameraEntity() },
-      entities: { [ENTITY]: { device_id: "dev1", platform: "verisure_owa" } },
+      entities: { [ENTITY]: { device_id: "dev1", platform: "securitas" } },
       devices: { dev1: { name: "Device" } },
     });
     const card = mountCameraCard({ config: { name: "Override" }, hass });
@@ -392,7 +392,7 @@ describe("verisure-owa-camera-card defensive defaults", () => {
   it("_findFullEntity returns null when the camera entry has no device_id", () => {
     const hass = makeHass({
       states: { [ENTITY]: makeCameraEntity() },
-      entities: { [ENTITY]: { platform: "verisure_owa" } },
+      entities: { [ENTITY]: { platform: "securitas" } },
     });
     const card = mountCameraCard({ hass });
     // Without a device_id the lookup returns null and the click goes to the thumbnail.
@@ -406,8 +406,8 @@ describe("verisure-owa-camera-card defensive defaults", () => {
 
   it("_entitiesByDeviceId reuses its cache when hass.entities is unchanged", () => {
     const entities = {
-      [ENTITY]: { device_id: "dev1", platform: "verisure_owa" },
-      "camera.test_full_image": { device_id: "dev1", platform: "verisure_owa" },
+      [ENTITY]: { device_id: "dev1", platform: "securitas" },
+      "camera.test_full_image": { device_id: "dev1", platform: "securitas" },
     };
     const hass = makeHass({
       states: { [ENTITY]: makeCameraEntity() },
@@ -444,8 +444,8 @@ describe("verisure-owa-camera-card static helpers", () => {
         "light.kitchen": { state: "on", attributes: {} },
       },
       entities: {
-        "camera.x_full_image": { platform: "verisure_owa" },
-        "camera.front_door": { platform: "verisure_owa" },
+        "camera.x_full_image": { platform: "securitas" },
+        "camera.front_door": { platform: "securitas" },
       },
     });
     const stub = ctor.getStubConfig(hass);

--- a/tests-js/unit/activity-log-suggestion.test.js
+++ b/tests-js/unit/activity-log-suggestion.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { activityLogEntitySuggestion } from "../../custom_components/securitas/www/verisure-owa-activity-log-card.js";
+import { makeHass } from "../fixtures/hass.js";
+
+const ours = (entityId, { platform = "securitas", events = [] } = {}) =>
+  makeHass({
+    entities: { [entityId]: { platform } },
+    states: { [entityId]: { attributes: { events } } },
+  });
+
+describe("activityLogEntitySuggestion", () => {
+  it("suggests the activity-log card for one of our activity-log sensors", () => {
+    const hass = ours("sensor.installation_activity_log");
+    expect(activityLogEntitySuggestion(hass, "sensor.installation_activity_log")).toEqual({
+      config: {
+        type: "custom:verisure-owa-activity-log-card",
+        entity: "sensor.installation_activity_log",
+      },
+    });
+  });
+
+  it("does not match the never-released verisure_owa domain", () => {
+    const hass = ours("sensor.activity", { platform: "verisure_owa" });
+    expect(activityLogEntitySuggestion(hass, "sensor.activity")).toBeNull();
+  });
+
+  it("returns null for a sensor from another integration", () => {
+    const hass = ours("sensor.activity", { platform: "template" });
+    expect(activityLogEntitySuggestion(hass, "sensor.activity")).toBeNull();
+  });
+
+  it("returns null for one of our sensors that has no events array", () => {
+    const hass = makeHass({
+      entities: { "sensor.battery": { platform: "securitas" } },
+      states: { "sensor.battery": { attributes: {} } },
+    });
+    expect(activityLogEntitySuggestion(hass, "sensor.battery")).toBeNull();
+  });
+
+  it("returns null for non-sensor domains", () => {
+    const hass = ours("binary_sensor.door");
+    expect(activityLogEntitySuggestion(hass, "binary_sensor.door")).toBeNull();
+  });
+
+  it("returns null when the entity is not in the registry", () => {
+    expect(activityLogEntitySuggestion(makeHass(), "sensor.unknown")).toBeNull();
+  });
+});

--- a/tests-js/unit/alarm-card-suggestion.test.js
+++ b/tests-js/unit/alarm-card-suggestion.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { alarmEntitySuggestion } from "../../custom_components/securitas/www/verisure-owa-alarm-card.js";
+import { makeHass } from "../fixtures/hass.js";
+
+const ours = (entityId, platform = "securitas") =>
+  makeHass({ entities: { [entityId]: { platform } } });
+
+describe("alarmEntitySuggestion", () => {
+  it("suggests the full card and the chip for one of our alarm panels", () => {
+    const hass = ours("alarm_control_panel.home");
+    expect(alarmEntitySuggestion(hass, "alarm_control_panel.home")).toEqual([
+      { config: { type: "custom:verisure-owa-alarm-card", entity: "alarm_control_panel.home" } },
+      { config: { type: "custom:verisure-owa-alarm-chip", entity: "alarm_control_panel.home" } },
+    ]);
+  });
+
+  it("does not match the never-released verisure_owa domain", () => {
+    const hass = ours("alarm_control_panel.home", "verisure_owa");
+    expect(alarmEntitySuggestion(hass, "alarm_control_panel.home")).toBeNull();
+  });
+
+  it("returns null for an alarm panel from another integration", () => {
+    const hass = ours("alarm_control_panel.other", "manual");
+    expect(alarmEntitySuggestion(hass, "alarm_control_panel.other")).toBeNull();
+  });
+
+  it("returns null for non-alarm domains", () => {
+    const hass = ours("sensor.temperature");
+    expect(alarmEntitySuggestion(hass, "sensor.temperature")).toBeNull();
+  });
+
+  it("returns null when the entity is not in the registry", () => {
+    expect(alarmEntitySuggestion(makeHass(), "alarm_control_panel.unknown")).toBeNull();
+  });
+});

--- a/tests-js/unit/camera-card-helpers.test.js
+++ b/tests-js/unit/camera-card-helpers.test.js
@@ -7,12 +7,12 @@ describe("findFullImageEntityIds", () => {
     expect(findFullImageEntityIds(makeHass())).toEqual([]);
   });
 
-  it("returns matching full-image cameras from our platforms", () => {
+  it("returns matching full-image cameras from our platform", () => {
     const hass = makeHass({
       entities: {
-        "camera.front_door_full_image": { platform: "verisure_owa" },
+        "camera.front_door_full_image": { platform: "securitas" },
         "camera.garden_full_image_2": { platform: "securitas" },
-        "camera.kitchen": { platform: "verisure_owa" },
+        "camera.kitchen": { platform: "securitas" },
         "camera.other_full_image": { platform: "generic" },
       },
     });
@@ -20,6 +20,16 @@ describe("findFullImageEntityIds", () => {
     expect(ids.sort()).toEqual(
       ["camera.front_door_full_image", "camera.garden_full_image_2"].sort(),
     );
+  });
+
+  it("ignores full-image cameras from the never-released verisure_owa domain", () => {
+    // The integration domain was briefly going to be renamed securitas →
+    // verisure_owa, but that was reversed before release, so no install ever
+    // registers entities under the verisure_owa platform.
+    const hass = makeHass({
+      entities: { "camera.front_door_full_image": { platform: "verisure_owa" } },
+    });
+    expect(findFullImageEntityIds(hass)).toEqual([]);
   });
 
   it("ignores entries without a platform field", () => {

--- a/tests-js/unit/camera-card-suggestion.test.js
+++ b/tests-js/unit/camera-card-suggestion.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { cameraEntitySuggestion } from "../../custom_components/securitas/www/verisure-owa-camera-card.js";
+import { makeHass } from "../fixtures/hass.js";
+
+const ours = (entityId, platform = "securitas") =>
+  makeHass({ entities: { [entityId]: { platform } } });
+
+describe("cameraEntitySuggestion", () => {
+  it("suggests the camera card for one of our camera entities", () => {
+    const hass = ours("camera.front_door");
+    expect(cameraEntitySuggestion(hass, "camera.front_door")).toEqual({
+      config: { type: "custom:verisure-owa-camera-card", entity: "camera.front_door" },
+    });
+  });
+
+  it("does not match the never-released verisure_owa domain", () => {
+    const hass = ours("camera.garden", "verisure_owa");
+    expect(cameraEntitySuggestion(hass, "camera.garden")).toBeNull();
+  });
+
+  it("returns null for a camera from another integration", () => {
+    const hass = ours("camera.generic_cam", "generic");
+    expect(cameraEntitySuggestion(hass, "camera.generic_cam")).toBeNull();
+  });
+
+  it("returns null for non-camera domains", () => {
+    const hass = ours("light.kitchen");
+    expect(cameraEntitySuggestion(hass, "light.kitchen")).toBeNull();
+  });
+
+  it("returns null for the internal full-image camera entity", () => {
+    const hass = ours("camera.front_door_full_image");
+    expect(cameraEntitySuggestion(hass, "camera.front_door_full_image")).toBeNull();
+  });
+
+  it("returns null when the entity is not in the registry", () => {
+    expect(cameraEntitySuggestion(makeHass(), "camera.unknown")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

HA 2026.6 lets custom cards opt into the card picker's **"By entity"** tab by exposing a `getEntitySuggestion(hass, entityId)` hook on their `window.customCards` entry. This adds that hook to the three entity-bound cards so they surface when the user selects a matching entity from this integration:

- **Alarm card** — offers the full card **and** the compact chip as variants for our `alarm_control_panel` entities.
- **Camera card** — offers the camera card for our cameras, excluding the internal `_full_image` snapshot entities.
- **Activity-log card** — offers the card for our activity-log sensors (detected by the `events` attribute array, mirroring the editor's own detection).

Each hook is a pure, exported function, guarded on the entity's registry `platform`, and unit-tested in isolation. The emitted configs use the canonical `custom:verisure-owa-*` card types.

## Platform-guard cleanup

The guard matches **only the `securitas` domain** (the integration's actual domain). This PR also drops a dead `verisure_owa` platform alias from the camera card's pre-existing `findFullImageEntityIds` helper (and its tests) — no installation registers entities under that platform. (Naming on other axes — the `verisure-owa-*` card types, `verisure_owa.*` services, `verisure_owa_api` package — is current and untouched.)

Also clears two pre-existing unused-var lint warnings in the alarm card.

## Testing

- Added unit tests for all three `getEntitySuggestion` hooks (ours vs foreign platform, wrong domain, `_full_image` exclusion, missing `events` array), written test-first (RED → GREEN).
- Full JS suite: **376 passing**; `npm run lint` clean.
