### PR TITLE
chore: bump version to 5.4.0 for development

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.3.0"
+    "version": "5.4.0"
 }


### PR DESCRIPTION
## Summary

Post-release roll-forward for the **5.3.0** release.

`v5.3.0` was promoted from pre-release to a final release by editing the existing GitHub release — the `release.yaml` workflow can't re-run for an already-existing tag. That manual promotion bypassed the workflow's *"Roll branch forward to the next minor (final releases only)"* step, which normally bumps `main` so unreleased work no longer carries the just-shipped version.

This bumps the manifest to **5.4.0** (next minor) for development — exactly what the workflow would have pushed automatically after a final release.

No code change; manifest version only.
