### PR TITLE
fix(alarm): treat accepted-but-unconfirmed arm/disarm as provisional — release 5.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
+## v5.3.0
+
+Arm and disarm no longer report a false failure — and roll the panel back to a stale, untrustworthy state — when the backend accepts the command but is slow to confirm it.
+
+### Fixed
+
+**Arm/disarm wrongly reported as failed when the backend is slow to confirm ([#508](https://github.com/guerrerotook/securitas-direct-new-api/issues/508)).**  On some backends — notably Italy (SDVECU) — the panel accepts an arm or disarm (the command returns `OK`) but the follow-up confirmation poll can sit on `processing.request` past the timeout.  The integration used to treat that timeout as an outright failure: it rolled the entity back to its previous state, logged an error, and raised an "arm/disarm failed" notification — even though the panel had actually carried out the command.  The result was a Home Assistant alarm state that couldn't be trusted (showing `disarmed` while the panel was armed, or the reverse) plus spurious failure alerts.  A command the backend has accepted but not yet confirmed is now treated as **accepted-but-provisional**: the entity optimistically shows the intended state, flags it as provisional, logs a *warning* rather than an error, and posts a distinct "not confirmed" notification — then reconciles automatically against the next authoritative status read.  Genuine failures still roll back and notify exactly as before.  A re-entry guard also stops a duplicate command being sent while one is already in flight.
+
+### Added
+
+**Configurable operation poll timeout.**  A new **Operation poll timeout** option (Configure → Advanced; default 120 s, range 60–300 s) sets how long to wait for the panel to confirm an arm/disarm before treating it as accepted-but-unconfirmed.  Raise it if you see "not confirmed within timeout" warnings in the log.
+
 ## v5.2.0
 
 Re-authentication is now reserved for genuine credential problems, and transient Verisure backend hiccups no longer drag you to the login screen.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ After setup, change settings via **Settings → Integrations → Verisure OWA �
 | **Activity Log and Events** | Poll the activity log once per minute in the background | No | Off by default: the log refreshes on demand from the card, and remote events (someone arming at the panel, an intrusion, a power cut) don't fire on the `verisure_owa_activity` bus. Turn it on if you want every event to fire — see [How often it refreshes](#how-often-it-refreshes). |
 | **Advanced** _(collapsed)_ | Update scan interval | 120s | How often the integration checks the alarm status. Set to 0 to disable automatic polling. |
 | | Delay between API requests | 2s | Minimum gap between consecutive API requests. Higher values reduce the risk of WAF rate limiting. |
+| | Operation poll timeout | 120s | How long to wait for the panel to confirm an arm/disarm action before treating it as accepted-but-unconfirmed (range 60–300s). Raise this if arm/disarm operations log `not confirmed within timeout` warnings. |
 
 ## Alarm State Mappings
 
@@ -490,6 +491,7 @@ After a restart, `notify.mobiles` shows up in the dropdown. The action buttons i
   - **Increase the API request delay** — The **Delay between API requests** (default: 2 seconds) controls the minimum gap between consecutive API calls. Increasing this to 4–5 seconds reduces request bursts.
   - If you have **multiple installations** on one account, each one polls independently, multiplying the request rate. All API requests to the same country domain are serialized through a shared queue, which helps, but the total volume still increases with each installation.
 - **Alarm shows wrong state after using the Verisure app** — Periodic polling reads the last known status from the Verisure server, which may take a moment to reflect changes made via the app. Press the **Refresh** button to force an immediate panel check.
+- **Arm/disarm logs `not confirmed within timeout`** — On a slow or congested backend the panel can accept an arm/disarm but not confirm it within the poll window. The integration shows the **intended** state provisionally (with a "… not confirmed" notification) and reconciles automatically on the next status read — it no longer reverts to the previous state or reports a hard failure. If this happens often, raise the **Operation poll timeout** under **Configure → Advanced**.
 - **Stale lock state after lock/unlock** — If the lock shows the old state after a lock or unlock command and only self-corrects after the next periodic poll (~2 minutes), please [open an issue](https://github.com/guerrerotook/securitas-direct-new-api/issues) with your debug logs. We are actively improving lock status polling and your logs will help.
 - **Cannot clear PIN code** — In the options flow, clear the PIN field and save. The PIN will be removed.
 - **2FA issues** — If 2FA fails, remove and re-add the integration; you'll be prompted for a new SMS code. If that doesn't work, create a new user in the Verisure mobile app, then log in to the customer web portal for your country to accept the terms of use before using those credentials in HA.

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -52,6 +52,7 @@ from .const import (  # noqa: F401 — re-exported for backwards compatibility
     CONF_CODE_ARM_REQUIRED,
     CONF_COUNTRY,
     CONF_DELAY_CHECK_OPERATION,
+    CONF_OPERATION_POLL_TIMEOUT,
     CONF_DEVICE_INDIGITALL,
     CONF_ENTRY_ID,
     CONF_INSTALLATION,
@@ -76,6 +77,7 @@ from .const import (  # noqa: F401 — re-exported for backwards compatibility
     DEFAULT_CODE_ARM_REQUIRED,
     DEFAULT_COUNTRY,
     DEFAULT_DELAY_CHECK_OPERATION,
+    DEFAULT_OPERATION_POLL_TIMEOUT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     PLATFORMS,
@@ -224,6 +226,7 @@ _OPTIONS_MANAGED_FIELDS: tuple[str, ...] = (
     CONF_ENABLE_ANNEX_PANEL,
     CONF_ENABLE_ACTIVITY_POLLING,
     CONF_LOCK_AUTOMATIONS,
+    CONF_OPERATION_POLL_TIMEOUT,
 )
 
 
@@ -300,6 +303,9 @@ def _build_config_dict(entry: ConfigEntry) -> tuple[dict[str, Any], bool]:
     config[CONF_SCAN_INTERVAL] = _opt(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     config[CONF_DELAY_CHECK_OPERATION] = _opt(
         CONF_DELAY_CHECK_OPERATION, DEFAULT_DELAY_CHECK_OPERATION
+    )
+    config[CONF_OPERATION_POLL_TIMEOUT] = _opt(
+        CONF_OPERATION_POLL_TIMEOUT, DEFAULT_OPERATION_POLL_TIMEOUT
     )
     config[CONF_ENTRY_ID] = entry.entry_id
     config[CONF_NOTIFY_GROUP] = _opt(CONF_NOTIFY_GROUP, "")

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -321,8 +321,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                     service="dismiss",
                     service_data={
                         "notification_id": (
-                            f"{DOMAIN}.operation_unconfirmed_"
-                            f"{self.installation.number}"
+                            f"{DOMAIN}.operation_unconfirmed_{self.installation.number}"
                         ),
                     },
                 )
@@ -827,9 +826,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         code, then disarmed, if the target has no modelled proto letter.
         """
         proto = (
-            ALARM_STATE_TO_PROTO.get(target)
-            or self._last_proto_code
-            or PROTO_DISARMED
+            ALARM_STATE_TO_PROTO.get(target) or self._last_proto_code or PROTO_DISARMED
         )
         return OperationStatus(protom_response=proto)
 

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -40,7 +40,9 @@ from ..const import (
     CIRCUIT_ANNEX,
     CIRCUIT_INTERIOR,
     CIRCUIT_PERIMETER,
+    CONF_OPERATION_POLL_TIMEOUT,
     CONF_UNSUPPORTED_COMMANDS,
+    DEFAULT_OPERATION_POLL_TIMEOUT,
 )
 from ..coordinators import AlarmCoordinator, AlarmStatusData
 from ..entity import VerisureEntity
@@ -71,6 +73,7 @@ from ..verisure_owa_api import (
 from ..verisure_owa_api.exceptions import OperationTimeoutError
 from ..verisure_owa_api.__version__ import __url__ as _PROJECT_URL
 from ..verisure_owa_api.command_resolver import (
+    ALARM_STATE_TO_PROTO,
     AlarmState,
     AnnexMode,
     CommandResolver,
@@ -790,6 +793,43 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._attr_extra_state_attributes["refresh_failed"] = True
         else:
             self._attr_extra_state_attributes.pop("refresh_failed", None)
+
+    def _set_state_provisional(self, provisional: bool) -> None:
+        """Flag the entity state as provisional (accepted-but-unconfirmed)."""
+        if provisional:
+            self._attr_extra_state_attributes["state_provisional"] = True
+        else:
+            self._attr_extra_state_attributes.pop("state_provisional", None)
+
+    def _optimistic_status(self, target: AlarmState) -> OperationStatus:
+        """Build an OperationStatus reflecting the *intended* target state.
+
+        Used when a command was accepted (res: OK) but the confirmation poll
+        timed out: we optimistically show the target (the fail-safe direction)
+        and let the coordinator reconcile. Falls back to the last known proto
+        code, then disarmed, if the target has no modelled proto letter.
+        """
+        proto = (
+            ALARM_STATE_TO_PROTO.get(target)
+            or self._last_proto_code
+            or PROTO_DISARMED
+        )
+        return OperationStatus(protom_response=proto)
+
+    def _notify_operation_unconfirmed(self, translation_key: str) -> None:
+        """Raise the accepted-but-unconfirmed persistent notification."""
+        timeout = self.client.config.get(
+            CONF_OPERATION_POLL_TIMEOUT, DEFAULT_OPERATION_POLL_TIMEOUT
+        )
+        _notify(
+            self.hass,
+            f"operation_unconfirmed_{self.installation.number}",
+            translation_key,
+            {
+                "installation": self.installation.alias,
+                "timeout": str(int(timeout)),
+            },
+        )
 
     def _set_waf_blocked(self, blocked: bool) -> None:
         """Track WAF rate-limit state for the alarm card."""

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -880,6 +880,12 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         """Send disarm command."""
         if not self._check_code(code):
             return
+        if self._operation_in_progress:
+            _LOGGER.debug(
+                "Disarm ignored for %s: an operation is already in progress",
+                self.installation.number,
+            )
+            return
         await self._dismiss_pending_force_context_on_siblings(
             reason=DISMISSAL_REASON_USER_DISARM,
             new_mode="disarmed",
@@ -953,6 +959,12 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         bypassed_exceptions: list[dict[str, Any]] | None = None,
     ) -> None:
         """Set the arm state using the command resolver."""
+        if self._operation_in_progress:
+            _LOGGER.debug(
+                "Arm ignored for %s: an operation is already in progress",
+                self.installation.number,
+            )
+            return
         # Capture the calling user's context up-front — HA expires
         # `self._context` ~1 s after async_set_context, and the arm
         # transition + state writes below take longer than that.

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -311,21 +311,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         if is_proto_letter(proto_code):
             self._last_proto_code = proto_code
         # A fresh authoritative status reconciles any provisional
-        # (accepted-but-unconfirmed) arm/disarm: clear the flag and dismiss
-        # the unconfirmed notification. (#508)
+        # (accepted-but-unconfirmed) arm/disarm: clearing the flag also
+        # dismisses the unconfirmed notification. (#508)
         if self._attr_extra_state_attributes.get("state_provisional"):
             self._set_state_provisional(False)
-            self.hass.async_create_task(
-                self.hass.services.async_call(
-                    domain="persistent_notification",
-                    service="dismiss",
-                    service_data={
-                        "notification_id": (
-                            f"{DOMAIN}.operation_unconfirmed_{self.installation.number}"
-                        ),
-                    },
-                )
-            )
         if proto_code == PROTO_DISARMED:
             self._state = AlarmControlPanelState.DISARMED
             self._last_unmapped_logged = None
@@ -811,11 +800,25 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
             self._attr_extra_state_attributes.pop("refresh_failed", None)
 
     def _set_state_provisional(self, provisional: bool) -> None:
-        """Flag the entity state as provisional (accepted-but-unconfirmed)."""
+        """Flag the entity state as provisional (accepted-but-unconfirmed).
+
+        Clearing the flag also dismisses the unconfirmed notification, so the
+        notification ID lives in one place — mirrors ``_set_waf_blocked``.
+        """
         if provisional:
             self._attr_extra_state_attributes["state_provisional"] = True
-        else:
-            self._attr_extra_state_attributes.pop("state_provisional", None)
+        elif self._attr_extra_state_attributes.pop("state_provisional", None):
+            self.hass.async_create_task(
+                self.hass.services.async_call(
+                    domain="persistent_notification",
+                    service="dismiss",
+                    service_data={
+                        "notification_id": (
+                            f"{DOMAIN}.operation_unconfirmed_{self.installation.number}"
+                        ),
+                    },
+                )
+            )
 
     def _optimistic_status(self, target: AlarmState) -> OperationStatus:
         """Build an OperationStatus reflecting the *intended* target state.
@@ -844,6 +847,30 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 "timeout": str(int(timeout)),
             },
         )
+
+    async def _handle_operation_timeout(
+        self, err: OperationTimeoutError, *, verb: str, target: AlarmState
+    ) -> None:
+        """Handle an accepted-but-unconfirmed arm/disarm (poll timed out, #508).
+
+        The command was accepted (``res: OK``) but the confirmation poll didn't
+        resolve within ``poll_timeout``. Reflect the target optimistically
+        (the fail-safe direction) and let the coordinator's ``xSStatus`` read
+        reconcile — never roll back or report a failure.
+        """
+        self._set_waf_blocked(False)
+        self._set_state_provisional(True)
+        self.update_status_alarm(self._optimistic_status(target))
+        _LOGGER.warning(
+            "%s not confirmed within timeout for %s; state provisional, "
+            "awaiting reconciliation: %s",
+            verb.capitalize(),
+            self.installation.number,
+            err.log_detail(),
+        )
+        self._notify_operation_unconfirmed(f"{verb}_unconfirmed")
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
     def _set_waf_blocked(self, blocked: bool) -> None:
         """Track WAF rate-limit state for the alarm card."""
@@ -909,23 +936,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 context=user_context,
             )
         except OperationTimeoutError as err:
-            # Command accepted (xSDisarmPanel res: OK) but the confirmation
-            # poll didn't resolve within poll_timeout. The panel is almost
-            # certainly actioning it (issue #508, IT backend). Reflect the
-            # target optimistically (fail-safe) and let the coordinator's
-            # xSStatus read reconcile — do NOT roll back or report a failure.
-            self._set_waf_blocked(False)
-            self._set_state_provisional(True)
-            self.update_status_alarm(self._optimistic_status(target))
-            _LOGGER.warning(
-                "Disarm not confirmed within timeout for %s; state provisional, "
-                "awaiting reconciliation: %s",
-                self.installation.number,
-                err.log_detail(),
-            )
-            self._notify_operation_unconfirmed("disarm_unconfirmed")
-            self.async_write_ha_state()
-            await self.coordinator.async_request_refresh()
+            await self._handle_operation_timeout(err, verb="disarm", target=target)
         except VerisureOwaError as err:
             self._state = self._last_state
             _LOGGER.error(
@@ -1004,21 +1015,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 exceptions=forced_excs,
             )
         except OperationTimeoutError as err:
-            # Arm accepted (xSArmPanel res: OK) but confirmation poll timed
-            # out. Optimistically reflect the target and reconcile via the
-            # coordinator — never roll back to the pre-arm state (#508).
-            self._set_waf_blocked(False)
-            self._set_state_provisional(True)
-            self.update_status_alarm(self._optimistic_status(target))
-            _LOGGER.warning(
-                "Arm not confirmed within timeout for %s; state provisional, "
-                "awaiting reconciliation: %s",
-                self.installation.number,
-                err.log_detail(),
-            )
-            self._notify_operation_unconfirmed("arm_unconfirmed")
-            self.async_write_ha_state()
-            await self.coordinator.async_request_refresh()
+            await self._handle_operation_timeout(err, verb="arm", target=target)
         except ArmingExceptionError as exc:
             self._set_force_context(exc, mode)
             self._state = self._last_state

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -888,6 +888,24 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 alias="Disarmed",
                 context=user_context,
             )
+        except OperationTimeoutError as err:
+            # Command accepted (xSDisarmPanel res: OK) but the confirmation
+            # poll didn't resolve within poll_timeout. The panel is almost
+            # certainly actioning it (issue #508, IT backend). Reflect the
+            # target optimistically (fail-safe) and let the coordinator's
+            # xSStatus read reconcile — do NOT roll back or report a failure.
+            self._set_waf_blocked(False)
+            self._set_state_provisional(True)
+            self.update_status_alarm(self._optimistic_status(target))
+            _LOGGER.warning(
+                "Disarm not confirmed within timeout for %s; state provisional, "
+                "awaiting reconciliation: %s",
+                self.installation.number,
+                err.log_detail(),
+            )
+            self._notify_operation_unconfirmed("disarm_unconfirmed")
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
         except VerisureOwaError as err:
             self._state = self._last_state
             _LOGGER.error(

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -310,6 +310,23 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         # arm/disarm refuses cleanly instead of acting on a stale cached state.
         if is_proto_letter(proto_code):
             self._last_proto_code = proto_code
+        # A fresh authoritative status reconciles any provisional
+        # (accepted-but-unconfirmed) arm/disarm: clear the flag and dismiss
+        # the unconfirmed notification. (#508)
+        if self._attr_extra_state_attributes.get("state_provisional"):
+            self._set_state_provisional(False)
+            self.hass.async_create_task(
+                self.hass.services.async_call(
+                    domain="persistent_notification",
+                    service="dismiss",
+                    service_data={
+                        "notification_id": (
+                            f"{DOMAIN}.operation_unconfirmed_"
+                            f"{self.installation.number}"
+                        ),
+                    },
+                )
+            )
         if proto_code == PROTO_DISARMED:
             self._state = AlarmControlPanelState.DISARMED
             self._last_unmapped_logged = None

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -311,10 +311,8 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         if is_proto_letter(proto_code):
             self._last_proto_code = proto_code
         # A fresh authoritative status reconciles any provisional
-        # (accepted-but-unconfirmed) arm/disarm: clearing the flag also
-        # dismisses the unconfirmed notification. (#508)
-        if self._attr_extra_state_attributes.get("state_provisional"):
-            self._set_state_provisional(False)
+        # (accepted-but-unconfirmed) arm/disarm. (#508)
+        self._reconcile_provisional()
         if proto_code == PROTO_DISARMED:
             self._state = AlarmControlPanelState.DISARMED
             self._last_unmapped_logged = None
@@ -819,6 +817,18 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                     },
                 )
             )
+
+    def _reconcile_provisional(self) -> None:
+        """Clear the provisional flag once an authoritative status is applied.
+
+        Shared by the combined panel and the axis sub-panels: the sub-panel
+        ``_update_from_coordinator`` override replaces the base method, so
+        without calling this it would never clear an accepted-but-unconfirmed
+        arm/disarm — leaving the flag set and its notification dangling
+        forever. Clearing the flag also dismisses the notification. (#508)
+        """
+        if self._attr_extra_state_attributes.get("state_provisional"):
+            self._set_state_provisional(False)
 
     def _optimistic_status(self, target: AlarmState) -> OperationStatus:
         """Build an OperationStatus reflecting the *intended* target state.

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -310,9 +310,11 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         # arm/disarm refuses cleanly instead of acting on a stale cached state.
         if is_proto_letter(proto_code):
             self._last_proto_code = proto_code
-        # A fresh authoritative status reconciles any provisional
-        # (accepted-but-unconfirmed) arm/disarm. (#508)
-        self._reconcile_provisional()
+            # A fresh authoritative status (a real proto letter) reconciles
+            # any provisional (accepted-but-unconfirmed) arm/disarm — gated on
+            # is_proto_letter so an error/placeholder status doesn't clear it,
+            # mirroring the axis sub-panel override. (#508)
+            self._reconcile_provisional()
         if proto_code == PROTO_DISARMED:
             self._state = AlarmControlPanelState.DISARMED
             self._last_unmapped_logged = None

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -977,6 +977,22 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 context=user_context,
                 exceptions=forced_excs,
             )
+        except OperationTimeoutError as err:
+            # Arm accepted (xSArmPanel res: OK) but confirmation poll timed
+            # out. Optimistically reflect the target and reconcile via the
+            # coordinator — never roll back to the pre-arm state (#508).
+            self._set_waf_blocked(False)
+            self._set_state_provisional(True)
+            self.update_status_alarm(self._optimistic_status(target))
+            _LOGGER.warning(
+                "Arm not confirmed within timeout for %s; state provisional, "
+                "awaiting reconciliation: %s",
+                self.installation.number,
+                err.log_detail(),
+            )
+            self._notify_operation_unconfirmed("arm_unconfirmed")
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
         except ArmingExceptionError as exc:
             self._set_force_context(exc, mode)
             self._state = self._last_state

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -931,6 +931,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         self._force_state(AlarmControlPanelState.DISARMING)
         self._operation_in_progress = True
         self._operation_epoch += 1
+        # Declared before the try so it is always bound in the except handlers
+        # (pyright reportPossiblyUnbound); it is always set before the awaited
+        # transition that can raise OperationTimeoutError.
+        target: AlarmState | None = None
         try:
             target = self._resolve_target_state("disarmed")
             result = await self._execute_transition(target)
@@ -946,6 +950,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 context=user_context,
             )
         except OperationTimeoutError as err:
+            assert target is not None  # set before the transition that raised
             await self._handle_operation_timeout(err, verb="disarm", target=target)
         except VerisureOwaError as err:
             self._state = self._last_state
@@ -997,6 +1002,10 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         if suid:
             force_params["suid"] = suid
 
+        # Declared before the try so it is always bound in the except handlers
+        # (pyright reportPossiblyUnbound); it is always set before the awaited
+        # transition that can raise OperationTimeoutError.
+        target: AlarmState | None = None
         try:
             target = self._resolve_target_state(mode)
             result = await self._execute_transition(target, **force_params)
@@ -1025,6 +1034,7 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
                 exceptions=forced_excs,
             )
         except OperationTimeoutError as err:
+            assert target is not None  # set before the transition that raised
             await self._handle_operation_timeout(err, verb="arm", target=target)
         except ArmingExceptionError as exc:
             self._set_force_context(exc, mode)

--- a/custom_components/securitas/alarm_control_panel/_panels.py
+++ b/custom_components/securitas/alarm_control_panel/_panels.py
@@ -110,6 +110,14 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
         try:
             result = await self._execute_transition(target)
         except VerisureOwaError as err:
+            # NOTE (#508 follow-up): an OperationTimeoutError (command accepted
+            # but the confirmation poll didn't resolve) is a VerisureOwaError,
+            # so it is rolled back here — unlike the user-facing arm/disarm
+            # paths, which now treat that as accepted-but-provisional. The
+            # rollback shows the circuits as still-armed (the fail-safe
+            # direction) but reports failure to the lock automation. Applying
+            # provisional semantics to this multi-entity path is a tracked
+            # follow-up, not handled in this change.
             for entity in affected:
                 entity._state = entity._last_state  # noqa: SLF001  # pylint: disable=protected-access
                 entity._operation_in_progress = False  # noqa: SLF001  # pylint: disable=protected-access

--- a/custom_components/securitas/alarm_control_panel/_panels.py
+++ b/custom_components/securitas/alarm_control_panel/_panels.py
@@ -222,6 +222,10 @@ class _AxisSubPanelMixin:
         if not is_proto_letter(proto_code):
             return
         self._last_proto_code = proto_code  # type: ignore[attr-defined]
+        # Reconcile any provisional (accepted-but-unconfirmed) arm/disarm.
+        # The base _update_from_coordinator does this, but this override
+        # replaces it — so call it here too or sub-panels never clear. (#508)
+        self._reconcile_provisional()  # type: ignore[attr-defined]
         if proto_code not in PROTO_TO_ALARM_STATE:
             return
         joint = self.coordinator.alarm_state  # type: ignore[attr-defined]

--- a/custom_components/securitas/config_flow.py
+++ b/custom_components/securitas/config_flow.py
@@ -31,6 +31,7 @@ from . import (
     CONF_CODE_ARM_REQUIRED,
     CONF_COUNTRY,
     CONF_DELAY_CHECK_OPERATION,
+    CONF_OPERATION_POLL_TIMEOUT,
     CONF_DEVICE_INDIGITALL,
     CONF_ENTRY_ID,
     CONF_INSTALLATION,
@@ -46,6 +47,7 @@ from . import (
     DEFAULT_CODE,
     DEFAULT_CODE_ARM_REQUIRED,
     DEFAULT_DELAY_CHECK_OPERATION,
+    DEFAULT_OPERATION_POLL_TIMEOUT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     VerisureHub,
@@ -380,6 +382,13 @@ def _build_settings_schema(
                         DEFAULT_DELAY_CHECK_OPERATION,
                     ),
                 ): vol.All(vol.Coerce(float), vol.Range(min=2.0, max=15.0)),
+                vol.Optional(
+                    CONF_OPERATION_POLL_TIMEOUT,
+                    default=defaults.get(
+                        CONF_OPERATION_POLL_TIMEOUT,
+                        DEFAULT_OPERATION_POLL_TIMEOUT,
+                    ),
+                ): vol.All(vol.Coerce(float), vol.Range(min=60.0, max=300.0)),
             }
         ),
         {"collapsed": True},
@@ -1048,6 +1057,9 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 CONF_DELAY_CHECK_OPERATION: self._get(
                     CONF_DELAY_CHECK_OPERATION, DEFAULT_DELAY_CHECK_OPERATION
+                ),
+                CONF_OPERATION_POLL_TIMEOUT: self._get(
+                    CONF_OPERATION_POLL_TIMEOUT, DEFAULT_OPERATION_POLL_TIMEOUT
                 ),
                 CONF_ENABLE_ACTIVITY_POLLING: self._get(
                     CONF_ENABLE_ACTIVITY_POLLING, DEFAULT_ENABLE_ACTIVITY_POLLING

--- a/custom_components/securitas/const.py
+++ b/custom_components/securitas/const.py
@@ -48,6 +48,7 @@ CONF_CODE_ARM_REQUIRED = "code_arm_required"
 CONF_DEVICE_INDIGITALL = "idDeviceIndigitall"
 CONF_ENTRY_ID = "entry_id"
 CONF_DELAY_CHECK_OPERATION = "delay_check_operation"
+CONF_OPERATION_POLL_TIMEOUT = "operation_poll_timeout"
 CONF_MAP_HOME = "map_home"
 CONF_MAP_AWAY = "map_away"
 CONF_MAP_NIGHT = "map_night"
@@ -78,6 +79,11 @@ DEFAULT_CODE_ARM_REQUIRED = False
 DEFAULT_ENABLE_ACTIVITY_POLLING = False
 DEFAULT_FORCE_ARM_NOTIFICATIONS = True
 DEFAULT_DELAY_CHECK_OPERATION = 2
+# Wall-clock seconds to wait for an arm/disarm confirmation poll to leave
+# the WAIT state before treating the operation as accepted-but-unconfirmed.
+# Raised from the legacy hard-coded 60 s — the IT (SDVECU) backend routinely
+# stays on `alarm-manager.processing.request` longer than that (issue #508).
+DEFAULT_OPERATION_POLL_TIMEOUT = 120.0
 DEFAULT_CODE = ""
 DEFAULT_COUNTRY = "ES"
 API_CACHE_TTL = 60  # seconds — sensor data changes hourly at most

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -23,8 +23,10 @@ from .api_queue import ApiQueue
 from .const import (
     CONF_COUNTRY,
     CONF_DELAY_CHECK_OPERATION,
+    CONF_OPERATION_POLL_TIMEOUT,
     CONF_DEVICE_INDIGITALL,
     CONF_REFRESH_TOKEN,
+    DEFAULT_OPERATION_POLL_TIMEOUT,
     DOMAIN,
     SIGNAL_CAMERA_STATE,
 )
@@ -173,6 +175,9 @@ class VerisureHub:
             uuid=domain_config[CONF_UNIQUE_ID],
             id_device_indigitall=domain_config[CONF_DEVICE_INDIGITALL],
             poll_delay=domain_config[CONF_DELAY_CHECK_OPERATION],
+            poll_timeout=domain_config.get(
+                CONF_OPERATION_POLL_TIMEOUT, DEFAULT_OPERATION_POLL_TIMEOUT
+            ),
             log_filter=self.log_filter,
             refresh_token=domain_config.get(CONF_REFRESH_TOKEN),
             on_refresh_token_changed=self._persist_refresh_token,

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.2.0"
+    "version": "5.3.0"
 }

--- a/custom_components/securitas/notification_translations.py
+++ b/custom_components/securitas/notification_translations.py
@@ -40,6 +40,26 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
             "title": "Verisure: Disarming failed",
             "message": "{error}",
         },
+        "arm_unconfirmed": {
+            "title": "Verisure: Arm not confirmed",
+            "message": (
+                "The arm command was sent to {installation} and accepted, but "
+                "the panel hasn't confirmed the new state within {timeout}s. The "
+                "state shown is provisional and will update automatically once "
+                "the panel reports in. If this keeps happening, raise the "
+                "**Operation poll timeout** in the integration options."
+            ),
+        },
+        "disarm_unconfirmed": {
+            "title": "Verisure: Disarm not confirmed",
+            "message": (
+                "The disarm command was sent to {installation} and accepted, but "
+                "the panel hasn't confirmed the new state within {timeout}s. The "
+                "state shown is provisional and will update automatically once "
+                "the panel reports in. If this keeps happening, raise the "
+                "**Operation poll timeout** in the integration options."
+            ),
+        },
         "rate_limited": {
             "title": "Verisure: Rate limited",
             "message": (
@@ -107,6 +127,26 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
         "disarm_failed": {
             "title": "Verisure: Error al desarmar",
             "message": "{error}",
+        },
+        "arm_unconfirmed": {
+            "title": "Verisure: Armado sin confirmar",
+            "message": (
+                "El comando de armado se envió a {installation} y se aceptó, pero "
+                "el panel no ha confirmado el nuevo estado en {timeout}s. El estado "
+                "mostrado es provisional y se actualizará automáticamente cuando el "
+                "panel responda. Si ocurre con frecuencia, aumenta el **Tiempo de "
+                "espera de confirmación** en las opciones de la integración."
+            ),
+        },
+        "disarm_unconfirmed": {
+            "title": "Verisure: Desarmado sin confirmar",
+            "message": (
+                "El comando de desarmado se envió a {installation} y se aceptó, pero "
+                "el panel no ha confirmado el nuevo estado en {timeout}s. El estado "
+                "mostrado es provisional y se actualizará automáticamente cuando el "
+                "panel responda. Si ocurre con frecuencia, aumenta el **Tiempo de "
+                "espera de confirmación** en las opciones de la integración."
+            ),
         },
         "rate_limited": {
             "title": "Verisure: Demasiadas solicitudes",
@@ -177,6 +217,27 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
         "disarm_failed": {
             "title": "Verisure : Échec du désarmement",
             "message": "{error}",
+        },
+        "arm_unconfirmed": {
+            "title": "Verisure : Armement non confirmé",
+            "message": (
+                "La commande d'armement a été envoyée à {installation} et acceptée, "
+                "mais le panneau n'a pas confirmé le nouvel état en {timeout}s. "
+                "L'état affiché est provisoire et se mettra à jour automatiquement "
+                "dès que le panneau répondra. Si cela se reproduit souvent, "
+                "augmentez le **Délai d'attente de confirmation** dans les options."
+            ),
+        },
+        "disarm_unconfirmed": {
+            "title": "Verisure : Désarmement non confirmé",
+            "message": (
+                "La commande de désarmement a été envoyée à {installation} et "
+                "acceptée, mais le panneau n'a pas confirmé le nouvel état en "
+                "{timeout}s. L'état affiché est provisoire et se mettra à jour "
+                "automatiquement dès que le panneau répondra. Si cela se reproduit "
+                "souvent, augmentez le **Délai d'attente de confirmation** dans les "
+                "options."
+            ),
         },
         "rate_limited": {
             "title": "Verisure : Trop de requêtes",
@@ -250,6 +311,26 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
             "title": "Verisure: Disattivazione fallita",
             "message": "{error}",
         },
+        "arm_unconfirmed": {
+            "title": "Verisure: inserimento non confermato",
+            "message": (
+                "Il comando di inserimento è stato inviato a {installation} ed "
+                "accettato, ma la centrale non ha confermato il nuovo stato entro "
+                "{timeout}s. Lo stato mostrato è provvisorio e si aggiornerà "
+                "automaticamente quando la centrale risponderà. Se accade spesso, "
+                "aumenta il **Timeout di conferma operazione** nelle opzioni."
+            ),
+        },
+        "disarm_unconfirmed": {
+            "title": "Verisure: disinserimento non confermato",
+            "message": (
+                "Il comando di disinserimento è stato inviato a {installation} ed "
+                "accettato, ma la centrale non ha confermato il nuovo stato entro "
+                "{timeout}s. Lo stato mostrato è provvisorio e si aggiornerà "
+                "automaticamente quando la centrale risponderà. Se accade spesso, "
+                "aumenta il **Timeout di conferma operazione** nelle opzioni."
+            ),
+        },
         "rate_limited": {
             "title": "Verisure: Troppe richieste",
             "message": (
@@ -322,6 +403,26 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
             "title": "Verisure: Falha ao desarmar",
             "message": "{error}",
         },
+        "arm_unconfirmed": {
+            "title": "Verisure: Armar não confirmado",
+            "message": (
+                "O comando de armar foi enviado para {installation} e aceito, mas "
+                "o painel não confirmou o novo estado em {timeout}s. O estado "
+                "mostrado é provisório e será atualizado automaticamente quando o "
+                "painel responder. Se isto acontecer com frequência, aumente o "
+                "**Tempo limite de confirmação** nas opções da integração."
+            ),
+        },
+        "disarm_unconfirmed": {
+            "title": "Verisure: Desarmar não confirmado",
+            "message": (
+                "O comando de desarmar foi enviado para {installation} e aceito, "
+                "mas o painel não confirmou o novo estado em {timeout}s. O estado "
+                "mostrado é provisório e será atualizado automaticamente quando o "
+                "painel responder. Se isto acontecer com frequência, aumente o "
+                "**Tempo limite de confirmação** nas opções da integração."
+            ),
+        },
         "rate_limited": {
             "title": "Verisure: Demasiados pedidos",
             "message": (
@@ -390,6 +491,26 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
         "disarm_failed": {
             "title": "Verisure: Falha ao desarmar",
             "message": "{error}",
+        },
+        "arm_unconfirmed": {
+            "title": "Verisure: Armar não confirmado",
+            "message": (
+                "O comando de armar foi enviado para {installation} e aceito, mas "
+                "o painel não confirmou o novo estado em {timeout}s. O estado "
+                "mostrado é provisório e será atualizado automaticamente quando o "
+                "painel responder. Se isto acontecer com frequência, aumente o "
+                "**Tempo limite de confirmação** nas opções da integração."
+            ),
+        },
+        "disarm_unconfirmed": {
+            "title": "Verisure: Desarmar não confirmado",
+            "message": (
+                "O comando de desarmar foi enviado para {installation} e aceito, "
+                "mas o painel não confirmou o novo estado em {timeout}s. O estado "
+                "mostrado é provisório e será atualizado automaticamente quando o "
+                "painel responder. Se isto acontecer com frequência, aumente o "
+                "**Tempo limite de confirmação** nas opções da integração."
+            ),
         },
         "rate_limited": {
             "title": "Verisure: Limite de requisições",
@@ -460,6 +581,26 @@ NOTIFICATION_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
         "disarm_failed": {
             "title": "Verisure: Error en desarmar",
             "message": "{error}",
+        },
+        "arm_unconfirmed": {
+            "title": "Verisure: Armat sense confirmar",
+            "message": (
+                "L'ordre d'armat s'ha enviat a {installation} i s'ha acceptat, però "
+                "el panell no ha confirmat el nou estat en {timeout}s. L'estat "
+                "mostrat és provisional i s'actualitzarà automàticament quan el "
+                "panell respongui. Si passa sovint, augmenta el **Temps d'espera de "
+                "confirmació** a les opcions de la integració."
+            ),
+        },
+        "disarm_unconfirmed": {
+            "title": "Verisure: Desarmat sense confirmar",
+            "message": (
+                "L'ordre de desarmat s'ha enviat a {installation} i s'ha acceptat, "
+                "però el panell no ha confirmat el nou estat en {timeout}s. L'estat "
+                "mostrat és provisional i s'actualitzarà automàticament quan el "
+                "panell respongui. Si passa sovint, augmenta el **Temps d'espera de "
+                "confirmació** a les opcions de la integració."
+            ),
         },
         "rate_limited": {
             "title": "Verisure: Massa peticions",

--- a/custom_components/securitas/strings.json
+++ b/custom_components/securitas/strings.json
@@ -86,7 +86,11 @@
                         "name": "Advanced",
                         "data": {
                             "scan_interval": "Update scan interval in seconds (0 disables auto-updates)",
-                            "delay_check_operation": "Delay between API requests (sec)"
+                            "delay_check_operation": "Delay between API requests (sec)",
+                            "operation_poll_timeout": "Operation poll timeout (seconds)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
                         }
                     }
                 }
@@ -140,7 +144,11 @@
                         "name": "Advanced",
                         "data": {
                             "scan_interval": "Update scan interval in seconds (0 disables auto-updates)",
-                            "delay_check_operation": "Delay between API requests (sec)"
+                            "delay_check_operation": "Delay between API requests (sec)",
+                            "operation_poll_timeout": "Operation poll timeout (seconds)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
                         }
                     }
                 }

--- a/custom_components/securitas/strings.json
+++ b/custom_components/securitas/strings.json
@@ -90,7 +90,7 @@
                             "operation_poll_timeout": "Operation poll timeout (seconds)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm action. Raise this if you get timeout warnings."
                         }
                     }
                 }
@@ -148,7 +148,7 @@
                             "operation_poll_timeout": "Operation poll timeout (seconds)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm action. Raise this if you get timeout warnings."
                         }
                     }
                 }

--- a/custom_components/securitas/translations/ca.json
+++ b/custom_components/securitas/translations/ca.json
@@ -68,7 +68,7 @@
                             "operation_poll_timeout": "Temps d'espera de confirmació (segons)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Quant de temps esperar que el panell confirmi un armat/desarmat abans de mostrar el nou estat com a provisional. Augmenta'l en servidors lents (p. ex. Itàlia)."
+                            "operation_poll_timeout": "Quant de temps esperar que el panell confirmi una acció d'armat/desarmat. Augmenta'l si reps avisos de temps d'espera esgotat."
                         }
                     },
                     "pin": {
@@ -126,7 +126,7 @@
                             "operation_poll_timeout": "Temps d'espera de confirmació (segons)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Quant de temps esperar que el panell confirmi un armat/desarmat abans de mostrar el nou estat com a provisional. Augmenta'l en servidors lents (p. ex. Itàlia)."
+                            "operation_poll_timeout": "Quant de temps esperar que el panell confirmi una acció d'armat/desarmat. Augmenta'l si reps avisos de temps d'espera esgotat."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/ca.json
+++ b/custom_components/securitas/translations/ca.json
@@ -64,7 +64,11 @@
                         "name": "Avançat",
                         "data": {
                             "scan_interval": "Interval d'actualització en segons (0 desactiva les actualitzacions automàtiques)",
-                            "delay_check_operation": "Retard entre sol·licituds de l'API (s)"
+                            "delay_check_operation": "Retard entre sol·licituds de l'API (s)",
+                            "operation_poll_timeout": "Temps d'espera de confirmació (segons)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Quant de temps esperar que el panell confirmi un armat/desarmat abans de mostrar el nou estat com a provisional. Augmenta'l en servidors lents (p. ex. Itàlia)."
                         }
                     },
                     "pin": {
@@ -118,7 +122,11 @@
                         "name": "Avançat",
                         "data": {
                             "scan_interval": "Interval d'actualització en segons (0 desactiva les actualitzacions automàtiques)",
-                            "delay_check_operation": "Retard entre sol·licituds de l'API (s)"
+                            "delay_check_operation": "Retard entre sol·licituds de l'API (s)",
+                            "operation_poll_timeout": "Temps d'espera de confirmació (segons)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Quant de temps esperar que el panell confirmi un armat/desarmat abans de mostrar el nou estat com a provisional. Augmenta'l en servidors lents (p. ex. Itàlia)."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/en.json
+++ b/custom_components/securitas/translations/en.json
@@ -86,7 +86,11 @@
                         "name": "Advanced",
                         "data": {
                             "scan_interval": "Update scan interval in seconds (0 disables auto-updates)",
-                            "delay_check_operation": "Delay between API requests (sec)"
+                            "delay_check_operation": "Delay between API requests (sec)",
+                            "operation_poll_timeout": "Operation poll timeout (seconds)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
                         }
                     }
                 }
@@ -140,7 +144,11 @@
                         "name": "Advanced",
                         "data": {
                             "scan_interval": "Update scan interval in seconds (0 disables auto-updates)",
-                            "delay_check_operation": "Delay between API requests (sec)"
+                            "delay_check_operation": "Delay between API requests (sec)",
+                            "operation_poll_timeout": "Operation poll timeout (seconds)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
                         }
                     }
                 }

--- a/custom_components/securitas/translations/en.json
+++ b/custom_components/securitas/translations/en.json
@@ -90,7 +90,7 @@
                             "operation_poll_timeout": "Operation poll timeout (seconds)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm action. Raise this if you get timeout warnings."
                         }
                     }
                 }
@@ -148,7 +148,7 @@
                             "operation_poll_timeout": "Operation poll timeout (seconds)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm before showing the new state as provisional. Raise this on slow backends (e.g. Italy)."
+                            "operation_poll_timeout": "How long to wait for the panel to confirm an arm/disarm action. Raise this if you get timeout warnings."
                         }
                     }
                 }

--- a/custom_components/securitas/translations/es.json
+++ b/custom_components/securitas/translations/es.json
@@ -68,7 +68,7 @@
                             "operation_poll_timeout": "Tiempo de espera de confirmación (segundos)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Cuánto tiempo esperar a que el panel confirme un armado/desarmado antes de mostrar el nuevo estado como provisional. Auméntalo en servidores lentos (p. ej. Italia)."
+                            "operation_poll_timeout": "Cuánto tiempo esperar a que el panel confirme una acción de armado/desarmado. Auméntalo si recibes avisos de tiempo de espera agotado."
                         }
                     },
                     "pin": {
@@ -126,7 +126,7 @@
                             "operation_poll_timeout": "Tiempo de espera de confirmación (segundos)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Cuánto tiempo esperar a que el panel confirme un armado/desarmado antes de mostrar el nuevo estado como provisional. Auméntalo en servidores lentos (p. ej. Italia)."
+                            "operation_poll_timeout": "Cuánto tiempo esperar a que el panel confirme una acción de armado/desarmado. Auméntalo si recibes avisos de tiempo de espera agotado."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/es.json
+++ b/custom_components/securitas/translations/es.json
@@ -64,7 +64,11 @@
                         "name": "Avanzado",
                         "data": {
                             "scan_interval": "Intervalo de actualización en segundos (0 desactiva las actualizaciones automáticas)",
-                            "delay_check_operation": "Retardo entre solicitudes de API (seg)"
+                            "delay_check_operation": "Retardo entre solicitudes de API (seg)",
+                            "operation_poll_timeout": "Tiempo de espera de confirmación (segundos)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Cuánto tiempo esperar a que el panel confirme un armado/desarmado antes de mostrar el nuevo estado como provisional. Auméntalo en servidores lentos (p. ej. Italia)."
                         }
                     },
                     "pin": {
@@ -118,7 +122,11 @@
                         "name": "Avanzado",
                         "data": {
                             "scan_interval": "Intervalo de actualización en segundos (0 desactiva las actualizaciones automáticas)",
-                            "delay_check_operation": "Retardo entre solicitudes de API (seg)"
+                            "delay_check_operation": "Retardo entre solicitudes de API (seg)",
+                            "operation_poll_timeout": "Tiempo de espera de confirmación (segundos)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Cuánto tiempo esperar a que el panel confirme un armado/desarmado antes de mostrar el nuevo estado como provisional. Auméntalo en servidores lentos (p. ej. Italia)."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -68,7 +68,7 @@
                             "operation_poll_timeout": "Délai d'attente de confirmation (secondes)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Durée d'attente de la confirmation d'armement/désarmement par le panneau avant d'afficher le nouvel état comme provisoire. Augmentez-la sur les serveurs lents (p. ex. l'Italie)."
+                            "operation_poll_timeout": "Durée d'attente de la confirmation d'une action d'armement/désarmement par le panneau. Augmentez-la si vous recevez des avertissements de délai dépassé."
                         }
                     },
                     "pin": {
@@ -126,7 +126,7 @@
                             "operation_poll_timeout": "Délai d'attente de confirmation (secondes)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Durée d'attente de la confirmation d'armement/désarmement par le panneau avant d'afficher le nouvel état comme provisoire. Augmentez-la sur les serveurs lents (p. ex. l'Italie)."
+                            "operation_poll_timeout": "Durée d'attente de la confirmation d'une action d'armement/désarmement par le panneau. Augmentez-la si vous recevez des avertissements de délai dépassé."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -64,7 +64,11 @@
                         "name": "Avancé",
                         "data": {
                             "scan_interval": "Intervalle de mise à jour en secondes (0 désactive les mises à jour automatiques)",
-                            "delay_check_operation": "Délai entre les requêtes API (sec)"
+                            "delay_check_operation": "Délai entre les requêtes API (sec)",
+                            "operation_poll_timeout": "Délai d'attente de confirmation (secondes)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Durée d'attente de la confirmation d'armement/désarmement par le panneau avant d'afficher le nouvel état comme provisoire. Augmentez-la sur les serveurs lents (p. ex. l'Italie)."
                         }
                     },
                     "pin": {
@@ -118,7 +122,11 @@
                         "name": "Avancé",
                         "data": {
                             "scan_interval": "Intervalle de mise à jour en secondes (0 désactive les mises à jour automatiques)",
-                            "delay_check_operation": "Délai entre les requêtes API (sec)"
+                            "delay_check_operation": "Délai entre les requêtes API (sec)",
+                            "operation_poll_timeout": "Délai d'attente de confirmation (secondes)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Durée d'attente de la confirmation d'armement/désarmement par le panneau avant d'afficher le nouvel état comme provisoire. Augmentez-la sur les serveurs lents (p. ex. l'Italie)."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -64,7 +64,11 @@
                         "name": "Avanzato",
                         "data": {
                             "scan_interval": "Intervallo di aggiornamento in secondi (0 disattiva gli aggiornamenti automatici)",
-                            "delay_check_operation": "Ritardo tra le richieste API (sec)"
+                            "delay_check_operation": "Ritardo tra le richieste API (sec)",
+                            "operation_poll_timeout": "Timeout di conferma operazione (secondi)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Per quanto tempo attendere che la centrale confermi un inserimento/disinserimento prima di mostrare il nuovo stato come provvisorio. Aumentalo su backend lenti (es. Italia)."
                         }
                     },
                     "pin": {
@@ -118,7 +122,11 @@
                         "name": "Avanzato",
                         "data": {
                             "scan_interval": "Intervallo di aggiornamento in secondi (0 disattiva gli aggiornamenti automatici)",
-                            "delay_check_operation": "Ritardo tra le richieste API (sec)"
+                            "delay_check_operation": "Ritardo tra le richieste API (sec)",
+                            "operation_poll_timeout": "Timeout di conferma operazione (secondi)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Per quanto tempo attendere che la centrale confermi un inserimento/disinserimento prima di mostrare il nuovo stato come provvisorio. Aumentalo su backend lenti (es. Italia)."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -68,7 +68,7 @@
                             "operation_poll_timeout": "Timeout di conferma operazione (secondi)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Per quanto tempo attendere che la centrale confermi un inserimento/disinserimento prima di mostrare il nuovo stato come provvisorio. Aumentalo su backend lenti (es. Italia)."
+                            "operation_poll_timeout": "Per quanto tempo attendere che la centrale confermi un'azione di inserimento/disinserimento. Aumentalo se ricevi avvisi di timeout."
                         }
                     },
                     "pin": {
@@ -126,7 +126,7 @@
                             "operation_poll_timeout": "Timeout di conferma operazione (secondi)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Per quanto tempo attendere che la centrale confermi un inserimento/disinserimento prima di mostrare il nuovo stato come provvisorio. Aumentalo su backend lenti (es. Italia)."
+                            "operation_poll_timeout": "Per quanto tempo attendere che la centrale confermi un'azione di inserimento/disinserimento. Aumentalo se ricevi avvisi di timeout."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -68,7 +68,7 @@
                             "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de uma ação de armar/desarmar pelo painel. Aumente se receber avisos de tempo limite."
                         }
                     },
                     "pin": {
@@ -126,7 +126,7 @@
                             "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de uma ação de armar/desarmar pelo painel. Aumente se receber avisos de tempo limite."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -64,7 +64,11 @@
                         "name": "Avançado",
                         "data": {
                             "scan_interval": "Intervalo de atualização em segundos (0 desativa as atualizações automáticas)",
-                            "delay_check_operation": "Atraso entre solicitações de API (seg)"
+                            "delay_check_operation": "Atraso entre solicitações de API (seg)",
+                            "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
                         }
                     },
                     "pin": {
@@ -118,7 +122,11 @@
                         "name": "Avançado",
                         "data": {
                             "scan_interval": "Intervalo de atualização em segundos (0 desativa as atualizações automáticas)",
-                            "delay_check_operation": "Atraso entre solicitações de API (seg)"
+                            "delay_check_operation": "Atraso entre solicitações de API (seg)",
+                            "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -68,7 +68,7 @@
                             "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de uma ação de armar/desarmar pelo painel. Aumente se receber avisos de tempo limite."
                         }
                     },
                     "pin": {
@@ -126,7 +126,7 @@
                             "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
                         },
                         "data_description": {
-                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de uma ação de armar/desarmar pelo painel. Aumente se receber avisos de tempo limite."
                         }
                     },
                     "pin": {

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -64,7 +64,11 @@
                         "name": "Avançado",
                         "data": {
                             "scan_interval": "Intervalo de atualização em segundos (0 desativa as atualizações automáticas)",
-                            "delay_check_operation": "Atraso entre solicitações de API (seg)"
+                            "delay_check_operation": "Atraso entre solicitações de API (seg)",
+                            "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
                         }
                     },
                     "pin": {
@@ -118,7 +122,11 @@
                         "name": "Avançado",
                         "data": {
                             "scan_interval": "Intervalo de atualização em segundos (0 desativa as atualizações automáticas)",
-                            "delay_check_operation": "Atraso entre solicitações de API (seg)"
+                            "delay_check_operation": "Atraso entre solicitações de API (seg)",
+                            "operation_poll_timeout": "Tempo limite de confirmação (segundos)"
+                        },
+                        "data_description": {
+                            "operation_poll_timeout": "Quanto tempo aguardar a confirmação de armar/desarmar pelo painel antes de mostrar o novo estado como provisório. Aumente em servidores lentos (por exemplo, Itália)."
                         }
                     },
                     "pin": {

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -128,6 +128,19 @@ class TestNotificationTranslationsPersistentMessageTrim:
             )
 
 
+def test_unconfirmed_notification_strings_exist_all_locales():
+    """Every locale defines arm_unconfirmed and disarm_unconfirmed with tokens."""
+    from custom_components.securitas.notification_translations import (
+        NOTIFICATION_TRANSLATIONS,
+    )
+
+    for locale, entries in NOTIFICATION_TRANSLATIONS.items():
+        for key in ("arm_unconfirmed", "disarm_unconfirmed"):
+            assert key in entries, f"{locale} missing {key}"
+            msg = entries[key]["message"]
+            assert "{installation}" in msg and "{timeout}" in msg, f"{locale}/{key}"
+
+
 class TestForceArmExpiredMobileMessageTranslation:
     """force_arm_expired entry must carry a mobile_message string per locale
     for the button-less informational mobile notification on expiry."""

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -8368,3 +8368,32 @@ def test_coordinator_status_clears_provisional_and_dismisses():
     assert call.kwargs["service_data"]["notification_id"].endswith(
         "operation_unconfirmed_123456"
     )
+
+
+async def test_disarm_reentry_guard_ignores_overlapping_call():
+    """A second disarm while one is in progress is ignored (no duplicate DARM)."""
+    from unittest.mock import AsyncMock
+
+    alarm = make_alarm()
+    alarm._last_proto_code = "Q"
+    alarm._operation_in_progress = True  # simulate an in-flight operation
+    alarm.client.disarm_alarm = AsyncMock()
+
+    await alarm.async_alarm_disarm()
+
+    alarm.client.disarm_alarm.assert_not_called()
+
+
+async def test_arm_reentry_guard_ignores_overlapping_call():
+    """A second arm while one is in progress is ignored (no duplicate command)."""
+    from unittest.mock import AsyncMock
+    from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+
+    alarm = make_alarm()
+    alarm._last_proto_code = "D"
+    alarm._operation_in_progress = True  # simulate an in-flight operation
+    alarm.client.arm_alarm = AsyncMock()
+
+    await alarm.set_arm_state(AlarmControlPanelState.ARMED_AWAY)
+
+    alarm.client.arm_alarm.assert_not_called()

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -8370,6 +8370,29 @@ def test_coordinator_status_clears_provisional_and_dismisses():
     )
 
 
+def test_subpanel_coordinator_status_clears_provisional_and_dismisses():
+    """Axis sub-panels override _update_from_coordinator, so they must also
+    reconcile a provisional flag on a fresh authoritative status (#508)."""
+    from custom_components.securitas.coordinators import AlarmStatusData
+
+    alarm = _make_interior_panel()
+    alarm._set_state_provisional(True)
+
+    status = SStatus(status="D", timestamp_update="1", wifi_connected=False)
+    data = AlarmStatusData(status=status, protom_response="D")
+
+    alarm._update_from_coordinator(data)
+
+    assert "state_provisional" not in alarm._attr_extra_state_attributes
+    alarm.hass.async_create_task.assert_called()
+    call = alarm.hass.services.async_call.call_args
+    assert call is not None, "hass.services.async_call was not called"
+    assert call.kwargs["service"] == "dismiss"
+    assert call.kwargs["service_data"]["notification_id"].endswith(
+        "operation_unconfirmed_12345"
+    )
+
+
 async def test_disarm_reentry_guard_ignores_overlapping_call():
     """A second disarm while one is in progress is ignored (no duplicate DARM)."""
     from unittest.mock import AsyncMock

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -8393,6 +8393,32 @@ def test_subpanel_coordinator_status_clears_provisional_and_dismisses():
     )
 
 
+async def test_disarm_genuine_failure_rolls_back_and_is_not_provisional():
+    """A non-timeout VerisureOwaError still rolls back + notifies disarm_failed
+    and must NOT set the provisional flag — only timeouts are provisional."""
+    from unittest.mock import AsyncMock
+
+    from custom_components.securitas.verisure_owa_api.exceptions import (
+        VerisureOwaError,
+    )
+
+    alarm = make_alarm()
+    alarm._last_proto_code = "Q"  # armed_night
+    alarm._last_state = AlarmControlPanelState.ARMED_NIGHT
+    alarm._state = AlarmControlPanelState.ARMED_NIGHT
+    alarm.client.disarm_alarm = AsyncMock(side_effect=VerisureOwaError("boom"))
+
+    with patch(
+        "custom_components.securitas.alarm_control_panel._base._notify"
+    ) as mock_notify:
+        await alarm.async_alarm_disarm()
+
+    # Genuine failure: rolled back to the prior state, NOT provisional.
+    assert "state_provisional" not in alarm._attr_extra_state_attributes
+    assert alarm._state == AlarmControlPanelState.ARMED_NIGHT
+    assert mock_notify.call_args[0][2] == "disarm_failed"
+
+
 async def test_disarm_reentry_guard_ignores_overlapping_call():
     """A second disarm while one is in progress is ignored (no duplicate DARM)."""
     from unittest.mock import AsyncMock

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -8333,4 +8333,38 @@ async def test_arm_timeout_is_provisional_not_failed():
     assert alarm._state == AlarmControlPanelState.ARMED_AWAY  # optimistic target
     assert alarm._attr_extra_state_attributes.get("state_provisional") is True
     assert mock_notify.call_args[0][2] == "arm_unconfirmed"
-    alarm.coordinator.async_request_refresh.assert_awaited()
+
+
+def test_coordinator_status_clears_provisional_and_dismisses():
+    """A fresh authoritative status clears the provisional flag and dismisses
+    the unconfirmed notification."""
+    from custom_components.securitas.coordinators import AlarmStatusData
+
+    alarm = make_alarm()
+    alarm._set_state_provisional(True)
+
+    # Build AlarmStatusData with an SStatus carrying a real proto code.
+    # SStatus uses pydantic with populate_by_name=True so keyword args
+    # must match the Python field names (status, timestamp_update, wifi_connected).
+    status = SStatus(status="D", timestamp_update="1", wifi_connected=False)
+    data = AlarmStatusData(status=status, protom_response="D")
+
+    alarm._update_from_coordinator(data)
+
+    # Provisional flag must be cleared.
+    assert "state_provisional" not in alarm._attr_extra_state_attributes
+
+    # async_create_task must have been called to schedule the dismiss.
+    alarm.hass.async_create_task.assert_called()
+
+    # Verify the dismiss targets the correct notification id.
+    # hass.services.async_call is a MagicMock; calling it (inside the
+    # coroutine-like object passed to async_create_task) records the call
+    # synchronously — _consume_coro only calls .close() on the return value.
+    call = alarm.hass.services.async_call.call_args
+    assert call is not None, "hass.services.async_call was not called"
+    assert call.kwargs["domain"] == "persistent_notification"
+    assert call.kwargs["service"] == "dismiss"
+    assert call.kwargs["service_data"]["notification_id"].endswith(
+        "operation_unconfirmed_123456"
+    )

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -8305,3 +8305,32 @@ async def test_disarm_timeout_is_provisional_not_failed():
     assert alarm._attr_extra_state_attributes.get("state_provisional") is True
     assert mock_notify.call_args[0][2] == "disarm_unconfirmed"
     alarm.coordinator.async_request_refresh.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_arm_timeout_is_provisional_not_failed():
+    """OperationTimeoutError after accepted arm => optimistic target state +
+    provisional flag + unconfirmed notification, NOT a rollback/failure."""
+    from unittest.mock import AsyncMock
+    from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+    from custom_components.securitas.verisure_owa_api.exceptions import (
+        OperationTimeoutError,
+    )
+
+    alarm = make_alarm()
+    alarm._last_proto_code = "D"  # disarmed
+    alarm._last_state = AlarmControlPanelState.DISARMED
+    alarm._state = AlarmControlPanelState.DISARMED
+    alarm.client.arm_alarm = AsyncMock(
+        side_effect=OperationTimeoutError("Poll operation timed out after 120.0s")
+    )
+
+    with patch(
+        "custom_components.securitas.alarm_control_panel._base._notify"
+    ) as mock_notify:
+        await alarm.set_arm_state(AlarmControlPanelState.ARMED_AWAY)
+
+    assert alarm._state == AlarmControlPanelState.ARMED_AWAY  # optimistic target
+    assert alarm._attr_extra_state_attributes.get("state_provisional") is True
+    assert mock_notify.call_args[0][2] == "arm_unconfirmed"
+    alarm.coordinator.async_request_refresh.assert_awaited()

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -8261,3 +8261,18 @@ class TestAsyncManualRefresh:
         await alarm.async_manual_refresh()
 
         assert alarm._attr_extra_state_attributes.get("waf_blocked") is True
+
+
+def test_optimistic_status_maps_target_to_proto():
+    alarm = make_alarm()
+    target = alarm._resolve_target_state("disarmed")
+    status = alarm._optimistic_status(target)
+    assert status.protom_response == "D"  # PROTO_DISARMED
+
+
+def test_set_state_provisional_toggles_attribute():
+    alarm = make_alarm()
+    alarm._set_state_provisional(True)
+    assert alarm._attr_extra_state_attributes.get("state_provisional") is True
+    alarm._set_state_provisional(False)
+    assert "state_provisional" not in alarm._attr_extra_state_attributes

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -8276,3 +8276,32 @@ def test_set_state_provisional_toggles_attribute():
     assert alarm._attr_extra_state_attributes.get("state_provisional") is True
     alarm._set_state_provisional(False)
     assert "state_provisional" not in alarm._attr_extra_state_attributes
+
+
+@pytest.mark.asyncio
+async def test_disarm_timeout_is_provisional_not_failed():
+    """OperationTimeoutError after accepted disarm => optimistic disarmed +
+    provisional flag + unconfirmed notification, NOT a rollback/failure."""
+    from unittest.mock import AsyncMock
+    from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+    from custom_components.securitas.verisure_owa_api.exceptions import (
+        OperationTimeoutError,
+    )
+
+    alarm = make_alarm()
+    alarm._last_proto_code = "Q"  # armed_night
+    alarm._last_state = AlarmControlPanelState.ARMED_NIGHT
+    alarm._state = AlarmControlPanelState.ARMED_NIGHT
+    alarm.client.disarm_alarm = AsyncMock(
+        side_effect=OperationTimeoutError("Poll operation timed out after 120.0s")
+    )
+
+    with patch(
+        "custom_components.securitas.alarm_control_panel._base._notify"
+    ) as mock_notify:
+        await alarm.async_alarm_disarm()
+
+    assert alarm._state == AlarmControlPanelState.DISARMED
+    assert alarm._attr_extra_state_attributes.get("state_provisional") is True
+    assert mock_notify.call_args[0][2] == "disarm_unconfirmed"
+    alarm.coordinator.async_request_refresh.assert_awaited()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2618,3 +2618,70 @@ class TestNotifyServiceDropdown:
         assert "notify" not in labels
         assert "send_message" not in labels
         assert "mobile_app_phone" in labels
+
+
+async def test_operation_poll_timeout_round_trips(hass):
+    """The advanced option is stored and surfaced in the runtime config dict."""
+    from custom_components.securitas import _build_config_dict
+    from custom_components.securitas.const import (
+        CONF_OPERATION_POLL_TIMEOUT,
+        DEFAULT_OPERATION_POLL_TIMEOUT,
+    )
+    from tests.conftest import make_config_entry_data
+
+    base_data = make_config_entry_data()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=base_data,
+        options={CONF_OPERATION_POLL_TIMEOUT: 180.0},
+    )
+    entry.add_to_hass(hass)
+    config, _ = _build_config_dict(entry)
+    assert config[CONF_OPERATION_POLL_TIMEOUT] == 180.0
+
+    entry_default = MockConfigEntry(
+        domain=DOMAIN,
+        data=base_data,
+        options={},
+    )
+    entry_default.add_to_hass(hass)
+    config_default, _ = _build_config_dict(entry_default)
+    assert config_default[CONF_OPERATION_POLL_TIMEOUT] == DEFAULT_OPERATION_POLL_TIMEOUT
+
+
+async def test_options_init_prefills_saved_operation_poll_timeout(hass):
+    """Reopening Options must pre-fill a previously saved operation_poll_timeout.
+
+    Regression for the bug where CONF_OPERATION_POLL_TIMEOUT was missing from
+    the defaults dict passed to _build_settings_schema, causing the form to
+    always show the schema default (120 s) instead of the saved value.
+    """
+    from custom_components.securitas.const import (
+        CONF_OPERATION_POLL_TIMEOUT,
+        DEFAULT_OPERATION_POLL_TIMEOUT,
+    )
+
+    saved_value = 180.0
+    assert saved_value != DEFAULT_OPERATION_POLL_TIMEOUT, (
+        "test value must differ from the schema default to be meaningful"
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=make_config_entry_data(),
+        options={CONF_OPERATION_POLL_TIMEOUT: saved_value},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    marker = _section_inner_marker(result["data_schema"], CONF_ADVANCED, CONF_OPERATION_POLL_TIMEOUT)
+    assert marker is not None, "operation_poll_timeout field not found in advanced section"
+    assert marker.default() == saved_value, (
+        f"Expected pre-filled default {saved_value!r}, got {marker.default()!r}. "
+        "CONF_OPERATION_POLL_TIMEOUT is missing from the async_step_init defaults dict."
+    )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2679,8 +2679,12 @@ async def test_options_init_prefills_saved_operation_poll_timeout(hass):
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
-    marker = _section_inner_marker(result["data_schema"], CONF_ADVANCED, CONF_OPERATION_POLL_TIMEOUT)
-    assert marker is not None, "operation_poll_timeout field not found in advanced section"
+    marker = _section_inner_marker(
+        result["data_schema"], CONF_ADVANCED, CONF_OPERATION_POLL_TIMEOUT
+    )
+    assert marker is not None, (
+        "operation_poll_timeout field not found in advanced section"
+    )
     assert marker.default() == saved_value, (
         f"Expected pre-filled default {saved_value!r}, got {marker.default()!r}. "
         "CONF_OPERATION_POLL_TIMEOUT is missing from the async_step_init defaults dict."


### PR DESCRIPTION
## Summary

Fixes #508. On the IT (SDVECU) backend, arm/disarm commands are accepted (`xSArm/DisarmPanel` → `res: OK`) but the follow-up confirmation poll (`xSArm/DisarmStatus`) frequently stays on `WAIT / alarm-manager.processing.request` past the hard-coded **60 s** `poll_timeout`. The old behaviour treated that timeout as a **failure**: it rolled the entity state back to the previous state, logged ERROR, and raised an `arm_failed` / `disarm_failed` notification — even though the panel had actually actioned the command. That produced a dangerous stale state (e.g. HA showing `disarmed` while the panel was armed) and false failures.

The official web client uses the **same** submit→poll flow (confirmed from a HAR capture), so the poll is kept — only the *timeout handling* changes.

## What changed

- **`operation_poll_timeout` is now configurable** (Advanced options; default **120 s**, range 60–300), threaded options-flow → runtime config → `VerisureOwaClient`. The hard-coded 60 s was never passed through and was the root trigger on IT.
- **A timed-out-but-accepted arm/disarm is treated as *accepted-but-provisional*, not a failure.** The entity optimistically shows the **target** state (the fail-safe direction), sets a `state_provisional` attribute, logs at WARNING, raises a distinct `arm_unconfirmed` / `disarm_unconfirmed` persistent notification (explains the state is provisional and to raise the timeout if it recurs), and requests a coordinator refresh. **It never rolls back.** Genuine, non-timeout failures still roll back + ERROR + `*_failed` exactly as before.
- **Reconciliation:** when the coordinator's next authoritative `xSStatus` read arrives, the provisional flag is cleared and the notification dismissed — on the combined panel **and** the axis sub-panels (Interior/Perimeter/Annex), whose `_update_from_coordinator` override would otherwise skip it.
- **Re-entry guard:** overlapping arm/disarm commands on the same entity are dropped (the duplicate `DARM1` storm visible in the issue logs).
- New user-facing strings translated across all 7 locales (en, es, fr, it, pt, pt-BR, ca): the option label/description and both notifications.

## Testing

New unit tests cover: configurable-timeout round-trip + options pre-fill; the `*_unconfirmed` strings in every locale; the provisional/optimistic/notify helpers; disarm + arm timeout → provisional (no rollback); genuine failure → rollback + **not** provisional; reconcile-clears-and-dismisses on both the combined panel and a sub-panel; and the re-entry guard.

Locally green: `ruff check`, `ruff format`, `pyright` (0/0), `pylint` (10.00/10), full `pytest` suite; pre-push hook passed.

## Known follow-ups (intentionally not in this PR)

- **`execute_partial_disarm`** (lock-automation circuit disarm) still rolls back on a poll timeout — the same symptom on that sibling path, though in the fail-safe direction (shows still-armed). Documented at the call site; needs its own per-entity provisional handling + tests.
- Cross-sibling concurrency lock (the re-entry guard is per-entity only).
- Session re-establishment on `error_protom_session` / `status_inventory_error`.
