### PR TITLE
release: roll branch forward to next minor after a final release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,3 +103,32 @@ jobs:
             --title "v$VERSION" \
             --generate-notes \
             $prerelease_flag
+
+      - name: Roll branch forward to the next minor (final releases only)
+        # Skip for pre-releases: only a finished release rolls the version
+        # forward, so unreleased work no longer carries the just-released
+        # version. Pushes directly to the dispatched branch, the same way the
+        # "Commit, tag, push" step above already does.
+        if: ${{ inputs.prerelease != true }}
+        run: |
+          NEXT=$(python3 -c "import os; mj, mn, _ = os.environ['VERSION'].split('-')[0].split('.'); print(f'{mj}.{int(mn)+1}.0')")
+          echo "Final release — rolling $BRANCH forward to development version $NEXT"
+          NEXT="$NEXT" python3 <<'PY'
+          import os, re, sys
+          new_version = os.environ["NEXT"]
+          path = "custom_components/securitas/manifest.json"
+          with open(path) as f:
+              content = f.read()
+          updated, n = re.subn(
+              r'("version"\s*:\s*)"[^"]+"',
+              lambda m: m.group(1) + f'"{new_version}"',
+              content,
+          )
+          if n != 1:
+              sys.exit(f"Expected exactly one version field in {path}, found {n}")
+          with open(path, "w") as f:
+              f.write(updated)
+          PY
+          git add custom_components/securitas/manifest.json
+          git commit -m "chore: bump version to $NEXT for development"
+          git push origin "HEAD:$BRANCH"


### PR DESCRIPTION
Small addition to the existing manual-dispatch `release.yaml`: after a **final** release is published, roll the dispatched branch forward to the next minor so unreleased work no longer carries the just-shipped version.

### What it does
Appends one step after "Create GitHub release":
- Runs only for final releases (`if: ${{ inputs.prerelease != true }}`).
- Computes the next minor from the released version (`X.Y.Z → X.(Y+1).0`).
- Bumps `custom_components/securitas/manifest.json` using the **same inline-python regex bump** the existing "Bump manifest versions" step uses (single-version-field assertion preserved).
- Commits `chore: bump version to <next> for development` and pushes to the dispatched branch — the same direct push the existing "Commit, tag, push" step already performs. No new secrets or settings.

### Notes
- The release tag stays on the release commit; the roll-forward commit lands on top.
- Pre-releases are intentionally left alone.
- `VERSION` is the already-regex-validated dispatch input; all values are passed via shell vars from the job `env:` (no `${{ }}` interpolation into `run:`), consistent with the rest of the workflow.