### PR TITLE
ci: move GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -27,9 +27,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       BRANCH: ${{ github.ref_name }}
       REF_TYPE: ${{ github.ref_type }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,9 +10,9 @@ jobs:
     name: Ruff lint & format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -28,9 +28,9 @@ jobs:
     name: Pylint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -46,9 +46,9 @@ jobs:
     name: Pyright
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -77,12 +77,12 @@ jobs:
           - { ha-channel: minimum, suite: unit, python-version: "3.13" }
           - { ha-channel: minimum, suite: integration, python-version: "3.13" }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libturbojpeg0-dev
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -126,7 +126,7 @@ jobs:
             --cov --cov-report=term-missing --no-cov-on-fail
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.ha-channel }}-${{ matrix.suite }}
           path: .coverage.${{ matrix.ha-channel }}.${{ matrix.suite }}*
@@ -139,9 +139,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -150,12 +150,12 @@ jobs:
       # Gate on the stable channel only — code is identical across channels,
       # so running the gate 3x would just multiply CI minutes for no signal.
       - name: Download unit coverage (stable)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-stable-unit
 
       - name: Download integration coverage (stable)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-stable-integration
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,7 +10,7 @@ jobs:
     name: HACS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: HACS validation
         uses: hacs/action@main
         with:
@@ -20,6 +20,6 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
GitHub Actions runners now execute actions on Node 24 by default and emit a deprecation warning for any action still declaring `using: node20` (see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The CodeQL action additionally warns that v3 will be removed in December 2026.

This bumps the affected actions to their Node 24 majors (verified each target's `runs.using` is `node24`):

- `actions/checkout` v4 → **v5**
- `actions/setup-node` v4 → **v5**
- `actions/setup-python` v5 → **v6**
- `actions/upload-artifact` v4 → **v7**
- `actions/download-artifact` v4 → **v8**
- `github/codeql-action/{init,autobuild,analyze}` v3 → **v4**

Version-only change. The artifact actions' API has been stable since the v3→v4 rewrite, so v4→v7/v8 only moves the runtime; the existing `name`/`path`/`retention-days` inputs are unchanged. `hacs/action@main` and `home-assistant/actions/hassfest@master` left as-is.