### PR TITLE
ci: add nightly "latest deps" workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,72 @@
+name: Nightly (latest deps)
+
+# Runs the repo's checks against the LATEST upstream dependencies (Home
+# Assistant, the test harness, HACS/hassfest) on a daily schedule. This is an
+# early-warning system for breakage introduced by new HA releases, kept
+# SEPARATE from PR CI (tests.yaml / validate.yaml) which pin/range their deps.
+on:
+  schedule:
+    - cron: "41 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests-latest:
+    name: Tests against latest HA + harness
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [unit, integration]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libturbojpeg0-dev
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install latest dependencies
+        run: |
+          pip install --upgrade pip
+          # Pull the newest HA core + custom-component test harness, ignoring the
+          # pinned/ranged versions in requirements_test.txt. Then install the
+          # repo's remaining test requirements (PyJWT, PyTurboJPEG, plugins) on
+          # top — pip keeps the already-upgraded HA/phcc unless a hard conflict
+          # forces otherwise.
+          pip install --upgrade homeassistant pytest-homeassistant-custom-component
+          pip install --upgrade -r requirements_test.txt
+
+      - name: Show resolved versions
+        run: pip list
+
+      - name: Run ${{ matrix.suite }} tests
+        run: |
+          if [ "${{ matrix.suite }}" = "unit" ]; then
+            MARKER="not integration"
+          else
+            MARKER="integration"
+          fi
+          python -m pytest tests/ -v --tb=short -m "$MARKER" -p no:cov
+
+  validate-latest:
+    name: Validate against latest HA (hassfest + HACS)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,11 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          # Match the dev/stable channel in tests.yaml: the latest HA line
+          # (2026.3+) requires 3.14, so the "latest deps" lane must run here
+          # too — on 3.13 pip would silently cap HA at the newest 3.13-compatible
+          # release instead of the actual latest.
+          python-version: "3.14"
 
       - name: Install latest dependencies
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1126,6 +1126,16 @@ Three parallel jobs run on every PR and push to main:
 2. **Pyright** — `pyright custom_components/verisure_owa/` for static type checking
 3. **Tests** — `pytest` with `--cov-fail-under=90` to enforce minimum coverage
 
+### Nightly workflow (`.github/workflows/nightly.yml`)
+
+A scheduled run (cron `41 4 * * *`, plus `workflow_dispatch`) exercises the repo
+against the **latest** upstream dependencies, separate from the pinned/ranged PR
+CI. It installs the newest Home Assistant core + `pytest-homeassistant-custom-component`
+and runs the unit + integration suites, and validates with hassfest + HACS
+against current HA. This is an early-warning system for breakage from new HA
+releases; it does not gate PRs. All other CI/validation/release workflows live
+alongside it under `.github/workflows/`.
+
 ## File reference
 
 | File | Lines | Purpose |


### PR DESCRIPTION
Adds a scheduled nightly CI workflow that runs the test suite against the latest published dependency versions, so dependency drift (HA core, library bumps) surfaces on its own schedule instead of breaking a release PR.

## Changes
- `.github/workflows/nightly.yml` — new scheduled workflow ("latest deps" run).
- `docs/architecture.md` — documents the nightly job.

No production code changes; CI/docs only.