### PR TITLE
chore: bump version to 5.4.1

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.4.0"
+    "version": "5.4.1"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.4.0";
-import "./verisure-owa-alarm-chip.js?v=5.4.0";
+import "./verisure-owa-alarm-card.js?v=5.4.1";
+import "./verisure-owa-alarm-chip.js?v=5.4.1";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.4.0";
+import "./verisure-owa-camera-card.js?v=5.4.1";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.4.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.4.1";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,7 +21,7 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.4.0";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.4.1";
 import {
   _t,
   STATE_CFG,
@@ -37,7 +37,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.4.0";
+} from "./verisure-owa-alarm-shared.js?v=5.4.1";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -47,7 +47,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.4.0";
+} from "./verisure-owa-alarm-shared.js?v=5.4.1";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,7 +13,7 @@ import {
   defaultArmState,
   attachGesture,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.4.0";
+} from "./verisure-owa-alarm-shared.js?v=5.4.1";
 
 class VerisureOwaAlarmBadge extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,7 +8,7 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.4.0";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.4.1";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.4.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.4.1";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Release-prep for **v5.4.1** (bugfix release).

Bumps `manifest.json` 5.4.0 → 5.4.1 and re-stamps the card cache-bust `?v=` tokens to match (guarded by `test_card_import_versions_match_manifest` and the JS `card-cache-busting` test — both run locally, green).

The single user-facing fix in this release — the automation-editor "Target could not be loaded" crash — already landed in #526, along with its `## v5.4.1` CHANGES.md section (which the Release workflow uses verbatim as the release notes).

**Why a separate bump PR:** `main` is a protected branch, so the Release workflow can't push its own version-bump commit (rejected with `Changes must be made through a pull request`). Pre-bumping here lets the workflow tag `v5.4.1` on the merge commit and publish without pushing to `main` — the same path that worked for v5.4.0.