### PR TITLE
fix: declare service target entity filters as lists

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -547,7 +547,9 @@ _ALIASED_SERVICES: tuple[tuple[str, SupportsResponse, dict[str, Any]], ...] = (
                 },
             },
             "target": {
-                "entity": {"integration": "securitas", "domain": "alarm_control_panel"}
+                "entity": [
+                    {"integration": "securitas", "domain": "alarm_control_panel"}
+                ]
             },
         },
     ),
@@ -562,7 +564,9 @@ _ALIASED_SERVICES: tuple[tuple[str, SupportsResponse, dict[str, Any]], ...] = (
             ),
             "fields": {},
             "target": {
-                "entity": {"integration": "securitas", "domain": "alarm_control_panel"}
+                "entity": [
+                    {"integration": "securitas", "domain": "alarm_control_panel"}
+                ]
             },
         },
     ),
@@ -657,7 +661,9 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
             ),
             "fields": {},
             "target": {
-                "entity": {"integration": "securitas", "domain": "alarm_control_panel"}
+                "entity": [
+                    {"integration": "securitas", "domain": "alarm_control_panel"}
+                ]
             },
         },
     },
@@ -672,7 +678,7 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
                 "supersedes the deprecated VerisureCaptureButton entity."
             ),
             "fields": {},
-            "target": {"entity": {"integration": "securitas", "domain": "camera"}},
+            "target": {"entity": [{"integration": "securitas", "domain": "camera"}]},
         },
     },
     {
@@ -685,7 +691,7 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
                 "Foreground-refresh the activity timeline for an installation."
             ),
             "fields": {},
-            "target": {"entity": {"integration": "securitas", "domain": "sensor"}},
+            "target": {"entity": [{"integration": "securitas", "domain": "sensor"}]},
         },
     },
     {
@@ -721,7 +727,7 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
                     "selector": {"text": {}},
                 },
             },
-            "target": {"entity": {"integration": "securitas", "domain": "sensor"}},
+            "target": {"entity": [{"integration": "securitas", "domain": "sensor"}]},
         },
     },
 )


### PR DESCRIPTION
## Problem

On current Home Assistant (reproduced on 2026.7.1), adding **any** action in
the automation editor fails. The target picker shows *"Target could not be
loaded"* and the websocket call returns `unknown_error` — for every device, not
only this integration's entities. The editor is unusable while the integration
is loaded.

```
File "homeassistant/components/websocket_api/commands.py", line 963, in handle_get_services_for_target
File "homeassistant/components/websocket_api/automation.py", line 346, in async_get_services_for_target
File "homeassistant/components/websocket_api/automation.py", line 243, in _async_get_automation_components_for_target
File "homeassistant/components/websocket_api/automation.py", line 211, in _get_automation_component_lookup_table
File "homeassistant/components/websocket_api/automation.py", line 164, in _get_automation_component_domains
    filter_integration = entity_filter_config.get("integration")
AttributeError: 'str' object has no attribute 'get'
```

## Cause

There are two ways a service description reaches Home Assistant, and only one
of them validates the target.

**`services.yaml`** is validated by `TargetSelector.CONFIG_SCHEMA`
(`homeassistant/helpers/service.py:192`), which applies `cv.ensure_list` to
`entity`. A mapping is normalised to a single-element list, which is why the
mapping shorthand is used by ~480 core integrations without trouble — including
this repo's own `services.yaml`, which is fine as-is.

**`async_set_service_schema()`** copies the target through unchanged
(`homeassistant/helpers/service.py:615`):

```python
if "target" in schema:
    description["target"] = schema["target"]
```

No validation, no `ensure_list`. All six descriptions registered that way in
`__init__.py` used the mapping form:

```python
"target": {
    "entity": {"integration": "securitas", "domain": "alarm_control_panel"}
},
```

`_get_automation_component_domains` iterates `target["entity"]`, so iterating a
mapping yields its keys as strings and `"integration".get(...)` raises.

Because `_get_automation_component_lookup_table` walks the descriptions of all
integrations to build the action list, a single malformed entry aborts the
entire lookup — hence the failure for every device rather than just this
integration's.

## Fix

Wrap each filter in a list, in `_ALIASED_SERVICES` (`force_arm`,
`force_arm_cancel`) and `_V5_ENTITY_SERVICES` (`refresh_alarm`,
`capture_image`, `refresh_activity_log`, `fetch_activity_image`). Six call
sites, no behaviour change beyond the descriptions parsing again.

## Testing

- Verified on a live install running v5.3.0 with the same change applied: the
  target picker loads again and actions can be added for all devices.
- `securitas.*` and `verisure_owa.*` services still appear in Developer Tools →
  Actions, scoped to the correct entity domains, with their field schemas
  intact.
- `ruff check` and `ruff format --diff` clean.
