### PR TITLE
ci: move dev+stable to Python 3.14 / HA 2026.6, keep minimum on 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - run: pip install ruff
 
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |
@@ -66,8 +66,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ha-channel: [dev, stable, minimum]
-        suite: [unit, integration]
+        # dev + stable run on the current Python (3.14, required by HA 2026.3+).
+        # The minimum channel pins HA 2025.2.0, whose phcc only supports 3.13,
+        # so it stays on 3.13 to keep proving our declared floor still works.
+        include:
+          - { ha-channel: dev, suite: unit, python-version: "3.14" }
+          - { ha-channel: dev, suite: integration, python-version: "3.14" }
+          - { ha-channel: stable, suite: unit, python-version: "3.14" }
+          - { ha-channel: stable, suite: integration, python-version: "3.14" }
+          - { ha-channel: minimum, suite: unit, python-version: "3.13" }
+          - { ha-channel: minimum, suite: integration, python-version: "3.13" }
     steps:
       - uses: actions/checkout@v4
 
@@ -76,13 +84,14 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies (stable)
         if: matrix.ha-channel == 'stable'
         run: |
           pip install --upgrade pip
-          # phcc pins the latest stable HA it supports — just install normally
+          # phcc pins the latest stable HA it supports — on Python 3.14 that is
+          # the 2026.6.x line. Just install normally.
           pip install -r requirements_test.txt
 
       - name: Install dependencies (minimum)
@@ -134,7 +143,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - run: pip install coverage
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import vitest from "eslint-plugin-vitest";
 
 export default [
   {
-    ignores: ["node_modules/**", "coverage/**", ".vitest-cache/**"],
+    ignores: ["node_modules/**", "coverage/**", ".vitest-cache/**", ".venv*/**", "venv/**"],
   },
   js.configs.recommended,
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.26.0
-homeassistant~=2025.2.0
+homeassistant>=2025.2.0
 voluptuous~=0.13.1
 aiohttp~=3.9.5
 PyJWT~=2.8.0

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -168,11 +168,27 @@ class TestForceArmExpiredMobileMessageTranslation:
 # manifest the same way and the test scaffolding can't be constructed — skip
 # those tests rather than fake them, since the real-HA assertions are what
 # give them value.
-_HAS_OBJECT_ID_BASE_KWARG = (
-    "object_id_base"
-    in inspect.signature(
-        _er_for_feature_detect.EntityRegistry.async_get_or_create
-    ).parameters
+def _param_names(func) -> set[str]:
+    """Return *func*'s parameter names without evaluating its annotations.
+
+    On Python 3.14 ``inspect.signature`` eagerly evaluates annotations, which
+    raises ``NameError`` for HA functions whose annotations reference
+    TYPE_CHECKING-only names (e.g. ``ConfigEntry`` on ``async_get_or_create``).
+    We only need the parameter names for feature detection, so request the
+    FORWARDREF format to skip evaluation. On Python 3.13 ``annotationlib``
+    doesn't exist and plain ``signature`` already returns the names safely.
+    """
+    try:
+        from annotationlib import Format
+
+        sig = inspect.signature(func, annotation_format=Format.FORWARDREF)
+    except ImportError:
+        sig = inspect.signature(func)
+    return set(sig.parameters)
+
+
+_HAS_OBJECT_ID_BASE_KWARG = "object_id_base" in _param_names(
+    _er_for_feature_detect.EntityRegistry.async_get_or_create
 )
 _DELETED_REGISTRY_ENTRY_HAS_ALIASES = "aliases" in {
     field.name for field in attr.fields(DeletedRegistryEntry)


### PR DESCRIPTION
## Why

HA 2026.3+ requires Python ≥3.14, and `pytest-homeassistant-custom-component` (phcc) raised its floor to 3.14 at `0.13.317`. On Python 3.13 the newest installable phcc is `0.13.316`, which pins **HA 2026.2.3** — so the CI `stable` channel was silently stuck two minor releases behind latest HA (now 2026.6.3).

## What

- **`tests.yaml`** — split the test matrix so each channel runs on the Python its HA needs:
  - `dev`, `stable` → **Python 3.14** (stable now resolves to the 2026.6.x line)
  - `minimum` → **Python 3.13** (HA 2025.2.0 / phcc 0.13.210, our declared floor)
  - Standalone `lint`/`pylint`/`pyright`/`coverage-gate` jobs → 3.14 to match the primary dev target.
- **`requirements.txt`** — `homeassistant ~=2025.2.0` → `>=2025.2.0`. The `~=` form caps at `<2025.3` and refuses to install on Python 3.14; it's a dev-convenience floor (not used by CI), so expressed as a true minimum.
- **`tests/test_alarm_panel.py`** — on Python 3.14 `inspect.signature` eagerly evaluates a function's annotations, raising `NameError` for HA functions annotated with `TYPE_CHECKING`-only names (`ConfigEntry` on `async_get_or_create`). The feature probe only needs parameter names, so it now requests the `FORWARDREF` annotation format on 3.14 and falls back to plain `signature` on 3.13.

## Verified locally

Recreated the test venv on **Python 3.14.5 / HA 2026.6.3 / phcc 0.13.339** and ran the full suite:
Ruff (lint+format), Pyright (0 errors), Pylint (10.00/10), pytest (**1674 passed**), vitest (**379 passed**).