### PR TITLE
fix: declare service target entity filters (and their domain) as lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
+## v5.4.1
+
+A fix for the Home Assistant automation editor, which became unusable — for every integration, not just this one — whenever this integration was loaded.
+
+### Fixed
+
+**Automation editor "Target could not be loaded" while the integration is loaded ([#525](https://github.com/guerrerotook/securitas-direct-new-api/pull/525)).**  On recent Home Assistant (reproduced on 2026.7.1), adding *any* action in the automation editor failed: the target picker showed "Target could not be loaded" and the websocket call returned `unknown_error` — for every device, not only this integration's entities.  The six services registered through `async_set_service_schema` declared their `target` entity filter as a bare mapping (`{"integration": …, "domain": …}`).  Unlike `services.yaml` — which Home Assistant validates and normalises with `cv.ensure_list` at every level — that registration path copies the target through unchanged, so the automation-editor lookup iterated the mapping's string keys and raised `AttributeError`.  Because Home Assistant builds that lookup once across *all* installed integrations, the single malformed entry aborted it for every device.  Both the entity filter and its `domain` are now declared as lists — the outer list stops the crash, and the inner list keeps the filter matching this integration's own entities — with a regression test guarding the shape.  Thanks to [@MarcelHoell](https://github.com/MarcelHoell) for the diagnosis and fix.
+
 ## v5.4.0
 
 The always-visible alarm chip now appears almost instantly on a cold dashboard load, the activity log recognises smart-lock door and Verisure-routine events instead of labelling them "Unknown event", and the card UI is fully localised and screen-reader friendly.

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -517,6 +517,32 @@ async def _fetch_and_cache_installations(
 
 ALIAS_DOMAIN = "verisure_owa"
 
+
+def _entity_target(domain: str) -> dict[str, Any]:
+    """Build a service ``target`` scoped to this integration's entities.
+
+    Both the ``entity`` filter list *and* its inner ``domain`` must be lists.
+    ``async_set_service_schema`` copies ``target`` through unchanged — unlike
+    ``services.yaml``, which HA normalises with ``cv.ensure_list`` at every
+    level (``helpers/selector.py``). Two failures follow from a bare mapping:
+
+    * A bare ``entity`` mapping is iterated to its string keys by HA's
+      automation-editor lookup, raising ``AttributeError`` and aborting the
+      shared cross-integration lookup — breaking the action/target picker for
+      *every* integration.
+    * A bare ``domain`` string reaches ``_AutomationComponentLookupData.create``
+      unnormalised, where ``set(config.get("domain", []))`` turns
+      ``"alarm_control_panel"`` into a set of single characters, so the filter
+      then matches no entity and these services are never offered for their own
+      entities.
+
+    Constructing both shapes here once keeps both bugs unrepresentable at the
+    call sites (guarded by
+    ``tests/test_init.py::TestServiceDescriptionTargets``).
+    """
+    return {"entity": [{"integration": DOMAIN, "domain": [domain]}]}
+
+
 # Tuples of (service_name, supports_response, schema_for_async_set_service_schema).
 # Every service the integration registers under `DOMAIN` (= "securitas") via
 # platform.async_register_entity_service is also exposed under `verisure_owa.<X>`
@@ -546,9 +572,7 @@ _ALIASED_SERVICES: tuple[tuple[str, SupportsResponse, dict[str, Any]], ...] = (
                     "selector": {"text": {"type": "password"}},
                 },
             },
-            "target": {
-                "entity": {"integration": "securitas", "domain": "alarm_control_panel"}
-            },
+            "target": _entity_target("alarm_control_panel"),
         },
     ),
     (
@@ -561,9 +585,7 @@ _ALIASED_SERVICES: tuple[tuple[str, SupportsResponse, dict[str, Any]], ...] = (
                 "notification."
             ),
             "fields": {},
-            "target": {
-                "entity": {"integration": "securitas", "domain": "alarm_control_panel"}
-            },
+            "target": _entity_target("alarm_control_panel"),
         },
     ),
 )
@@ -656,9 +678,7 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
                 "deprecated VerisureRefreshButton entity."
             ),
             "fields": {},
-            "target": {
-                "entity": {"integration": "securitas", "domain": "alarm_control_panel"}
-            },
+            "target": _entity_target("alarm_control_panel"),
         },
     },
     {
@@ -672,7 +692,7 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
                 "supersedes the deprecated VerisureCaptureButton entity."
             ),
             "fields": {},
-            "target": {"entity": {"integration": "securitas", "domain": "camera"}},
+            "target": _entity_target("camera"),
         },
     },
     {
@@ -685,7 +705,7 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
                 "Foreground-refresh the activity timeline for an installation."
             ),
             "fields": {},
-            "target": {"entity": {"integration": "securitas", "domain": "sensor"}},
+            "target": _entity_target("sensor"),
         },
     },
     {
@@ -721,7 +741,7 @@ _V5_ENTITY_SERVICES: tuple[dict[str, Any], ...] = (
                     "selector": {"text": {}},
                 },
             },
-            "target": {"entity": {"integration": "securitas", "domain": "sensor"}},
+            "target": _entity_target("sensor"),
         },
     },
 )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2094,3 +2094,72 @@ class TestStaticPathAliases:
         paths = [cfg.url_path for cfg in call_args]
         assert "/verisure-owa-panel" in paths
         assert "/securitas_panel" in paths
+
+
+# ===========================================================================
+# TestServiceDescriptionTargets
+# ===========================================================================
+
+
+class TestServiceDescriptionTargets:
+    """Regression guard: service ``target`` entity filters must be lists.
+
+    These descriptions reach HA via ``async_set_service_schema``, which copies
+    ``target`` through *unchanged* — unlike ``services.yaml``, which is
+    validated by ``TargetSelector.CONFIG_SCHEMA`` and normalised with
+    ``cv.ensure_list``. HA's automation-editor lookup
+    (``_get_automation_component_domains``) iterates ``target["entity"]``
+    expecting a list of ``{integration, domain}`` mappings; a bare mapping
+    iterates to its *string keys* and raises ``AttributeError``, which aborts
+    the shared cross-integration lookup and breaks the action/target picker for
+    *every* integration while this one is loaded (PR #525).
+    """
+
+    def test_target_entity_filters_are_lists(self):
+        """Every service ``target["entity"]`` must be a list of mapping filters."""
+        from custom_components.securitas import (
+            _ALIASED_SERVICES,
+            _V5_ENTITY_SERVICES,
+        )
+
+        schemas = [(name, schema) for name, _sr, schema in _ALIASED_SERVICES]
+        schemas += [
+            (spec["service_name"], spec["schema"])
+            for spec in _V5_ENTITY_SERVICES
+            if spec.get("schema")
+        ]
+        targets = [
+            (name, schema["target"]["entity"])
+            for name, schema in schemas
+            if schema.get("target", {}).get("entity") is not None
+        ]
+
+        # Guard against a vacuous pass if the specs move or lose their targets.
+        assert targets, "no service target entity filters found — did the specs move?"
+
+        for service_name, entity in targets:
+            assert isinstance(entity, list), (
+                f"{service_name}: target['entity'] must be a list of mapping "
+                f"filters (async_set_service_schema does not run cv.ensure_list), "
+                f"got {type(entity).__name__}"
+            )
+            assert entity and all(isinstance(item, dict) for item in entity), (
+                f"{service_name}: target['entity'] must be a non-empty list of "
+                "mapping filters"
+            )
+            # HA's entity-filter schema normalises `domain` with cv.ensure_list
+            # (helpers/selector.py) — but only on the validated services.yaml
+            # path. async_set_service_schema skips that, so a bare-string domain
+            # reaches _AutomationComponentLookupData.create unchanged, where
+            # `set(config.get("domain", []))` turns "alarm_control_panel" into a
+            # set of single characters and the filter then matches no entity.
+            for filt in entity:
+                if "domain" in filt:
+                    domain = filt["domain"]
+                    assert isinstance(domain, list) and all(
+                        isinstance(d, str) for d in domain
+                    ), (
+                        f"{service_name}: entity filter 'domain' must be a list "
+                        f"of strings so it survives async_set_service_schema's "
+                        f"unvalidated copy; got {domain!r}"
+                    )


### PR DESCRIPTION
## Problem

On recent Home Assistant (reproduced on 2026.7.1), adding **any** action in the automation editor fails — the target picker shows *"Target could not be loaded"* and the websocket call returns `unknown_error`, for **every** device, not just this integration's entities, whenever the integration is loaded:

```
File "homeassistant/components/websocket_api/automation.py", line 164, in _get_automation_component_domains
    filter_integration = entity_filter_config.get("integration")
AttributeError: 'str' object has no attribute 'get'
```

## Cause

Six service descriptions are registered via `async_set_service_schema`, which — unlike `services.yaml` (validated by `TargetSelector.CONFIG_SCHEMA` and normalised with `cv.ensure_list` at every level) — **copies `target` through unchanged**. All six used the mapping shorthand:

```python
"target": {"entity": {"integration": "securitas", "domain": "alarm_control_panel"}}
```

Two failures follow from that unvalidated copy:

1. **The crash (every integration).** HA's automation-editor lookup iterates `target["entity"]` expecting a *list*. A bare mapping iterates to its string keys, so `"integration".get(...)` raises `AttributeError`. Because that lookup is built once across **all** installed integrations, the single malformed entry aborts it for every device.
2. **A silent domain-match failure (subtler).** Even with the outer `entity` wrapped in a list, the inner `domain` string reaches `_AutomationComponentLookupData.create` unnormalised, where `set(config.get("domain", []))` turns `"alarm_control_panel"` into a **set of single characters** — so the filter matches none of this integration's own entities (empirically: `_EntityFilter.matches(...)` returns `False`).

## Fix

Add an `_entity_target(domain)` helper that builds the fully-normalised shape **once** and use it at all six call sites:

```python
def _entity_target(domain: str) -> dict[str, Any]:
    return {"entity": [{"integration": DOMAIN, "domain": [domain]}]}
```

The outer list stops the crash; the inner list keeps the filter matching. Centralising the shape makes the bare-mapping bug unrepresentable at the call sites, and drops the six-fold `"securitas"` literal in favour of the imported `DOMAIN`.

A regression test (`tests/test_init.py::TestServiceDescriptionTargets`) guards that every service `target["entity"]` is a list of mapping filters **and** each filter's `domain` is a list of strings.

## Credit

Diagnosis and the original fix by **@MarcelHoell** in #525. This PR additionally normalises the inner `domain` (needed for the target filter to actually match entities) and adds the regression test + changelog entry.

## Testing

- Empirically verified against HA 2026.5.1: with the helper's output, `_EntityFilter.matches(...)` returns `True` for `alarm_control_panel` / `camera` / `sensor` entities; the pre-fix bare mapping reproduced both the `AttributeError` and the character-set domain.
- Full pre-push gate green: `ruff`, `pyright`, translations, docs, 754 unit tests.