### PR TITLE
feat(activity): categorize smart-lock door + Verisure routine events

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ If you want every event to fire on the bus, turn on continuous polling under **S
 
 Each entry carries a **category** — a stable label for the type of event. The full list:
 
-`armed`, `armed_with_exceptions`, `arming_failed`, `disarmed`, `alarm`, `alarm_resolved`, `tampering`, `sabotage`, `image_request`, `power_cut`, `power_restored`, `status_check`, `communication_failed`, `communication_restored`, `unknown`.
+`armed`, `armed_with_exceptions`, `arming_failed`, `disarmed`, `alarm`, `alarm_resolved`, `tampering`, `sabotage`, `image_request`, `power_cut`, `power_restored`, `status_check`, `communication_failed`, `communication_restored`, `door_opened`, `door_closed`, `routine_executed`, `unknown`.
 
 ### Activity events vs the alarm panel entity
 

--- a/custom_components/securitas/verisure_owa_api/models/activity.py
+++ b/custom_components/securitas/verisure_owa_api/models/activity.py
@@ -70,6 +70,13 @@ class ActivityCategory(StrEnum):
     # unreachable. Mirror of COMMUNICATION_FAILED — the panel emits this
     # when comms recover so the user can correlate outages.
     COMMUNICATION_RESTORED = "communication_restored"
+    # Connected smart-lock (DR device) door signals — the lock opening and
+    # then auto-locking. Distinct events so cards can icon them separately.
+    DOOR_OPENED = "door_opened"
+    DOOR_CLOSED = "door_closed"
+    # A Verisure-app "routine" fired — a user-scheduled automation that can
+    # arm/disarm the alarm on a schedule.
+    ROUTINE_EXECUTED = "routine_executed"
     UNKNOWN = "unknown"
 
 
@@ -141,6 +148,15 @@ _ACTIVITY_TYPE_TO_CATEGORY: dict[int, ActivityCategory] = {
     # "Estado de las comunicaciones" — emitted when the panel's link to the
     # central/website returns to normal after a period of being unreachable.
     3121: ActivityCategory.COMMUNICATION_RESTORED,
+    # Connected smart-lock (DR device) door signals. Seen on a French panel as
+    # "Porte ouverte" (324, lock opened) / "Porte fermée" (325, lock auto-locked
+    # a few minutes later). GitHub #512.
+    324: ActivityCategory.DOOR_OPENED,
+    325: ActivityCategory.DOOR_CLOSED,
+    # A Verisure-app "routine" fired (source=ROUTINES) — a user-scheduled
+    # automation that can arm/disarm the alarm. Seen as "Routine exécutée".
+    # GitHub #513.
+    70: ActivityCategory.ROUTINE_EXECUTED,
 }
 
 

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -39,6 +39,9 @@ export const TRANSLATIONS = {
       status_check: "Status check",
       communication_failed: "Communication failed",
       communication_restored: "Communication restored",
+      door_opened: "Door opened",
+      door_closed: "Door closed",
+      routine_executed: "Routine executed",
       unknown: "Unknown event",
     },
     exception_status: {
@@ -74,6 +77,9 @@ export const TRANSLATIONS = {
       status_check: "Comprobación de estado",
       communication_failed: "Fallo de comunicación",
       communication_restored: "Comunicación restablecida",
+      door_opened: "Puerta abierta",
+      door_closed: "Puerta cerrada",
+      routine_executed: "Rutina ejecutada",
       unknown: "Evento desconocido",
     },
     exception_status: {
@@ -109,6 +115,9 @@ export const TRANSLATIONS = {
       status_check: "Verifica di stato",
       communication_failed: "Errore di comunicazione",
       communication_restored: "Comunicazione ripristinata",
+      door_opened: "Porta aperta",
+      door_closed: "Porta chiusa",
+      routine_executed: "Routine eseguita",
       unknown: "Evento sconosciuto",
     },
     exception_status: {
@@ -144,6 +153,9 @@ export const TRANSLATIONS = {
       status_check: "Vérification de l'état",
       communication_failed: "Échec de communication",
       communication_restored: "Communication rétablie",
+      door_opened: "Porte ouverte",
+      door_closed: "Porte fermée",
+      routine_executed: "Routine exécutée",
       unknown: "Événement inconnu",
     },
     exception_status: {
@@ -179,6 +191,9 @@ export const TRANSLATIONS = {
       status_check: "Verificação de estado",
       communication_failed: "Falha de comunicação",
       communication_restored: "Comunicação restaurada",
+      door_opened: "Porta aberta",
+      door_closed: "Porta fechada",
+      routine_executed: "Rotina executada",
       unknown: "Evento desconhecido",
     },
     exception_status: {
@@ -214,6 +229,9 @@ export const TRANSLATIONS = {
       status_check: "Verificação de status",
       communication_failed: "Falha de comunicação",
       communication_restored: "Comunicação restaurada",
+      door_opened: "Porta aberta",
+      door_closed: "Porta fechada",
+      routine_executed: "Rotina executada",
       unknown: "Evento desconhecido",
     },
     exception_status: {
@@ -249,6 +267,9 @@ export const TRANSLATIONS = {
       status_check: "Comprovació d'estat",
       communication_failed: "Error de comunicació",
       communication_restored: "Comunicació restablerta",
+      door_opened: "Porta oberta",
+      door_closed: "Porta tancada",
+      routine_executed: "Rutina executada",
       unknown: "Esdeveniment desconegut",
     },
     exception_status: {
@@ -289,6 +310,9 @@ const CATEGORY_ICONS = {
   status_check: "mdi:lan-check",
   communication_failed: "mdi:lan-disconnect",
   communication_restored: "mdi:lan-connect",
+  door_opened: "mdi:door-open",
+  door_closed: "mdi:door-closed",
+  routine_executed: "mdi:robot",
   unknown: "mdi:help-circle",
 };
 
@@ -307,6 +331,12 @@ const CATEGORY_COLORS = {
   status_check: "var(--secondary-text-color)",
   communication_failed: "var(--error-color, #db4437)",
   communication_restored: "var(--success-color, #43a047)",
+  // Lock opened — an access event, blue/info like an arm-state change.
+  door_opened: "var(--info-color, #039be5)",
+  // Lock auto-closed (secured again) — green like the other "restored" states.
+  door_closed: "var(--success-color, #43a047)",
+  // Routine fired — informational, neutral like status_check.
+  routine_executed: "var(--secondary-text-color)",
   unknown: "var(--secondary-text-color)",
 };
 

--- a/tests-js/integration/activity-log-card.test.js
+++ b/tests-js/integration/activity-log-card.test.js
@@ -547,6 +547,38 @@ describe("verisure-owa-activity-log-card extra branches", () => {
     expect(card.shadowRoot.querySelector(".card-header").textContent).toBe("Recent");
   });
 
+  it.each([
+    ["door_opened", "mdi:door-open", "Door opened"],
+    ["door_closed", "mdi:door-closed", "Door closed"],
+    ["routine_executed", "mdi:robot", "Routine executed"],
+  ])(
+    "renders the %s category with its own icon, label, and no unknown prompt",
+    (category, icon, label) => {
+      const card = mountActivityCard({
+        hass: makeHass({
+          states: {
+            [ENTITY]: makeActivityLogEntity({
+              events: [
+                {
+                  id_signal: `${category}-1`,
+                  time: "2026-06-14 19:21:54",
+                  category,
+                  alias: label,
+                },
+              ],
+            }),
+          },
+        }),
+      });
+      const html = card.shadowRoot.innerHTML;
+      expect(html).toContain(icon);
+      // Not falling through to the unknown icon / prompt.
+      expect(html).not.toContain("mdi:help-circle");
+      expect(card.shadowRoot.querySelector(".unknown-prompt")).toBeNull();
+      expect(card.shadowRoot.querySelector(".category").textContent).toBe(label);
+    },
+  );
+
   it("renders an event whose category is not in CATEGORY_ICONS with the unknown icon", () => {
     const card = mountActivityCard({
       hass: makeHass({

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1132,6 +1132,22 @@ class TestActivityEventCategory:
         a period of being unreachable.  Mirror of COMMUNICATION_FAILED."""
         assert self._ev(3121).category == ActivityCategory.COMMUNICATION_RESTORED
 
+    def test_door_events(self):
+        """324 / 325 are the connected smart-lock (DR device) door signals.
+
+        Seen on a French panel as "Porte ouverte" (324) / "Porte fermée" (325)
+        — the lock opening and then auto-locking a few minutes later. GitHub
+        #512."""
+        assert self._ev(324).category == ActivityCategory.DOOR_OPENED
+        assert self._ev(325).category == ActivityCategory.DOOR_CLOSED
+
+    def test_routine_executed(self):
+        """70 fires when a Verisure-app "routine" runs (source=ROUTINES).
+
+        Routines are user-scheduled automations that can arm/disarm the alarm.
+        Seen as "Routine exécutée". GitHub #513."""
+        assert self._ev(70).category == ActivityCategory.ROUTINE_EXECUTED
+
     def test_unknown_codes(self):
         """Codes we haven't seen fall through to UNKNOWN — future-proofing."""
         assert self._ev(99999).category == ActivityCategory.UNKNOWN


### PR DESCRIPTION
## What

Three panel event types were surfacing as **"Unknown event"** in the activity log. This maps them to proper categories:

| type | panel alias | category | icon | colour |
|------|-------------|----------|------|--------|
| `324` | Porte ouverte | `door_opened` | `mdi:door-open` | info / blue |
| `325` | Porte fermée | `door_closed` | `mdi:door-closed` | success / green |
| `70` | Routine exécutée (`source=ROUTINES`) | `routine_executed` | `mdi:robot` | neutral grey |

- **324 / 325** — a connected smart-lock (`DR` device) opening and then auto-locking a few minutes later. Reported on a French panel in #512.
- **70** — a Verisure-app "routine" firing. Routines are user-scheduled automations that can arm/disarm the alarm. Reported in #513.

## Changes

- `ActivityCategory`: add `DOOR_OPENED`, `DOOR_CLOSED`, `ROUTINE_EXECUTED`; map codes 324/325/70 in `_ACTIVITY_TYPE_TO_CATEGORY`.
- Activity-log card: add icons, colours, and localised labels in **all 7 locales** (en/es/it/fr/pt/pt-BR/ca).
- README: add the three labels to the documented category list.
- These are **panel-only** signals (not HA-initiated), so `HA_INJECTABLE_CATEGORIES` is intentionally left untouched — no dedup-filter impact.

## Tests

- Python: new `test_door_events` + `test_routine_executed` in `TestActivityEventCategory` (TDD — watched them fail first).
- JS: parametrised render test asserting each new category renders its own icon/label and **not** the unknown fallback/prompt; the existing translations-completeness suite enforces all 7 locales carry the new keys.
- Full local run green: pytest 1674 passed · vitest 379 passed · ruff/pyright/pylint/eslint/prettier clean.

Closes #512
Closes #513