### PR TITLE
fix(auth): stop forcing reauth on transient session errors for token-only accounts

### DIFF
--- a/custom_components/securitas/coordinators.py
+++ b/custom_components/securitas/coordinators.py
@@ -14,7 +14,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, NoReturn
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -127,26 +127,60 @@ class ActivityData:
 # ── Error handling ───────────────────────────────────────────────────────────
 
 
-async def _handle_session_expired(client: VerisureOwaClient) -> None:
-    """Re-login after a SessionExpiredError, routing by failure type.
+def _raise_fetch_error(err: VerisureOwaError, label: str) -> NoReturn:
+    """Map a data-fetch VerisureOwaError to reauth vs. retry.
 
-    Genuine auth failures (bad credentials, account blocked, 2FA, revoked
-    token) raise ConfigEntryAuthFailed to trigger the HA reauth flow. Transient
-    server-side failures raise UpdateFailed so the coordinator retries on the
-    next interval — we never force a reauth prompt for a backend wobble.
+    A genuinely dead session — bad credentials, account blocked, 2FA, or an
+    explicitly invalid/revoked token (err 60067/60052) — reaching the fetch
+    means the refresh-token chain is broken with no way to recover unattended:
+    raise ConfigEntryAuthFailed so HA prompts reauth. Everything else is a
+    transient backend wobble → UpdateFailed (retry next poll).
     """
+    if is_genuine_auth_failure(err):
+        raise ConfigEntryAuthFailed(f"Re-authentication required: {err}") from err
+    raise UpdateFailed(f"{label} update failed: {err}") from err
+
+
+async def _handle_session_expired(
+    client: VerisureOwaClient, err: SessionExpiredError
+) -> None:
+    """Recover from a SessionExpiredError that survived the client's own
+    refresh-and-retry.
+
+    Reaching here means the auth token was refreshed successfully (a *failed*
+    refresh raises a different error the caller classifies), yet the server
+    still returned "Invalid session, try again later" — a transient backend
+    desync, not a dead token. A refresh-token-only account (no stored password,
+    the norm since v5.1.0) has nothing stronger to try: login() would only raise
+    "no password available", which must NOT be allowed to masquerade as a
+    genuine credential failure and force a needless reauth. Treat it as
+    transient and retry next poll.
+
+    When a password is available, attempt a full re-login (it can recover a
+    genuinely dead refresh token) and classify the outcome.
+    """
+    if not client.password:
+        # The token was just refreshed successfully, so this lingering 403 is a
+        # transient backend desync. Keep the server's original error for
+        # diagnostics and chaining rather than fabricating a generic one.
+        client.record_auth_recovery_failure(err)
+        raise UpdateFailed(f"Transient session error, will retry: {err}") from err
     try:
         await client.login()
-    except (VerisureOwaError, asyncio.TimeoutError) as err:
+    except (VerisureOwaError, asyncio.TimeoutError) as login_err:
         owa_err = (
-            err
-            if isinstance(err, VerisureOwaError)
-            else VerisureOwaError(f"Login timed out: {err!r}")
+            login_err
+            if isinstance(login_err, VerisureOwaError)
+            else VerisureOwaError(f"Login timed out: {login_err!r}")
         )
         if is_genuine_auth_failure(owa_err):
-            raise ConfigEntryAuthFailed(f"Re-authentication failed: {owa_err}") from err
+            raise ConfigEntryAuthFailed(
+                f"Re-authentication failed: {owa_err}"
+            ) from login_err
         client.record_auth_recovery_failure(owa_err)
-        raise UpdateFailed(f"Transient auth error, will retry: {owa_err}") from err
+        raise UpdateFailed(
+            f"Transient auth error, will retry: {owa_err}"
+        ) from login_err
 
 
 async def _fetch_with_session_recovery[T](
@@ -156,28 +190,27 @@ async def _fetch_with_session_recovery[T](
 ) -> T:
     """Run *fetcher* with one-shot session-expired recovery.
 
-    On SessionExpiredError, re-login then retry once. WAFBlockedError and any
-    remaining VerisureOwaError are wrapped as UpdateFailed messages keyed on
-    *label* — the human-readable subject for the failure.
-
-    Re-login (on SessionExpiredError) may itself raise ConfigEntryAuthFailed
-    for a genuine credential failure, or UpdateFailed for a transient relogin
-    error — both propagate uncaught.
+    On SessionExpiredError, recover (relogin for a password account; transient
+    retry for a refresh-token-only one) then retry once. A genuine auth failure
+    surfacing from the fetch itself — e.g. a dead refresh token (err 60067)
+    raised out of the client's pre-request auth check — raises
+    ConfigEntryAuthFailed for reauth; WAFBlockedError and any other
+    VerisureOwaError become UpdateFailed keyed on *label*.
     """
     try:
         return await fetcher()
-    except SessionExpiredError:
-        await _handle_session_expired(client)
+    except SessionExpiredError as expired:
+        await _handle_session_expired(client, expired)
         try:
             return await fetcher()
         except WAFBlockedError as err:
             raise UpdateFailed(f"WAF blocked {label.lower()} request: {err}") from err
         except VerisureOwaError as err:
-            raise UpdateFailed(f"{label} update failed: {err}") from err
+            _raise_fetch_error(err, label)
     except WAFBlockedError as err:
         raise UpdateFailed(f"WAF blocked {label.lower()} request: {err}") from err
     except VerisureOwaError as err:
-        raise UpdateFailed(f"{label} update failed: {err}") from err
+        _raise_fetch_error(err, label)
 
 
 # ── AlarmCoordinator ─────────────────────────────────────────────────────────
@@ -486,10 +519,12 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
     ) -> dict[str, ThumbnailResponse]:
         """Fetch thumbnails for all cameras, preserving previous on failure.
 
-        SessionExpiredError and WAFBlockedError are re-raised so the caller
-        can handle auth/WAF issues at the coordinator level.  Other
-        VerisureOwaError instances are treated as individual camera
-        failures — logged and skipped.
+        SessionExpiredError, WAFBlockedError, and genuine auth failures (a dead
+        refresh token surfacing from a thumbnail fetch) are re-raised so the
+        caller can handle auth/WAF issues at the coordinator level — otherwise a
+        genuinely dead session would be silently swallowed per-camera and never
+        prompt reauth. Other VerisureOwaError instances are treated as
+        individual camera failures — logged and skipped.
         """
         thumbnails: dict[str, ThumbnailResponse] = {}
         for camera in self._cameras:
@@ -505,6 +540,8 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
             except (SessionExpiredError, WAFBlockedError):
                 raise
             except VerisureOwaError as err:
+                if is_genuine_auth_failure(err):
+                    raise
                 _LOGGER.warning(
                     "Failed to fetch thumbnail for camera %s (zone %s): %s",
                     camera.name,

--- a/custom_components/securitas/verisure_owa_api/client/_sentinel.py
+++ b/custom_components/securitas/verisure_owa_api/client/_sentinel.py
@@ -59,13 +59,23 @@ class _SentinelMixin(_ClientBase):
 
         if target_device is None:
             return empty
+        status = target_device.get("status")
+        if (
+            status is None
+            or status.get("humidity") is None
+            or status.get("temperature") is None
+        ):
+            # A matched device can arrive with a null status or missing core
+            # readings during transient backend hiccups; degrade to empty
+            # rather than crash the coordinator.
+            return empty
 
-        air_quality_code = target_device["status"].get("airQualityCode")
+        air_quality_code = status.get("airQualityCode")
         return Sentinel(
-            alias=target_device["alias"],
+            alias=target_device.get("alias") or "",
             air_quality=str(air_quality_code) if air_quality_code is not None else "",
-            humidity=int(target_device["status"]["humidity"]),
-            temperature=int(target_device["status"]["temperature"]),
+            humidity=int(status["humidity"]),
+            temperature=int(status["temperature"]),
             zone=target_device.get("zone", ""),
         )
 
@@ -111,8 +121,10 @@ class _SentinelMixin(_ClientBase):
             except (ValueError, TypeError):
                 pass
 
-        status = aq_data.get("status", {})
+        # status may be null, and current may be present-but-null, during
+        # transient backend hiccups — coalesce both to 0 rather than crash.
+        status = aq_data.get("status") or {}
         return AirQuality(
             value=value,
-            status_current=int(status.get("current", 0)),
+            status_current=int(status.get("current") or 0),
         )

--- a/tests/test_client_misc.py
+++ b/tests/test_client_misc.py
@@ -294,6 +294,58 @@ class TestGetSentinelData:
         assert result.alias == ""
         assert result.temperature == 0
 
+    async def test_null_status_returns_empty_sentinel(self, client, transport):
+        """A matched device with null status degrades to empty, not a crash."""
+        transport.execute.return_value = sentinel_response(
+            devices=[
+                {
+                    "alias": "Living Room",
+                    "status": None,
+                    "zone": "1",
+                },
+            ],
+        )
+
+        inst = _make_installation()
+        service = _make_service(
+            attributes=[Attribute(name="zone", value="1", active=True)]
+        )
+        result = await client.get_sentinel_data(inst, service)
+
+        assert isinstance(result, Sentinel)
+        assert result.alias == ""
+        assert result.temperature == 0
+        assert result.humidity == 0
+        assert result.air_quality == ""
+
+    async def test_null_core_reading_returns_empty_sentinel(self, client, transport):
+        """A matched device whose status is present but missing a core reading
+        (null humidity/temperature) degrades to empty, not a crash."""
+        transport.execute.return_value = sentinel_response(
+            devices=[
+                {
+                    "alias": "Living Room",
+                    "status": {
+                        "temperature": 22,
+                        "humidity": None,
+                        "airQualityCode": 3,
+                    },
+                    "zone": "1",
+                },
+            ],
+        )
+
+        inst = _make_installation()
+        service = _make_service(
+            attributes=[Attribute(name="zone", value="1", active=True)]
+        )
+        result = await client.get_sentinel_data(inst, service)
+
+        assert isinstance(result, Sentinel)
+        assert result.alias == ""
+        assert result.temperature == 0
+        assert result.humidity == 0
+
 
 # ── get_air_quality_data tests ───────────────────────────────────────────────
 
@@ -359,6 +411,40 @@ class TestGetAirQualityData:
         assert result is not None
         assert result.value is None
         assert result.status_current == 2
+
+    async def test_null_current_defaults_status_current_to_zero(
+        self, client, transport
+    ):
+        """A null status.current defaults status_current to 0, not a crash."""
+        transport.execute.return_value = air_quality_response(
+            data={
+                "status": {"current": None, "avg6h": 80},
+                "hours": [{"id": "1", "value": "70"}],
+            }
+        )
+
+        inst = _make_installation()
+        result = await client.get_air_quality_data(inst, "1")
+
+        assert result is not None
+        assert result.status_current == 0
+        assert result.value == 70
+
+    async def test_null_status_defaults_status_current_to_zero(self, client, transport):
+        """A null status object defaults status_current to 0, not a crash."""
+        transport.execute.return_value = air_quality_response(
+            data={
+                "status": None,
+                "hours": [{"id": "1", "value": "70"}],
+            }
+        )
+
+        inst = _make_installation()
+        result = await client.get_air_quality_data(inst, "1")
+
+        assert result is not None
+        assert result.status_current == 0
+        assert result.value == 70
 
 
 # ── list_installations tests ─────────────────────────────────────────────────

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -59,9 +59,14 @@ def _make_hass() -> MagicMock:
 
 
 def _make_client() -> AsyncMock:
-    """Create a mock VerisureOwaClient with async methods."""
+    """Create a mock VerisureOwaClient with async methods.
+
+    Defaults to a password-bearing account so the relogin path is exercised;
+    refresh-token-only tests override ``client.password = ""``.
+    """
     client = AsyncMock(spec=VerisureOwaClient)
     client.protom_response = ""
+    client.password = "test-password"
     return client
 
 
@@ -298,6 +303,75 @@ class TestAlarmCoordinator:
         with pytest.raises(UpdateFailed):
             await coord._async_update_data()
         client.record_auth_recovery_failure.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persistent_session_expired_without_password_does_not_reauth(self):
+        """Repro of the 2026-07-21 reauth: a 403 'Invalid session, try again
+        later' survives the client's own refresh+retry, and with no stored
+        password login() can only raise 'no password available'. That must be
+        treated as transient (retry), never turned into a reauth prompt."""
+        hass = _make_hass()
+        client = _make_client()
+        client.password = ""  # refresh-token-only account (v5.1.0+)
+        queue = _make_queue()
+        installation = _make_installation()
+
+        expired = SessionExpiredError(
+            "Invalid session. Please, try again later.", http_status=403
+        )
+        client.get_general_status.side_effect = expired
+        # A password-less relogin can only ever fail this way:
+        client.login.side_effect = AuthenticationError(
+            "Cannot login: no password available (refresh token rejected)."
+        )
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        with pytest.raises(UpdateFailed) as exc_info:
+            await coord._async_update_data()
+        client.login.assert_not_awaited()
+        # The original server error is preserved for diagnostics and chaining,
+        # not replaced by a fabricated one.
+        client.record_auth_recovery_failure.assert_called_once_with(expired)
+        assert exc_info.value.__cause__ is expired
+
+    @pytest.mark.asyncio
+    async def test_genuine_dead_token_on_fetch_triggers_reauth(self):
+        """A genuinely dead refresh token (err 60067) surfaces as a genuine auth
+        error straight out of the fetch (via _ensure_auth), not as a
+        SessionExpiredError. It must prompt reauth, not be swallowed as a
+        transient UpdateFailed."""
+        hass = _make_hass()
+        client = _make_client()
+        client.password = ""
+        queue = _make_queue()
+        installation = _make_installation()
+
+        dead = VerisureOwaError("Invalid Session")
+        dead.response_body = {"errors": [{"data": {"err": "60067"}}]}
+        client.get_general_status.side_effect = dead
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coord._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_authentication_error_on_fetch_triggers_reauth(self):
+        """An AuthenticationError reaching the fetch (a dead refresh token the
+        password-less client could not recover) prompts reauth rather than being
+        wrapped as a transient UpdateFailed."""
+        hass = _make_hass()
+        client = _make_client()
+        client.password = ""
+        queue = _make_queue()
+        installation = _make_installation()
+
+        client.get_general_status.side_effect = AuthenticationError(
+            "Cannot login: no password available (refresh token rejected)."
+        )
+
+        coord = self._make_coordinator(hass, client, queue, installation)
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coord._async_update_data()
 
 
 # ── SentinelCoordinator ──────────────────────────────────────────────────────
@@ -716,6 +790,25 @@ class TestCameraCoordinator:
 
         coord = self._make_coordinator(hass, client, queue, installation, cameras)
         with pytest.raises(UpdateFailed):
+            await coord._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_genuine_auth_failure_triggers_reauth(self):
+        """A genuine auth failure (dead refresh token) from a thumbnail fetch
+        must propagate to reauth, not be swallowed as a per-camera skip."""
+        hass = _make_hass()
+        client = _make_client()
+        client.password = ""
+        queue = _make_queue()
+        installation = _make_installation()
+        cameras = self._make_cameras(2)
+
+        client.get_thumbnail.side_effect = AuthenticationError(
+            "Cannot login: no password available (refresh token rejected)."
+        )
+
+        coord = self._make_coordinator(hass, client, queue, installation, cameras)
+        with pytest.raises(ConfigEntryAuthFailed):
             await coord._async_update_data()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Two users in Spain reported being forced to re-authenticate every day/week. Debug logs (issue #499 thread) showed the refresh token was healthy the whole time — **493/493 `RefreshLogin` calls returned `res:OK`, zero `60067`**. The reauth was self-inflicted:

1. A data query gets a server-side 403 `"Invalid session. Please, try again later."` (`SessionExpiredError`).
2. The client's own recovery refreshes the token — **successfully** — and retries once.
3. The retry **still** 403s (a transient ES-backend desync; `Internal Server Error`s are interleaved in the logs).
4. The coordinator's `_handle_session_expired` then calls `client.login()`. For a refresh-token-only account (no stored password since v5.1.0) that **always** raises `AuthenticationError` "no password available" → classified as a genuine auth failure → `ConfigEntryAuthFailed` → reauth prompt.

The token was never dead; a transient 403 that outlived a successful refresh was being laundered into a hard reauth.

## What

Classify on the actual server response instead of on the dead-end `login()`:

- **`_handle_session_expired`** — when there's no password, a `SessionExpiredError` that survived the client's refresh+retry is transient (`record_auth_recovery_failure` + `UpdateFailed`, retry next poll). It no longer calls the password-less `login()`.
- **`_raise_fetch_error`** (new) — the outer `except VerisureOwaError` sites in `_fetch_with_session_recovery` now classify with `is_genuine_auth_failure`, so a genuinely dead refresh token (err `60067`) surfacing from the fetch **does** prompt reauth instead of retrying forever (the inverse gap).
- **`CameraCoordinator._fetch_thumbnails`** — re-raise genuine auth failures instead of swallowing them per-camera, so a dead session there also reaches reauth.

The distinction is clean by exception type: `SessionExpiredError` (refresh succeeded, 403 lingers) = transient; `AuthenticationError`/`60067` from the fetch = genuinely dead = reauth.

Also included (separate commit) — **sentinel partial-data guards**: the same debug logs showed `get_sentinel_data`/`get_air_quality_data` crashing the coordinator on null `status`, null `humidity`/`temperature`, and present-but-null `current` (`dict.get`'s default only applies to absent keys). Both now degrade to empty/0 instead of raising.

## Testing

- 4 new coordinator tests (incl. a faithful repro of the 2026-07-21 reauth sequence) + 4 new client tests.
- Full suite green; `ruff`/`ruff format`/`pyright` (0 errors)/`pylint` (10.00/10) clean.

## Follow-ups (not in this PR)

- **Escalation-WARNING observability**: for a *persistently* desynced token-only account, a successful refresh calls `note_auth_success()` which resets the auth-recovery streak, so the throttled ≥3-strike "report this" escalation never fires — instead the first-failure WARNING repeats per poll. Non-blocking; needs its own change to the streak machinery + tests.
- Client-side `_check_authentication_token` left untouched: a `res != "OK"` refresh on a token-only account still routes via `login()`→reauth. Unobserved (all refreshes were `res:OK`) and a larger auth-contract change; deferred.
