### PR TITLE
Fix services.yaml entity target breaking the automation editor

### DIFF
--- a/custom_components/securitas/services.yaml
+++ b/custom_components/securitas/services.yaml
@@ -15,8 +15,8 @@ force_arm:
     windows) from a previous failed arm attempt.
   target:
     entity:
-      integration: securitas
-      domain: alarm_control_panel
+      - integration: securitas
+        domain: alarm_control_panel
   fields:
     code:
       example: "1234"
@@ -31,8 +31,8 @@ force_arm_cancel:
     Cancel a pending force-arm and dismiss the arming-exception notification.
   target:
     entity:
-      integration: securitas
-      domain: alarm_control_panel
+      - integration: securitas
+        domain: alarm_control_panel
 
 ## refresh_activity_log, fetch_activity_image, refresh_alarm and
 ## capture_image are v5+ services available ONLY under verisure_owa.*


### PR DESCRIPTION
## Problem

With current Home Assistant (tested on 2026.7.1), adding any action in the
automation editor fails. The target picker shows *"Target could not be loaded"*
and the websocket call returns `unknown_error` — for **every** device, not just
alarm panels.

Backend traceback:

```
File "homeassistant/components/websocket_api/commands.py", line 963, in handle_get_services_for_target
    services = await async_get_services_for_target(...)
File "homeassistant/components/websocket_api/automation.py", line 346, in async_get_services_for_target
File "homeassistant/components/websocket_api/automation.py", line 243, in _async_get_automation_components_for_target
File "homeassistant/components/websocket_api/automation.py", line 211, in _get_automation_component_lookup_table
File "homeassistant/components/websocket_api/automation.py", line 164, in _get_automation_component_domains
    filter_integration = entity_filter_config.get("integration")
AttributeError: 'str' object has no attribute 'get'
```

## Cause

`custom_components/securitas/services.yaml` declares `target.entity` as a
mapping:

```yaml
  target:
    entity:
      integration: securitas
      domain: alarm_control_panel
```

Home Assistant expects a **list** of entity filters and iterates over it:

```python
for entity_filter_config in entity_filters_config:
    filter_integration = entity_filter_config.get("integration")
```

Iterating a mapping yields its keys as strings, so `"integration".get(...)`
raises `AttributeError`.

`_get_automation_component_lookup_table` builds the action list across all
integrations, so this single malformed description aborts the whole lookup.
That is why the picker breaks for every device while this integration is
loaded.

## Fix

Wrap both filters in a list, so each parses as one entity filter. No behaviour
change beyond the descriptions now loading.

## Testing

- Restarted HA with the patched file; the target picker loads again and actions
  can be added for all devices.
- `force_arm` and `force_arm_cancel` still appear in Developer Tools → Actions,
  scoped to this integration's `alarm_control_panel` entities, with the `code`
  password field intact.
