### PR TITLE
ci: add version-controlled pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Pre-push gate for securitas-direct-new-api (Python integration + a Lovelace
+# card with eslint/prettier/vitest). Strategy: cheap lint first, then drift
+# checks (i18n, docs), then the slower tests — and only for the areas whose
+# files actually changed in this push.
+#
+# Python tests run UNIT-only here (the integration suite + the combined 90%
+# coverage gate stay in CI, which also runs the min/dev HA matrix). Tests run
+# against the HA-stable installed in this environment (the devcontainer).
+#
+# Install once per clone:  bash bin/install-hooks.sh
+# Bypass in an emergency:  git push --no-verify
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+LOG_FILE="/tmp/securitas-pre-push.log"
+failed=0
+exec > >(tee "$LOG_FILE") 2>&1
+
+step() { printf '\n\033[1;34m▶ %s\033[0m\n' "$1"; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$1"; failed=1; }
+pass() { printf '\033[1;32m✓ %s\033[0m\n' "$1"; }
+need() { command -v "$1" >/dev/null 2>&1 || { fail "$1 not found — are you pushing from the devcontainer? (deps expected there)"; return 1; }; }
+
+# --- Compute the precise diff range from the refs git feeds us on stdin ---
+ZERO=0000000000000000000000000000000000000000
+default_base() {
+  for ref in origin/main main origin/HEAD; do
+    git rev-parse --verify --quiet "$ref" >/dev/null 2>&1 && { echo "$ref"; return; }
+  done
+  echo "HEAD~1"
+}
+range=""
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$ZERO" ] && continue
+  if [ "$remote_sha" = "$ZERO" ]; then
+    base="$(git merge-base "$(default_base)" "$local_sha" 2>/dev/null || default_base)"
+    range="${base}..${local_sha}"
+  else
+    range="${remote_sha}..${local_sha}"
+  fi
+done
+[ -n "$range" ] || range="$(default_base)..HEAD"
+
+changed="$(git diff --name-only "$range" 2>/dev/null || git diff --name-only HEAD~1)"
+echo "pre-push: $(printf '%s\n' "$changed" | grep -c . || true) changed file(s) in range $range"
+
+py_changed=$(printf '%s\n' "$changed"   | grep -E '^(custom_components/securitas/|tests/).*\.py$' || true)
+fe_changed=$(printf '%s\n' "$changed"   | grep -E '^(custom_components/securitas/www/|tests-js/)' || true)
+i18n_changed=$(printf '%s\n' "$changed" | grep -E '^custom_components/securitas/(strings\.json|translations/)' || true)
+
+# --- Step 1: fast lint/format + types (Python) ---
+if [ -n "$py_changed" ]; then
+  step "Ruff format"
+  if need ruff && ruff format --check .; then pass "Ruff format"
+  else fail "Ruff format — run: ruff format ."; fi
+
+  step "Ruff lint"
+  if need ruff && ruff check .; then pass "Ruff lint"
+  else fail "Ruff lint — run: ruff check --fix ."; fi
+
+  step "Pyright"
+  if need pyright && pyright custom_components/; then pass "Pyright"
+  else fail "Pyright — see above"; fi
+fi
+
+# --- Step 2: i18n drift ---
+if [ -n "$i18n_changed$py_changed" ]; then
+  step "Translations"
+  if python3 "$ROOT/scripts/check_translations.py"; then pass "Translations"
+  else fail "Translations — see above"; fi
+fi
+
+# --- Step 3: docs drift ---
+step "Docs"
+if python3 "$ROOT/scripts/check_docs.py" "$range"; then pass "Docs"
+else fail "Docs — structural change needs a docs update"; fi
+
+# --- Step 4: Python unit tests (slower; only if Python changed) ---
+if [ -n "$py_changed" ]; then
+  step "Python unit tests"
+  if need python && (unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE; python -m pytest tests/ -m "not integration"); then
+    pass "Python unit tests"
+  else
+    fail "Python unit tests"
+  fi
+fi
+
+# --- Step 5: frontend lint + tests (only if the card changed) ---
+if [ -n "$fe_changed" ]; then
+  step "Frontend lint"
+  if need npm && npm run lint; then pass "Frontend lint"
+  else fail "Frontend lint — run: npm run lint:fix"; fi
+
+  step "Frontend tests"
+  if need npm && npm test; then pass "Frontend tests"
+  else fail "Frontend tests"; fi
+fi
+
+# --- Result ---
+echo ""
+if [ "$failed" -ne 0 ]; then
+  printf '\033[1;31m✗ Pre-push checks failed. Push aborted.\033[0m\n\n\033[1mFailures:\033[0m\n'
+  perl -pe 's/\e\[[0-9;]*m//g' "$LOG_FILE" | grep -E "^✗ " | sed 's/^/  /'
+  printf '\n\033[1mFull log:\033[0m %s\n' "$LOG_FILE"
+  exit 1
+fi
+printf '\033[1;32m✓ All pre-push checks passed.\033[0m\n'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,6 +30,9 @@ default_base() {
   done
   echo "HEAD~1"
 }
+# Single-ref assumption: a push of multiple refs at once (e.g. `git push --all`)
+# feeds several stdin lines and only the last is gated here. That's fine for the
+# normal one-branch-at-a-time flow; CI is the backstop for bulk pushes.
 range=""
 while read -r _local_ref local_sha _remote_ref remote_sha; do
   [ "$local_sha" = "$ZERO" ] && continue
@@ -41,6 +44,12 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
   fi
 done
 [ -n "$range" ] || range="$(default_base)..HEAD"
+
+# The remote SHA in the range may be absent locally (shallow clone, not fetched
+# recently) — fall back to a base we know exists so downstream consumers of the
+# range (e.g. check_docs.py, which has no fallback of its own) don't crash.
+range_base="${range%%..*}"
+git rev-parse --verify --quiet "${range_base}^{commit}" >/dev/null 2>&1 || range="$(default_base)..HEAD"
 
 changed="$(git diff --name-only "$range" 2>/dev/null || git diff --name-only HEAD~1)"
 echo "pre-push: $(printf '%s\n' "$changed" | grep -c . || true) changed file(s) in range $range"
@@ -67,19 +76,19 @@ fi
 # --- Step 2: i18n drift ---
 if [ -n "$i18n_changed$py_changed" ]; then
   step "Translations"
-  if python3 "$ROOT/scripts/check_translations.py"; then pass "Translations"
+  if need python3 && python3 "$ROOT/scripts/check_translations.py"; then pass "Translations"
   else fail "Translations — see above"; fi
 fi
 
 # --- Step 3: docs drift ---
 step "Docs"
-if python3 "$ROOT/scripts/check_docs.py" "$range"; then pass "Docs"
+if need python3 && python3 "$ROOT/scripts/check_docs.py" "$range"; then pass "Docs"
 else fail "Docs — structural change needs a docs update"; fi
 
 # --- Step 4: Python unit tests (slower; only if Python changed) ---
 if [ -n "$py_changed" ]; then
   step "Python unit tests"
-  if need python && (unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE; python -m pytest tests/ -m "not integration"); then
+  if need python3 && (unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE; python3 -m pytest tests/ -m "not integration"); then
     pass "Python unit tests"
   else
     fail "Python unit tests"

--- a/bin/install-hooks.sh
+++ b/bin/install-hooks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Point this clone's git hooks at the version-controlled .githooks/ dir.
+#
+# Uses a RELATIVE path on purpose: git resolves core.hooksPath relative to each
+# working tree's root, so the same setting works in the main checkout, in any
+# linked worktree, and across machines (devcontainer + host) — unlike an
+# absolute /workspaces/... path, which only resolves in one environment.
+#
+# Run once per clone:  bash bin/install-hooks.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+echo "✓ core.hooksPath -> .githooks ($(git config core.hooksPath))"

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -29,7 +29,12 @@ DOC_PREFIXES = ("readme", "docs/", "changelog")
 
 def git(*args: str) -> str:
     out = subprocess.run(
-        ["git", *args], cwd=ROOT, capture_output=True, text=True, check=True
+        ["git", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
     )
     return out.stdout
 
@@ -45,15 +50,20 @@ def component_dir() -> Path | None:
 def services_keys(ref: str, path: str) -> set[str]:
     """Top-level service keys in services.yaml at a given git ref ('' = worktree)."""
     try:
-        text = git("show", f"{ref}:{path}") if ref else (ROOT / path).read_text()
+        text = (
+            git("show", f"{ref}:{path}")
+            if ref
+            else (ROOT / path).read_text(encoding="utf-8")
+        )
     except (subprocess.CalledProcessError, FileNotFoundError):
         return set()
     # services.yaml top-level keys are the service names — read them without a
     # yaml dependency: lines at column 0 that aren't comments and end in ':'.
     keys = set()
     for line in text.splitlines():
-        if line and line[0] not in " #\t" and ":" in line:
-            keys.add(line.split(":", 1)[0].strip())
+        stripped = line.rstrip()
+        if stripped and stripped[0] not in " #\t" and stripped.endswith(":"):
+            keys.add(stripped[:-1].strip())
     return keys
 
 
@@ -68,7 +78,11 @@ def main() -> int:
     status = git("diff", "--name-status", diff_range).splitlines()
     changed = [line.split("\t") for line in status if line.strip()]
 
-    docs_touched = any(parts[-1].lower().startswith(DOC_PREFIXES) for parts in changed)
+    # Check every path field (parts[0] is the A/D/R status) so a rename that
+    # moves a docs file is counted via its old path too, not just the new one.
+    docs_touched = any(
+        p.lower().startswith(DOC_PREFIXES) for parts in changed for p in parts[1:]
+    )
 
     structural: list[str] = []
     edited_py = False

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Guard against docs drift on a push.
+
+Policy (matches what the team agreed):
+  * STRUCTURAL surface change with no docs touched  -> ERROR (block the push)
+  * Routine code edit with no docs touched          -> WARNING (nudge only)
+  * Any docs file touched                            -> all good
+
+"Structural" = the integration's public surface changed shape: a *.py module
+under the component was added / removed / renamed, or a service was added or
+removed in services.yaml. Those are exactly the changes that tend to leave the
+README describing something that no longer matches. Editing the body of an
+existing module is a routine edit — worth a nudge, not a block.
+
+Usage:  check_docs.py <git-diff-range>      e.g. check_docs.py origin/main..HEAD
+
+Exit code: 1 on a blocking structural drift, else 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOC_PREFIXES = ("readme", "docs/", "changelog")
+
+
+def git(*args: str) -> str:
+    out = subprocess.run(
+        ["git", *args], cwd=ROOT, capture_output=True, text=True, check=True
+    )
+    return out.stdout
+
+
+def component_dir() -> Path | None:
+    base = ROOT / "custom_components"
+    if not base.is_dir():
+        return None
+    dirs = [d for d in base.iterdir() if d.is_dir() and (d / "manifest.json").exists()]
+    return dirs[0] if len(dirs) == 1 else None
+
+
+def services_keys(ref: str, path: str) -> set[str]:
+    """Top-level service keys in services.yaml at a given git ref ('' = worktree)."""
+    try:
+        text = git("show", f"{ref}:{path}") if ref else (ROOT / path).read_text()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return set()
+    # services.yaml top-level keys are the service names — read them without a
+    # yaml dependency: lines at column 0 that aren't comments and end in ':'.
+    keys = set()
+    for line in text.splitlines():
+        if line and line[0] not in " #\t" and ":" in line:
+            keys.add(line.split(":", 1)[0].strip())
+    return keys
+
+
+def main() -> int:
+    diff_range = sys.argv[1] if len(sys.argv) > 1 else "origin/main..HEAD"
+    comp = component_dir()
+    if comp is None:
+        return 0
+    comp_rel = comp.relative_to(ROOT).as_posix()
+
+    # name-status gives us A/D/R/M per file — we need the verb, not just the path.
+    status = git("diff", "--name-status", diff_range).splitlines()
+    changed = [line.split("\t") for line in status if line.strip()]
+
+    docs_touched = any(parts[-1].lower().startswith(DOC_PREFIXES) for parts in changed)
+
+    structural: list[str] = []
+    edited_py = False
+    for parts in changed:
+        verb, path = parts[0], parts[-1]
+        if not path.startswith(f"{comp_rel}/") or "/translations/" in path:
+            continue
+        if path.endswith(".py"):
+            if verb[0] in ("A", "D", "R"):
+                structural.append(f"{verb[0]} {path}")
+            else:
+                edited_py = True
+
+    svc = f"{comp_rel}/services.yaml"
+    if any(p[-1] == svc for p in changed):
+        base = diff_range.split("..")[0] or "HEAD"
+        added_removed = services_keys(base, svc) ^ services_keys("", svc)
+        if added_removed:
+            structural.append(f"services.yaml: {', '.join(sorted(added_removed))}")
+
+    if structural and not docs_touched:
+        print("  ✗ Structural surface change without a docs update:")
+        for s in structural:
+            print(f"      {s}")
+        print("    Update README.md / docs/ (or `git push --no-verify` if truly N/A).")
+        return 1
+    if edited_py and not docs_touched:
+        print(
+            "  ⚠ Component code changed but no docs touched — check the README still matches."
+        )
+    else:
+        print("check_docs: ok ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -59,7 +59,7 @@ def main() -> int:
     if not strings_file.exists():
         sys.exit(f"check_translations: no strings.json in {component}")
 
-    reference = flatten(json.loads(strings_file.read_text()))
+    reference = flatten(json.loads(strings_file.read_text(encoding="utf-8")))
     trans_dir = component / "translations"
     if not trans_dir.is_dir():
         print("check_translations: no translations/ dir — nothing to check")
@@ -67,7 +67,7 @@ def main() -> int:
 
     had_error = False
     for path in sorted(trans_dir.glob("*.json")):
-        keys = flatten(json.loads(path.read_text()))
+        keys = flatten(json.loads(path.read_text(encoding="utf-8")))
         stale = sorted(keys - reference)
         missing = sorted(reference - keys)
         if stale:

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate translation files against the source strings.json.
+
+Catches the drift that matters: a string key that was renamed or removed in
+strings.json but left behind in a translations/<lang>.json (a "stale" key).
+Stale keys are ERRORS — they're dead weight that can mask typos and never
+surface to the user. Missing keys (a language that hasn't translated a string
+yet) are only WARNINGS — partial translations are normal and expected.
+
+Auto-detects the integration under custom_components/<component>/. Pass an
+explicit component dir as the first argument to override.
+
+Exit code: 1 if any stale keys are found, else 0.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def flatten(obj: object, prefix: str = "") -> set[str]:
+    """Flatten a nested dict into the set of dotted leaf-key paths."""
+    keys: set[str] = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            path = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict) and v:
+                keys |= flatten(v, path)
+            else:
+                keys.add(path)
+    return keys
+
+
+def find_component(root: Path) -> Path:
+    """Locate custom_components/<component>/ — the sole integration package."""
+    base = root / "custom_components"
+    candidates = (
+        [d for d in base.iterdir() if d.is_dir() and (d / "strings.json").exists()]
+        if base.is_dir()
+        else []
+    )
+    if len(candidates) != 1:
+        names = ", ".join(d.name for d in candidates) or "none"
+        sys.exit(
+            f"check_translations: expected exactly one component with strings.json, found: {names}"
+        )
+    return candidates[0]
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    component = (
+        Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else find_component(root)
+    )
+
+    strings_file = component / "strings.json"
+    if not strings_file.exists():
+        sys.exit(f"check_translations: no strings.json in {component}")
+
+    reference = flatten(json.loads(strings_file.read_text()))
+    trans_dir = component / "translations"
+    if not trans_dir.is_dir():
+        print("check_translations: no translations/ dir — nothing to check")
+        return 0
+
+    had_error = False
+    for path in sorted(trans_dir.glob("*.json")):
+        keys = flatten(json.loads(path.read_text()))
+        stale = sorted(keys - reference)
+        missing = sorted(reference - keys)
+        if stale:
+            had_error = True
+            print(f"  ✗ {path.name}: {len(stale)} stale key(s) not in strings.json:")
+            for k in stale:
+                print(f"      {k}")
+        if missing:
+            print(f"  ⚠ {path.name}: {len(missing)} untranslated key(s)")
+
+    if had_error:
+        print(
+            "\ncheck_translations: stale keys found — remove them or fix strings.json"
+        )
+        return 1
+    print("check_translations: no stale keys ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a changed-area-aware **pre-push** gate under \`.githooks/\`, wired via a **relative** \`core.hooksPath\` so it resolves in the devcontainer, on the host, and in every worktree.

## What runs (only for the areas that changed)
1. **Lint + types** — \`ruff format --check .\` + \`ruff check .\` + \`pyright custom_components/\` when Python changes
2. **i18n** — \`check_translations.py\`: errors on stale keys, warns on untranslated
3. **Docs** — \`check_docs.py\`: blocks a structural surface change with no docs update; soft-warns on routine edits
4. **Python unit tests** — \`pytest tests/ -m "not integration"\` when Python changes (integration suite + combined 90% coverage gate stay in CI)
5. **Frontend** — \`npm run lint\` + \`npm test\` (vitest) when the card (\`www/\` or \`tests-js/\`) changes

\`bin/install-hooks.sh\` is force-tracked past the blanket \`bin\` ignore. Bypass with \`git push --no-verify\`. Part of a fleet-wide rollout.