### PR TITLE
chore: enforce an explicit ruff rule set to stay green on latest ruff

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -3,25 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from collections import OrderedDict
 from collections.abc import Callable
 from datetime import timedelta
-import logging
 from pathlib import Path
-import time
 from typing import Any
 from uuid import uuid4
 
 import voluptuous as vol
-
-from homeassistant.components import frontend  # noqa: F401 — re-exported so tests can patch
+from homeassistant.components import (
+    frontend,  # noqa: F401 — re-exported so tests can patch
+)
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryNotReady,
-    HomeAssistantError,
-)
 from homeassistant.const import (
     CONF_CODE,
     CONF_DEVICE_ID,
@@ -32,6 +28,11 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.service import (
@@ -40,7 +41,13 @@ from homeassistant.helpers.service import (
 )
 
 from .api_queue import ApiQueue
+from .card_resources import (
+    _register_card_resource,
+    _unregister_card_resource,
+)
 from .const import (  # noqa: F401 — re-exported for backwards compatibility
+    ACTIVITY_LOG_CARD_BASE_URL,
+    ACTIVITY_LOG_CARD_URL,
     API_CACHE_TTL,
     CAMERA_CARD_BASE_URL,
     CAMERA_CARD_URL,
@@ -48,37 +55,35 @@ from .const import (  # noqa: F401 — re-exported for backwards compatibility
     CARD_URL,
     CHIP_CARD_BASE_URL,
     CHIP_CARD_URL,
-    ACTIVITY_LOG_CARD_BASE_URL,
-    ACTIVITY_LOG_CARD_URL,
     CONF_ADVANCED,
     CONF_CODE_ARM_REQUIRED,
     CONF_COUNTRY,
     CONF_DELAY_CHECK_OPERATION,
-    CONF_OPERATION_POLL_TIMEOUT,
     CONF_DEVICE_INDIGITALL,
+    CONF_ENABLE_ACTIVITY_POLLING,
+    CONF_ENABLE_ANNEX_PANEL,
+    CONF_ENABLE_INTERIOR_PANEL,
+    CONF_ENABLE_PERIMETER_PANEL,
     CONF_ENTRY_ID,
+    CONF_FORCE_ARM_NOTIFICATIONS,
     CONF_INSTALLATION,
+    CONF_LOCK_AUTOMATIONS,
     CONF_MAP_AWAY,
     CONF_MAP_CUSTOM,
     CONF_MAP_HOME,
     CONF_MAP_NIGHT,
     CONF_MAP_VACATION,
     CONF_NOTIFY_GROUP,
-    CONF_FORCE_ARM_NOTIFICATIONS,
-    CONF_ENABLE_INTERIOR_PANEL,
-    CONF_ENABLE_PERIMETER_PANEL,
-    CONF_ENABLE_ANNEX_PANEL,
-    CONF_ENABLE_ACTIVITY_POLLING,
-    CONF_LOCK_AUTOMATIONS,
+    CONF_OPERATION_POLL_TIMEOUT,
     CONF_REFRESH_TOKEN,
     CONF_UNSUPPORTED_COMMANDS,
-    DEFAULT_ENABLE_ACTIVITY_POLLING,
-    DEFAULT_FORCE_ARM_NOTIFICATIONS,
     COUNTRY_CODES,
     DEFAULT_CODE,
     DEFAULT_CODE_ARM_REQUIRED,
     DEFAULT_COUNTRY,
     DEFAULT_DELAY_CHECK_OPERATION,
+    DEFAULT_ENABLE_ACTIVITY_POLLING,
+    DEFAULT_FORCE_ARM_NOTIFICATIONS,
     DEFAULT_OPERATION_POLL_TIMEOUT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -96,10 +101,6 @@ from .coordinators import (  # noqa: F401
     LockCoordinator,
     SentinelCoordinator,
 )
-from .card_resources import (  # noqa: F401 — re-exported for backwards compatibility
-    _register_card_resource,
-    _unregister_card_resource,
-)
 from .discovery import (  # noqa: F401 — re-exported for backwards compatibility
     _async_discover_devices,
     _discover_cameras,
@@ -107,7 +108,6 @@ from .discovery import (  # noqa: F401 — re-exported for backwards compatibili
     _schedule_lock_config_retry,
 )
 from .events import attach_activity_listener
-from .migrate_unique_ids import migrate_unique_ids
 from .hub import (  # noqa: F401 — re-exported for backwards compatibility
     VerisureDevice,
     VerisureHub,
@@ -115,12 +115,13 @@ from .hub import (  # noqa: F401 — re-exported for backwards compatibility
     _notify,
 )
 from .log_filter import SensitiveDataFilter, TransientCoordinatorErrorFilter
+from .migrate_unique_ids import migrate_unique_ids
 from .verisure_owa_api import (
     ApiDomains,
     AuthenticationError,
     Installation,
-    VerisureOwaError,
     TwoFactorRequiredError,
+    VerisureOwaError,
     generate_device_id,
     generate_uuid,
 )
@@ -789,7 +790,7 @@ def register_service_aliases(hass: HomeAssistant) -> None:
         async_set_service_schema(hass, ALIAS_DOMAIN, service_name, schema)
 
 
-async def async_setup(hass: HomeAssistant, config: dict[str, object]) -> bool:  # noqa: ARG001  # pylint: disable=unused-argument
+async def async_setup(hass: HomeAssistant, config: dict[str, object]) -> bool:  # pylint: disable=unused-argument
     """Integration-wide setup, called once regardless of config entries.
 
     Surfaces a Repairs issue if an orphaned ``custom_components/verisure_owa/``

--- a/custom_components/securitas/alarm_control_panel/__init__.py
+++ b/custom_components/securitas/alarm_control_panel/__init__.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 import logging
 
 import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CODE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     async_get_current_platform,
@@ -114,7 +114,7 @@ async def _heal_combined_panel_entity_id(
     """
     try:
         ent_reg = er.async_get(hass)
-    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # heal is best-effort; never fail setup
+    except Exception:  # pylint: disable=broad-exception-caught  # heal is best-effort; never fail setup
         return
     our_unique_id = f"v4_securitas_direct.{installation.number}"
     alias_slug = slugify(installation.alias)
@@ -126,7 +126,7 @@ async def _heal_combined_panel_entity_id(
         our_entity_id = ent_reg.async_get_entity_id(
             "alarm_control_panel", DOMAIN, our_unique_id
         )
-    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+    except Exception:  # pylint: disable=broad-exception-caught
         return
     if our_entity_id is None or our_entity_id == canonical:
         return
@@ -186,7 +186,7 @@ async def _heal_subpanel_entity_id(
     """
     try:
         ent_reg = er.async_get(hass)
-    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # heal is best-effort; never fail setup
+    except Exception:  # pylint: disable=broad-exception-caught  # heal is best-effort; never fail setup
         return
     our_unique_id = f"v4_securitas_direct.{installation.number}{suffix}"
     alias_slug = slugify(installation.alias)
@@ -202,7 +202,7 @@ async def _heal_subpanel_entity_id(
         our_entity_id = ent_reg.async_get_entity_id(
             "alarm_control_panel", DOMAIN, our_unique_id
         )
-    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+    except Exception:  # pylint: disable=broad-exception-caught
         return
     if our_entity_id is None or our_entity_id == canonical:
         return
@@ -344,7 +344,7 @@ async def async_setup_entry(
                 coordinator=coordinator,
             )
             all_entities.append(peri_panel)
-            axis_panels[peri_panel._AXIS] = peri_panel  # noqa: SLF001  # pylint: disable=protected-access
+            axis_panels[peri_panel._AXIS] = peri_panel  # pylint: disable=protected-access
 
         if enable_annex:
             annex_panel = AnnexVerisureOwaAlarmPanel(
@@ -354,7 +354,7 @@ async def async_setup_entry(
                 coordinator=coordinator,
             )
             all_entities.append(annex_panel)
-            axis_panels[annex_panel._AXIS] = annex_panel  # noqa: SLF001  # pylint: disable=protected-access
+            axis_panels[annex_panel._AXIS] = annex_panel  # pylint: disable=protected-access
 
         if enable_interior:
             interior_panel = InteriorVerisureOwaAlarmPanel(
@@ -364,7 +364,7 @@ async def async_setup_entry(
                 coordinator=coordinator,
             )
             all_entities.append(interior_panel)
-            axis_panels[interior_panel._AXIS] = interior_panel  # noqa: SLF001  # pylint: disable=protected-access
+            axis_panels[interior_panel._AXIS] = interior_panel  # pylint: disable=protected-access
 
     async_add_entities(all_entities, False)
     hass.data[DOMAIN]["alarm_entities"] = {a.installation.number: a for a in alarms}

--- a/custom_components/securitas/alarm_control_panel/_base.py
+++ b/custom_components/securitas/alarm_control_panel/_base.py
@@ -7,12 +7,12 @@ inherit the bulk of their behaviour from BaseVerisureOwaAlarmPanel here.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import datetime
-from datetime import timedelta
 import logging
-from typing import Any
 import uuid
+from collections.abc import Callable
+from datetime import timedelta
+from typing import Any
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import (
@@ -60,28 +60,28 @@ from ..events import (
 )
 from ..notification_translations import get_notification_strings
 from ..verisure_owa_api import (
-    ArmingExceptionError,
-    Installation,
-    OperationStatus,
     PROTO_DISARMED,
     PROTO_TO_STATE,
     STATE_LABELS,
     STATE_TO_COMMAND,
+    ArmingExceptionError,
+    Installation,
+    OperationStatus,
     VerisureOwaError,
     VerisureOwaState,
     is_proto_letter,
 )
-from ..verisure_owa_api.exceptions import OperationTimeoutError
 from ..verisure_owa_api.command_resolver import (
     ALARM_STATE_TO_PROTO,
+    PROTO_TO_ALARM_STATE,
     AlarmState,
     AnnexMode,
     CommandResolver,
     CommandStep,
     InteriorMode,
     PerimeterMode,
-    PROTO_TO_ALARM_STATE,
 )
+from ..verisure_owa_api.exceptions import OperationTimeoutError
 from ..verisure_owa_api.models import ActivityCategory, ActivityException
 
 # Map HA alarm state names to config keys
@@ -1279,16 +1279,16 @@ class BaseVerisureOwaAlarmPanel(  # type: ignore[override]
         holds context at any time.
         """
         for panel in self._siblings_on_installation():
-            if panel._force_context is None:  # noqa: SLF001  # pylint: disable=protected-access
+            if panel._force_context is None:  # pylint: disable=protected-access
                 continue
             # Fire the public event first (panel attribution), then wipe
             # the panel's context. The integration's own dismissed-event
             # handler clears the shared notification.
-            panel._fire_arming_exception_dismissed_event(  # noqa: SLF001  # pylint: disable=protected-access
+            panel._fire_arming_exception_dismissed_event(  # pylint: disable=protected-access
                 reason=reason,
                 new_mode=new_mode,
             )
-            panel._clear_force_context()  # noqa: SLF001  # pylint: disable=protected-access
+            panel._clear_force_context()  # pylint: disable=protected-access
             # Push the wiped `force_arm_available` / `arm_exceptions`
             # attributes to HA's state machine on every cleared panel.
             # `self` will be re-written by the caller's downstream

--- a/custom_components/securitas/alarm_control_panel/_panels.py
+++ b/custom_components/securitas/alarm_control_panel/_panels.py
@@ -30,12 +30,12 @@ from ..verisure_owa_api import (
     is_proto_letter,
 )
 from ..verisure_owa_api.command_resolver import (
+    PROTO_TO_ALARM_STATE,
+    VERISURE_OWA_STATE_TO_ALARM_STATE,
     AlarmState,
     AnnexMode,
     InteriorMode,
     PerimeterMode,
-    PROTO_TO_ALARM_STATE,
-    VERISURE_OWA_STATE_TO_ALARM_STATE,
 )
 from ._base import BaseVerisureOwaAlarmPanel, build_partial_disarm_target
 
@@ -104,9 +104,9 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
 
         affected = [self, *self._affected_axis_subpanels(circuits)]
         for entity in affected:
-            entity._operation_in_progress = True  # noqa: SLF001  # pylint: disable=protected-access
-            entity._operation_epoch += 1  # noqa: SLF001  # pylint: disable=protected-access
-            entity._force_state(AlarmControlPanelState.DISARMING)  # noqa: SLF001  # pylint: disable=protected-access
+            entity._operation_in_progress = True  # pylint: disable=protected-access
+            entity._operation_epoch += 1  # pylint: disable=protected-access
+            entity._force_state(AlarmControlPanelState.DISARMING)  # pylint: disable=protected-access
         try:
             result = await self._execute_transition(target)
         except VerisureOwaError as err:
@@ -119,8 +119,8 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
             # provisional semantics to this multi-entity path is a tracked
             # follow-up, not handled in this change.
             for entity in affected:
-                entity._state = entity._last_state  # noqa: SLF001  # pylint: disable=protected-access
-                entity._operation_in_progress = False  # noqa: SLF001  # pylint: disable=protected-access
+                entity._state = entity._last_state  # pylint: disable=protected-access
+                entity._operation_in_progress = False  # pylint: disable=protected-access
                 entity.async_write_ha_state()
             _LOGGER.error(
                 "Partial disarm failed for %s circuits %s: %s",
@@ -131,7 +131,7 @@ class CombinedVerisureOwaAlarmPanel(BaseVerisureOwaAlarmPanel):
             return False
         for entity in affected:
             entity.update_status_alarm(result)
-            entity._operation_in_progress = False  # noqa: SLF001  # pylint: disable=protected-access
+            entity._operation_in_progress = False  # pylint: disable=protected-access
             entity.async_write_ha_state()
         await self.coordinator.async_request_refresh()
         return True

--- a/custom_components/securitas/camera.py
+++ b/custom_components/securitas/camera.py
@@ -32,7 +32,7 @@ _placeholder_lock: asyncio.Lock | None = None
 
 async def _get_placeholder_image(hass: HomeAssistant) -> bytes:
     """Return the placeholder JPEG, reading the file once via the executor."""
-    global _PLACEHOLDER_IMAGE, _placeholder_lock  # pylint: disable=global-statement  # noqa: PLW0603
+    global _PLACEHOLDER_IMAGE, _placeholder_lock  # pylint: disable=global-statement
     cached = _PLACEHOLDER_IMAGE
     if cached is not None:
         return cached

--- a/custom_components/securitas/card_resources.py
+++ b/custom_components/securitas/card_resources.py
@@ -10,6 +10,7 @@ add_extra_js_url for the lifetime of the running session.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 
 from homeassistant.components import frontend
@@ -71,10 +72,8 @@ async def _unregister_card_resource(
     """Remove a card Lovelace resource on unload."""
     resource_id = hass.data.get(DOMAIN, {}).get(storage_key)
     if not resource_id:
-        try:
+        with contextlib.suppress(Exception):
             frontend.remove_extra_js_url(hass, card_url)
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
         return
     try:
         lovelace_data = hass.data.get("lovelace")

--- a/custom_components/securitas/config_flow.py
+++ b/custom_components/securitas/config_flow.py
@@ -31,9 +31,9 @@ from . import (
     CONF_CODE_ARM_REQUIRED,
     CONF_COUNTRY,
     CONF_DELAY_CHECK_OPERATION,
-    CONF_OPERATION_POLL_TIMEOUT,
     CONF_DEVICE_INDIGITALL,
     CONF_ENTRY_ID,
+    CONF_FORCE_ARM_NOTIFICATIONS,
     CONF_INSTALLATION,
     CONF_MAP_AWAY,
     CONF_MAP_CUSTOM,
@@ -41,12 +41,12 @@ from . import (
     CONF_MAP_NIGHT,
     CONF_MAP_VACATION,
     CONF_NOTIFY_GROUP,
-    CONF_FORCE_ARM_NOTIFICATIONS,
-    DEFAULT_FORCE_ARM_NOTIFICATIONS,
+    CONF_OPERATION_POLL_TIMEOUT,
     COUNTRY_CODES,
     DEFAULT_CODE,
     DEFAULT_CODE_ARM_REQUIRED,
     DEFAULT_DELAY_CHECK_OPERATION,
+    DEFAULT_FORCE_ARM_NOTIFICATIONS,
     DEFAULT_OPERATION_POLL_TIMEOUT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -55,6 +55,7 @@ from . import (
     _resolve_flow_capabilities,
     generate_uuid,
 )
+from .api_queue import ApiQueue
 from .const import (
     CIRCUIT_ANNEX,
     CIRCUIT_INTERIOR,
@@ -64,11 +65,10 @@ from .const import (
     CONF_ENABLE_INTERIOR_PANEL,
     CONF_ENABLE_PERIMETER_PANEL,
     CONF_LOCK_AUTOMATIONS,
-    DEFAULT_ENABLE_ACTIVITY_POLLING,
     CONF_REFRESH_TOKEN,
+    DEFAULT_ENABLE_ACTIVITY_POLLING,
     LOCK_CIRCUITS,
 )
-from .api_queue import ApiQueue
 from .verisure_owa_api import (
     PERI_DEFAULTS,
     STATE_LABELS,
@@ -77,8 +77,8 @@ from .verisure_owa_api import (
     AuthenticationError,
     Installation,
     OtpPhone,
-    VerisureOwaError,
     TwoFactorRequiredError,
+    VerisureOwaError,
     dropdown_options,
 )
 from .verisure_owa_api.capabilities import detect_annex, detect_peri
@@ -283,7 +283,7 @@ def _get_notify_options(hass: HomeAssistant) -> list[dict[str, str]]:
     """Build notify service dropdown options."""
     notify_services = sorted(
         svc
-        for svc in hass.services.async_services().get("notify", {}).keys()
+        for svc in hass.services.async_services().get("notify", {})
         if svc not in _NOTIFY_EXCLUDE
     )
     return [{"value": "", "label": "(disabled)"}] + [
@@ -531,7 +531,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema({vol.Required(CONF_CODE): str}),
                 errors={"base": "invalid_otp"},
             )
-        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception as err:  # pylint: disable=broad-exception-caught
             _LOGGER.error(
                 "send_sms_code raised unexpected %s: %s", type(err).__name__, err
             )

--- a/custom_components/securitas/coordinators.py
+++ b/custom_components/securitas/coordinators.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any, NoReturn
 
 from homeassistant.config_entries import ConfigEntry
@@ -23,9 +23,9 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api_queue import ApiQueue
+from .events import HA_INJECTABLE_CATEGORIES
 from .verisure_owa_api.capabilities import detect_annex, detect_peri
 from .verisure_owa_api.client import VerisureOwaClient
-from .events import HA_INJECTABLE_CATEGORIES
 from .verisure_owa_api.command_resolver import (
     PROTO_TO_ALARM_STATE,
     AlarmState,
@@ -33,8 +33,8 @@ from .verisure_owa_api.command_resolver import (
     PerimeterMode,
 )
 from .verisure_owa_api.exceptions import (
-    VerisureOwaError,
     SessionExpiredError,
+    VerisureOwaError,
     WAFBlockedError,
     is_genuine_auth_failure,
 )
@@ -167,7 +167,7 @@ async def _handle_session_expired(
         raise UpdateFailed(f"Transient session error, will retry: {err}") from err
     try:
         await client.login()
-    except (VerisureOwaError, asyncio.TimeoutError) as login_err:
+    except (TimeoutError, VerisureOwaError) as login_err:
         owa_err = (
             login_err
             if isinstance(login_err, VerisureOwaError)
@@ -561,7 +561,7 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
         parsed = _parse_panel_time(thumbnail.timestamp)
         if parsed is None:
             return False
-        age = datetime.now(tz=timezone.utc) - parsed.replace(tzinfo=timezone.utc)
+        age = datetime.now(tz=UTC) - parsed.replace(tzinfo=UTC)
         return age < timedelta(hours=max_age_hours)
 
     async def _fetch_full_image(
@@ -595,7 +595,7 @@ class CameraCoordinator(DataUpdateCoordinator[CameraData]):
                     thumbnail.signal_type,
                     priority=ApiQueue.BACKGROUND,
                 )
-        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception:  # pylint: disable=broad-exception-caught
             _LOGGER.warning(
                 "Failed to fetch full image for camera zone %s",
                 zone_id,

--- a/custom_components/securitas/discovery.py
+++ b/custom_components/securitas/discovery.py
@@ -139,7 +139,7 @@ def _schedule_lock_config_retry(
                 lock_entity.device_id,
                 priority=hub.api_queue.BACKGROUND,
             )
-        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception:  # pylint: disable=broad-exception-caught
             config = None
 
         if config is not None:
@@ -237,13 +237,13 @@ async def _discover_locks(
                 lock_config=lock_config,
             )
             if entry is not None:
-                new_lock._entry_id = entry.entry_id  # noqa: SLF001  # pylint: disable=protected-access
+                new_lock._entry_id = entry.entry_id  # pylint: disable=protected-access
             locks.append(new_lock)
             # Register the lock so the options flow can discover it.
             entry_data.setdefault("registered_locks", []).append(
                 {
                     "device_id": device_id,
-                    "alias": new_lock._attr_name or device_id,  # noqa: SLF001  # pylint: disable=protected-access
+                    "alias": new_lock._attr_name or device_id,  # pylint: disable=protected-access
                 }
             )
         lock_add(locks, False)

--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -7,7 +7,6 @@ from functools import partial
 from typing import Any
 
 from aiohttp import ClientSession
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -23,8 +22,8 @@ from .api_queue import ApiQueue
 from .const import (
     CONF_COUNTRY,
     CONF_DELAY_CHECK_OPERATION,
-    CONF_OPERATION_POLL_TIMEOUT,
     CONF_DEVICE_INDIGITALL,
+    CONF_OPERATION_POLL_TIMEOUT,
     CONF_REFRESH_TOKEN,
     DEFAULT_OPERATION_POLL_TIMEOUT,
     DOMAIN,
@@ -39,11 +38,11 @@ from .verisure_owa_api import (
     Installation,
     OperationStatus,
     OtpPhone,
+    Service,
     SmartLock,
     SmartLockMode,
-    VerisureOwaError,
-    Service,
     ThumbnailResponse,
+    VerisureOwaError,
 )
 from .verisure_owa_api.client import VerisureOwaClient
 from .verisure_owa_api.http_transport import HttpTransport
@@ -402,7 +401,7 @@ class VerisureHub:
                 thumbnail.signal_type,
                 priority=ApiQueue.BACKGROUND,
             )
-        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception:  # pylint: disable=broad-exception-caught
             _LOGGER.warning(
                 "Could not fetch full image for %s",
                 camera_device.name,

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -16,26 +16,26 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DOMAIN, VerisureHub
+from .api_queue import ApiQueue
 from .const import (
-    CONF_LOCK_AUTOMATIONS,
+    CIRCUIT_ANNEX,
     CIRCUIT_INTERIOR,
     CIRCUIT_PERIMETER,
-    CIRCUIT_ANNEX,
+    CONF_LOCK_AUTOMATIONS,
 )
 from .coordinators import LockCoordinator
 from .entity import VerisureEntity
 from .verisure_owa_api import (
     Installation,
-    VerisureOwaError,
     SmartLock,
+    VerisureOwaError,
 )
-from .api_queue import ApiQueue
 from .verisure_owa_api.client import SMARTLOCK_DEVICE_ID
 from .verisure_owa_api.models import (
     AlarmState,
+    AnnexMode,
     InteriorMode,
     PerimeterMode,
-    AnnexMode,
 )
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ def _lock_status_name(status: str) -> str:
 # indistinguishable except by waiting out the physical actuation.  So the
 # ceiling must still cover the worst case.  Upstream PR #413 measured ~6s to
 # start + ~4.5s to complete (~10.5s typical) and validated a 15s wait; 7
-# attempts × 3s spans ~18s, comfortably past that, so we never declare failure
+# attempts x 3s spans ~18s, comfortably past that, so we never declare failure
 # before the lock has had time to act.  (This wait was lost when
 # change_lock_mode moved to the generic submit-and-poll scaffold, which returns
 # on the ~2s command ack.)  Until the cache removal in this branch, this
@@ -506,7 +506,7 @@ class VerisureLock(  # type: ignore[override]
         # clobber the transitional state during this read.
         try:
             pre_mode = await self._read_lock_mode(priority=ApiQueue.FOREGROUND)
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught
             pre_mode = None
         pre_ts = pre_mode.status_timestamp if pre_mode is not None else ""
         try:
@@ -575,7 +575,7 @@ class VerisureLock(  # type: ignore[override]
         for attempt in range(1, self._verify_attempts + 1):
             try:
                 mode = await self._read_lock_mode(priority=ApiQueue.FOREGROUND)
-            except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            except Exception:  # pylint: disable=broad-exception-caught
                 mode = None
 
             if mode is not None:

--- a/custom_components/securitas/log_filter.py
+++ b/custom_components/securitas/log_filter.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 
-
 _COORDINATORS_LOGGER = "custom_components.securitas.coordinators"
 
 # Phrases identifying transient backend conditions that HA's DataUpdateCoordinator
@@ -37,7 +36,7 @@ class TransientCoordinatorErrorFilter(logging.Filter):
             return True
         try:
             message = record.getMessage()
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # filter must never crash
+        except Exception:  # pylint: disable=broad-exception-caught  # filter must never crash
             return True
         if any(phrase in message for phrase in _TRANSIENT_PHRASES):
             record.levelno = logging.WARNING
@@ -70,10 +69,7 @@ class SensitiveDataFilter(logging.Filter):
         """Register an installation number for partial masking."""
         if not number:
             return
-        if len(number) <= 4:
-            masked = "***"
-        else:
-            masked = "***" + number[-4:]
+        masked = "***" if len(number) <= 4 else "***" + number[-4:]
         self._secrets[number] = masked
 
     def update_secret(self, key: str, value: str | None) -> None:
@@ -120,7 +116,7 @@ class SensitiveDataFilter(logging.Filter):
                 record.args = tuple(self._redact_value(a) for a in record.args)
             elif isinstance(record.args, dict):
                 record.args = {k: self._redact_value(v) for k, v in record.args.items()}
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # filter must never crash
+        except Exception:  # pylint: disable=broad-exception-caught  # filter must never crash
             pass  # Never break logging
 
         return True

--- a/custom_components/securitas/verisure_owa_api/__init__.py
+++ b/custom_components/securitas/verisure_owa_api/__init__.py
@@ -3,20 +3,28 @@
 import logging
 
 from .client import VerisureOwaClient, generate_device_id, generate_uuid  # noqa: F401
-from .http_transport import HttpTransport  # noqa: F401
 from .const import (  # noqa: F401
-    CommandType,
     PERI_DEFAULTS,
     PERI_OPTIONS,
     PROTO_DISARMED,
     PROTO_TO_STATE,
-    STD_DEFAULTS,
-    STD_OPTIONS,
     STATE_LABELS,
     STATE_TO_COMMAND,
+    STD_DEFAULTS,
+    STD_OPTIONS,
+    CommandType,
     VerisureOwaState,
     dropdown_options,
 )
+from .domains import ApiDomains  # noqa: F401
+from .exceptions import (  # noqa: F401
+    AccountBlockedError,
+    ArmingExceptionError,
+    AuthenticationError,
+    TwoFactorRequiredError,
+    VerisureOwaError,
+)
+from .http_transport import HttpTransport  # noqa: F401
 from .models import (  # noqa: F401
     AirQuality,
     AlarmState,
@@ -33,21 +41,13 @@ from .models import (  # noqa: F401
     ProtoCode,
     Sentinel,
     Service,
-    SStatus,
     SmartLock,
     SmartLockMode,
     SmartLockModeStatus,
+    SStatus,
     ThumbnailResponse,
     is_proto_letter,
     parse_proto_code,
-)
-from .domains import ApiDomains  # noqa: F401
-from .exceptions import (  # noqa: F401
-    AccountBlockedError,
-    ArmingExceptionError,
-    AuthenticationError,
-    VerisureOwaError,
-    TwoFactorRequiredError,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/securitas/verisure_owa_api/capabilities.py
+++ b/custom_components/securitas/verisure_owa_api/capabilities.py
@@ -6,13 +6,13 @@ capabilities data and decide what features the integration should expose.
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from .models import Attribute, Installation, Service
 
 
 def detect_peri(
-    installation: Installation | None | object,
+    installation: Installation | object | None,
     services: Iterable[Service],
     capabilities: frozenset[str],
 ) -> bool:

--- a/custom_components/securitas/verisure_owa_api/client/_auth.py
+++ b/custom_components/securitas/verisure_owa_api/client/_auth.py
@@ -76,13 +76,14 @@ class _AuthMixin(_ClientBase):
                     raise _new from err
                 if result_json.get("data"):
                     data = result_json["data"]
-                    if data.get("xSLoginToken"):
-                        if data["xSLoginToken"].get("needDeviceAuthorization"):
-                            _new = TwoFactorRequiredError(
-                                err.message, http_status=err.http_status
-                            )
-                            _new.response_body = result_json
-                            raise _new from err
+                    if data.get("xSLoginToken") and data["xSLoginToken"].get(
+                        "needDeviceAuthorization"
+                    ):
+                        _new = TwoFactorRequiredError(
+                            err.message, http_status=err.http_status
+                        )
+                        _new.response_body = result_json
+                        raise _new from err
                     _new = AuthenticationError(err.message, http_status=err.http_status)
                     _new.response_body = result_json
                     raise _new from err

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -16,9 +16,9 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
+import jwt
 from aiohttp import ClientConnectorError
 from pydantic import BaseModel, ValidationError
-import jwt
 
 from ..exceptions import (
     OperationTimeoutError,
@@ -198,7 +198,7 @@ class _ClientBase:
         if self._on_refresh_token_changed is not None:
             try:
                 self._on_refresh_token_changed(value)
-            except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+            except Exception:  # pylint: disable=broad-exception-caught
                 _LOGGER.warning(
                     "on_refresh_token_changed callback raised; refresh token "
                     "stored in memory but host persistence may have failed",
@@ -459,10 +459,7 @@ class _ClientBase:
                     if await self.refresh_token():  # type: ignore[attr-defined]
                         return
                     _LOGGER.warning("Refresh token failed, falling back to login")
-                except (
-                    VerisureOwaError,
-                    asyncio.TimeoutError,
-                ) as err:
+                except (TimeoutError, VerisureOwaError) as err:
                     owa_err = (
                         err
                         if isinstance(err, VerisureOwaError)
@@ -694,7 +691,7 @@ class _ClientBase:
                 await asyncio.sleep(delay)
             try:
                 result = await check_fn()
-            except (ClientConnectorError, asyncio.TimeoutError) as err:
+            except (TimeoutError, ClientConnectorError) as err:
                 _LOGGER.warning("Transient error during poll, retrying: %s", err)
                 first = False
                 continue

--- a/custom_components/securitas/verisure_owa_api/client/_lock.py
+++ b/custom_components/securitas/verisure_owa_api/client/_lock.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from ..exceptions import VerisureOwaError
 from ..graphql_queries import (
     CHANGE_LOCK_MODE_MUTATION,
     CHANGE_LOCK_MODE_STATUS_QUERY,
@@ -20,7 +21,6 @@ from ..models import (
     SmartLockMode,
     SmartLockModeStatus,
 )
-from ..exceptions import VerisureOwaError
 from ..responses import (
     ChangeLockModeEnvelope,
     DanalockConfigEnvelope,
@@ -129,7 +129,7 @@ class _LockMixin(_ClientBase):
                     device_id,
                     exc_info=True,
                 )
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught
             _LOGGER.debug(
                 "Smartlock config fetch failed unexpectedly for %s device %s, "
                 "trying Danalock",
@@ -141,7 +141,7 @@ class _LockMixin(_ClientBase):
         # ── Danalock fallback (two-phase polling) ──
         try:
             return await self._get_danalock_config(installation, device_id)
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught
             _LOGGER.debug(
                 "Danalock config fetch also failed for %s device %s",
                 installation.number,

--- a/custom_components/securitas/verisure_owa_api/client/_sentinel.py
+++ b/custom_components/securitas/verisure_owa_api/client/_sentinel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 
 from ..graphql_queries import AIR_QUALITY_QUERY, SENTINEL_QUERY
@@ -116,10 +117,8 @@ class _SentinelMixin(_ClientBase):
         value: int | None = None
         hours = aq_data.get("hours") or []
         if hours:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 value = int(hours[-1].get("value", 0))
-            except (ValueError, TypeError):
-                pass
 
         # status may be null, and current may be present-but-null, during
         # transient backend hiccups — coalesce both to 0 rather than crash.

--- a/custom_components/securitas/verisure_owa_api/command_resolver.py
+++ b/custom_components/securitas/verisure_owa_api/command_resolver.py
@@ -12,12 +12,12 @@ from dataclasses import dataclass
 
 from .const import VerisureOwaState
 from .models import (
+    PROTO_TO_STATE,
     AlarmState,
     AnnexMode,
     InteriorMode,
     PerimeterMode,
     ProtoCode,
-    PROTO_TO_STATE,
 )
 
 # Re-export for backward compatibility
@@ -269,7 +269,7 @@ class CommandResolver:
         if target.perimeter == PerimeterMode.ON and target.interior != InteriorMode.OFF:
             arm_cmd = _INTERIOR_ARM[target.interior]
             combined = _COMBINED_ARM.get(target.interior, [])
-            all_cmds = list(combined) + [f"{arm_cmd}+PERI1"]
+            all_cmds = [*list(combined), f"{arm_cmd}+PERI1"]
             cmds = self._filter_unsupported(all_cmds)
             return [CommandStep(commands=cmds)]
 

--- a/custom_components/securitas/verisure_owa_api/const.py
+++ b/custom_components/securitas/verisure_owa_api/const.py
@@ -62,7 +62,7 @@ PROTO_TO_STATE: dict[str, VerisureOwaState] = {
     "C": VerisureOwaState.PARTIAL_NIGHT_PERI,
     "T": VerisureOwaState.TOTAL,
     "A": VerisureOwaState.TOTAL_PERI,
-    # Annex-armed codes (interior-mode-bit × annex-bit, no perimeter).
+    # Annex-armed codes (interior-mode-bit x annex-bit, no perimeter).
     # Source: issue #441 status-code table.
     "X": VerisureOwaState.ANNEX_ONLY,  # main disarmed,  annex armed
     "R": VerisureOwaState.PARTIAL_DAY_ANNEX,  # main day,       annex armed
@@ -140,8 +140,8 @@ def dropdown_options(*, has_peri: bool, has_annex: bool) -> list[VerisureOwaStat
 
     Always offers the four interior modes. Adds peri-bearing variants when
     has_peri, annex-bearing variants when has_annex, and peri+annex variants
-    when both are set. The combined-panel mappings cover every interior ×
-    perimeter × annex combination the panel can sit in, so users can map
+    when both are set. The combined-panel mappings cover every interior x
+    perimeter x annex combination the panel can sit in, so users can map
     any HA button to any reachable state.
     """
     options: list[VerisureOwaState] = list(STD_OPTIONS)

--- a/custom_components/securitas/verisure_owa_api/examples/basic_operations.py
+++ b/custom_components/securitas/verisure_owa_api/examples/basic_operations.py
@@ -7,9 +7,9 @@ from uuid import uuid4
 import aiohttp
 from verisure_owa_api import (
     _LOGGER,
-    VerisureOwaClient,
-    HttpTransport,
     ApiDomains,
+    HttpTransport,
+    VerisureOwaClient,
     VerisureOwaError,
     generate_device_id,
     generate_uuid,

--- a/custom_components/securitas/verisure_owa_api/responses/activity.py
+++ b/custom_components/securitas/verisure_owa_api/responses/activity.py
@@ -16,6 +16,6 @@ class ActivityEnvelope(BaseModel):
         reg: list[ActivityEvent] | None = None
 
     class Data(BaseModel):
-        xSActV2: "ActivityEnvelope._Inner"  # noqa: N815
+        xSActV2: ActivityEnvelope._Inner
 
     data: Data

--- a/custom_components/securitas/verisure_owa_api/responses/alarm.py
+++ b/custom_components/securitas/verisure_owa_api/responses/alarm.py
@@ -15,7 +15,7 @@ class CheckAlarmEnvelope(BaseModel):
     """Response envelope for xSCheckAlarm."""
 
     class Data(BaseModel):
-        xSCheckAlarm: _ResMsgRef  # noqa: N815
+        xSCheckAlarm: _ResMsgRef
 
     data: Data
 
@@ -24,7 +24,7 @@ class CheckAlarmStatusEnvelope(BaseModel):
     """Response envelope for xSCheckAlarmStatus."""
 
     class Data(BaseModel):
-        xSCheckAlarmStatus: _OperationResult  # noqa: N815
+        xSCheckAlarmStatus: _OperationResult
 
     data: Data
 
@@ -33,7 +33,7 @@ class GeneralStatusEnvelope(BaseModel):
     """Response envelope for xSStatus."""
 
     class Data(BaseModel):
-        xSStatus: SStatus  # noqa: N815
+        xSStatus: SStatus
 
     data: Data
 
@@ -42,7 +42,7 @@ class ArmPanelEnvelope(BaseModel):
     """Response envelope for xSArmPanel."""
 
     class Data(BaseModel):
-        xSArmPanel: _ResMsgRef  # noqa: N815
+        xSArmPanel: _ResMsgRef
 
     data: Data
 
@@ -51,7 +51,7 @@ class ArmStatusEnvelope(BaseModel):
     """Response envelope for xSArmStatus."""
 
     class Data(BaseModel):
-        xSArmStatus: _OperationResult  # noqa: N815
+        xSArmStatus: _OperationResult
 
     data: Data
 
@@ -60,7 +60,7 @@ class DisarmPanelEnvelope(BaseModel):
     """Response envelope for xSDisarmPanel."""
 
     class Data(BaseModel):
-        xSDisarmPanel: _ResMsgRef  # noqa: N815
+        xSDisarmPanel: _ResMsgRef
 
     data: Data
 
@@ -69,7 +69,7 @@ class DisarmStatusEnvelope(BaseModel):
     """Response envelope for xSDisarmStatus."""
 
     class Data(BaseModel):
-        xSDisarmStatus: _OperationResult  # noqa: N815
+        xSDisarmStatus: _OperationResult
 
     data: Data
 
@@ -87,9 +87,9 @@ class GetExceptionsEnvelope(BaseModel):
     class _Inner(_NullSafeBase):
         res: str = ""
         msg: str | None = None
-        exceptions: "list[GetExceptionsEnvelope._ZoneException] | None" = None
+        exceptions: list[GetExceptionsEnvelope._ZoneException] | None = None
 
     class Data(BaseModel):
-        xSGetExceptions: "GetExceptionsEnvelope._Inner"  # noqa: N815
+        xSGetExceptions: GetExceptionsEnvelope._Inner
 
     data: Data

--- a/custom_components/securitas/verisure_owa_api/responses/auth.py
+++ b/custom_components/securitas/verisure_owa_api/responses/auth.py
@@ -20,7 +20,7 @@ class LoginEnvelope(BaseModel):
 
         res: str = ""
         msg: str | None = None
-        hash: str | None = None  # noqa: A003
+        hash: str | None = None
         refresh_token: str | None = Field(default=None, validation_alias="refreshToken")
         legals: Any | None = None
         change_password: bool | None = Field(
@@ -32,7 +32,7 @@ class LoginEnvelope(BaseModel):
         main_user: bool | None = Field(default=None, validation_alias="mainUser")
 
     class Data(BaseModel):
-        xSLoginToken: "LoginEnvelope._Inner"  # noqa: N815
+        xSLoginToken: LoginEnvelope._Inner
 
     data: Data
 
@@ -45,7 +45,7 @@ class RefreshLoginEnvelope(BaseModel):
 
         res: str = ""
         msg: str | None = None
-        hash: str | None = None  # noqa: A003
+        hash: str | None = None
         refresh_token: str | None = Field(default=None, validation_alias="refreshToken")
         legals: Any | None = None
         change_password: bool | None = Field(
@@ -57,7 +57,7 @@ class RefreshLoginEnvelope(BaseModel):
         main_user: bool | None = Field(default=None, validation_alias="mainUser")
 
     class Data(BaseModel):
-        xSRefreshLogin: "RefreshLoginEnvelope._Inner"  # noqa: N815
+        xSRefreshLogin: RefreshLoginEnvelope._Inner
 
     data: Data
 
@@ -70,12 +70,12 @@ class ValidateDeviceEnvelope(BaseModel):
 
         res: str = ""
         msg: str | None = None
-        hash: str | None = None  # noqa: A003
+        hash: str | None = None
         refresh_token: str | None = Field(default=None, validation_alias="refreshToken")
         legals: Any | None = None
 
     class Data(BaseModel):
-        xSValidateDevice: "ValidateDeviceEnvelope._Inner"  # noqa: N815
+        xSValidateDevice: ValidateDeviceEnvelope._Inner
 
     data: Data
 
@@ -84,6 +84,6 @@ class SendOtpEnvelope(BaseModel):
     """Response envelope for xSSendOtp."""
 
     class Data(BaseModel):
-        xSSendOtp: _ResMsg  # noqa: N815
+        xSSendOtp: _ResMsg
 
     data: Data

--- a/custom_components/securitas/verisure_owa_api/responses/camera.py
+++ b/custom_components/securitas/verisure_owa_api/responses/camera.py
@@ -21,7 +21,7 @@ class DeviceListEnvelope(BaseModel):
         devices: list[dict[str, Any]] | None = None
 
     class Data(BaseModel):
-        xSDeviceList: "DeviceListEnvelope._Inner"  # noqa: N815
+        xSDeviceList: DeviceListEnvelope._Inner
 
     data: Data
 
@@ -30,7 +30,7 @@ class RequestImagesEnvelope(BaseModel):
     """Response envelope for xSRequestImages."""
 
     class Data(BaseModel):
-        xSRequestImages: _ResMsgRef  # noqa: N815
+        xSRequestImages: _ResMsgRef
 
     data: Data
 
@@ -45,7 +45,7 @@ class RequestImagesStatusEnvelope(BaseModel):
         status: str | None = None
 
     class Data(BaseModel):
-        xSRequestImagesStatus: "RequestImagesStatusEnvelope._Inner"  # noqa: N815
+        xSRequestImagesStatus: RequestImagesStatusEnvelope._Inner
 
     data: Data
 
@@ -54,7 +54,7 @@ class ThumbnailEnvelope(BaseModel):
     """Response envelope for xSGetThumbnail."""
 
     class Data(BaseModel):
-        xSGetThumbnail: ThumbnailResponse  # noqa: N815
+        xSGetThumbnail: ThumbnailResponse
 
     data: Data
 
@@ -66,6 +66,6 @@ class PhotoImagesEnvelope(BaseModel):
         devices: list[dict[str, Any]] | None = None
 
     class Data(BaseModel):
-        xSGetPhotoImages: "PhotoImagesEnvelope._Inner"  # noqa: N815
+        xSGetPhotoImages: PhotoImagesEnvelope._Inner
 
     data: Data

--- a/custom_components/securitas/verisure_owa_api/responses/installation.py
+++ b/custom_components/securitas/verisure_owa_api/responses/installation.py
@@ -19,7 +19,7 @@ class InstallationListEnvelope(BaseModel):
         installations: list[Installation]
 
     class Data(BaseModel):
-        xSInstallations: "InstallationListEnvelope._Inner"  # noqa: N815
+        xSInstallations: InstallationListEnvelope._Inner
 
     data: Data
 
@@ -40,9 +40,9 @@ class ServicesEnvelope(BaseModel):
     class _Inner(_NullSafeBase):
         res: str = ""
         msg: str | None = None
-        installation: "ServicesEnvelope._Installation | None" = None
+        installation: ServicesEnvelope._Installation | None = None
 
     class Data(BaseModel):
-        xSSrv: "ServicesEnvelope._Inner"  # noqa: N815
+        xSSrv: ServicesEnvelope._Inner
 
     data: Data

--- a/custom_components/securitas/verisure_owa_api/responses/lock.py
+++ b/custom_components/securitas/verisure_owa_api/responses/lock.py
@@ -17,7 +17,7 @@ class SmartlockConfigEnvelope(BaseModel):
     """Response envelope for xSGetSmartlockConfig."""
 
     class Data(BaseModel):
-        xSGetSmartlockConfig: SmartLock  # noqa: N815
+        xSGetSmartlockConfig: SmartLock
 
     data: Data
 
@@ -26,7 +26,7 @@ class DanalockConfigEnvelope(BaseModel):
     """Response envelope for xSGetDanalockConfig."""
 
     class Data(BaseModel):
-        xSGetDanalockConfig: _ResMsgRef  # noqa: N815
+        xSGetDanalockConfig: _ResMsgRef
 
     data: Data
 
@@ -43,7 +43,7 @@ class DanalockConfigStatusEnvelope(BaseModel):
         features: LockFeatures | None = None
 
     class Data(BaseModel):
-        xSGetDanalockConfigStatus: "DanalockConfigStatusEnvelope._Inner"  # noqa: N815
+        xSGetDanalockConfigStatus: DanalockConfigStatusEnvelope._Inner
 
     data: Data
 
@@ -60,7 +60,7 @@ class LockModeEnvelope(BaseModel):
         )
 
     class Data(BaseModel):
-        xSGetLockCurrentMode: "LockModeEnvelope._Inner"  # noqa: N815
+        xSGetLockCurrentMode: LockModeEnvelope._Inner
 
     data: Data
 
@@ -69,7 +69,7 @@ class ChangeLockModeEnvelope(BaseModel):
     """Response envelope for xSChangeSmartlockMode."""
 
     class Data(BaseModel):
-        xSChangeSmartlockMode: _ResMsgRef  # noqa: N815
+        xSChangeSmartlockMode: _ResMsgRef
 
     data: Data
 
@@ -88,6 +88,6 @@ class ChangeLockModeStatusEnvelope(BaseModel):
         status: str | None = None
 
     class Data(BaseModel):
-        xSChangeSmartlockModeStatus: "ChangeLockModeStatusEnvelope._Inner"  # noqa: N815
+        xSChangeSmartlockModeStatus: ChangeLockModeStatusEnvelope._Inner
 
     data: Data

--- a/custom_components/securitas/verisure_owa_api/responses/sentinel.py
+++ b/custom_components/securitas/verisure_owa_api/responses/sentinel.py
@@ -20,7 +20,7 @@ class SentinelEnvelope(BaseModel):
         forecast: dict[str, Any] | None = None
 
     class Data(BaseModel):
-        xSComfort: "SentinelEnvelope._Inner"  # noqa: N815
+        xSComfort: SentinelEnvelope._Inner
 
     data: Data
 
@@ -33,6 +33,6 @@ class AirQualityEnvelope(BaseModel):
         data: dict[str, Any] | None = None
 
     class Data(BaseModel):
-        xSAirQuality: "AirQualityEnvelope._Inner"  # noqa: N815
+        xSAirQuality: AirQualityEnvelope._Inner
 
     data: Data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,23 @@ exclude_also = [
 ]
 
 [tool.ruff]
-exclude = [".claude"]
+# docs/ is prose: ruff 0.16 began formatting Python fenced in Markdown, which
+# only reflows the illustrative snippets there — not something we want ruff to
+# police. Its job here is the package and its tests.
+exclude = [".claude", "docs"]
+target-version = "py313"
+
+[tool.ruff.lint]
+# Enforce an explicit rule set rather than ruff's defaults, which shift between
+# releases: 0.16.0 expanded the defaults and reddened this job on an untouched
+# tree. Pinning the rules we enforce (not the ruff version) lets CI install the
+# latest ruff and still stay green. This set mirrors the sibling integrations.
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
+# Line width is left to `ruff format`; E501 would otherwise only fire on long
+# string literals and comments the formatter deliberately leaves intact.
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# Test fixtures legitimately carry mutable class attributes (RUF012) and assert
+# that mutation raises *any* exception (B017) — both are noise in test code.
+"tests/**/*.py" = ["RUF012", "B017"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,45 +1,12 @@
 """Shared fixtures for the Verisure OWA HA integration tests."""
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
 import pytest
-
-from .mock_graphql import MockGraphQLServer
-
-from custom_components.securitas import (
-    CONF_CODE_ARM_REQUIRED,
-    CONF_COUNTRY,
-    CONF_DELAY_CHECK_OPERATION,
-    CONF_DEVICE_INDIGITALL,
-    CONF_ENTRY_ID,
-    CONF_MAP_AWAY,
-    CONF_MAP_CUSTOM,
-    CONF_MAP_HOME,
-    CONF_MAP_NIGHT,
-    CONF_MAP_VACATION,
-    CONF_NOTIFY_GROUP,
-    CONF_FORCE_ARM_NOTIFICATIONS,
-    DEFAULT_DELAY_CHECK_OPERATION,
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-    VerisureDevice,
-    VerisureHub,
-)
-from custom_components.securitas.verisure_owa_api.client import (
-    VerisureOwaClient,
-)
-from custom_components.securitas.verisure_owa_api.http_transport import (
-    HttpTransport,
-)
-from custom_components.securitas.verisure_owa_api.const import (
-    PERI_DEFAULTS,
-    STD_DEFAULTS,
-)
-from custom_components.securitas.verisure_owa_api.models import Installation
 from homeassistant.const import (
     CONF_CODE,
     CONF_DEVICE_ID,
@@ -49,6 +16,38 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 
+from custom_components.securitas import (
+    CONF_CODE_ARM_REQUIRED,
+    CONF_COUNTRY,
+    CONF_DELAY_CHECK_OPERATION,
+    CONF_DEVICE_INDIGITALL,
+    CONF_ENTRY_ID,
+    CONF_FORCE_ARM_NOTIFICATIONS,
+    CONF_MAP_AWAY,
+    CONF_MAP_CUSTOM,
+    CONF_MAP_HOME,
+    CONF_MAP_NIGHT,
+    CONF_MAP_VACATION,
+    CONF_NOTIFY_GROUP,
+    DEFAULT_DELAY_CHECK_OPERATION,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    VerisureDevice,
+    VerisureHub,
+)
+from custom_components.securitas.verisure_owa_api.client import (
+    VerisureOwaClient,
+)
+from custom_components.securitas.verisure_owa_api.const import (
+    PERI_DEFAULTS,
+    STD_DEFAULTS,
+)
+from custom_components.securitas.verisure_owa_api.http_transport import (
+    HttpTransport,
+)
+from custom_components.securitas.verisure_owa_api.models import Installation
+
+from .mock_graphql import MockGraphQLServer
 
 # ── integration-marker auto-application ───────────────────────────────────────
 #
@@ -93,7 +92,7 @@ SECRET = "test-secret"
 
 def make_jwt(exp_minutes: int = 15, **extra_claims) -> str:
     """Create a real HS256 JWT with a known expiry."""
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=exp_minutes)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=exp_minutes)
     payload = {"exp": exp, "sub": "test-user", **extra_claims}
     return jwt.encode(payload, SECRET, algorithm="HS256")
 

--- a/tests/mock_graphql.py
+++ b/tests/mock_graphql.py
@@ -6,11 +6,10 @@ error handling — while returning canned responses.
 """
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import jwt
-
 
 # ── JWT helper ────────────────────────────────────────────────────────────────
 
@@ -19,7 +18,7 @@ _JWT_SECRET = "test-secret"
 
 def make_jwt(exp_minutes: int = 60, **extra_claims) -> str:
     """Create a real HS256 JWT with a known expiry."""
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=exp_minutes)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=exp_minutes)
     payload = {"exp": exp, "sub": "test-user", **extra_claims}
     return jwt.encode(payload, _JWT_SECRET, algorithm="HS256")
 
@@ -533,7 +532,7 @@ def graphql_air_quality(
     hour_value: str = "114",
     hour_id: str = "18:00",
     status_current: int = 1,
-    hours: list | None | object = _UNSET,
+    hours: list | object | None = _UNSET,
 ) -> dict:
     """xSAirQuality response.
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -1,15 +1,14 @@
 """Tests for alarm_control_panel entity logic."""
 
 import inspect
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import attr
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature  # type: ignore[attr-defined]
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntityFeature,  # type: ignore[attr-defined]
+)
 from homeassistant.components.alarm_control_panel.const import (
     AlarmControlPanelState,
     CodeFormat,
@@ -18,11 +17,27 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as _er_for_feature_detect
 from homeassistant.helpers.entity_registry import DeletedRegistryEntry
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.securitas.verisure_owa_api.models import (
-    Installation,
-    OperationStatus,
-    SStatus,
+from custom_components.securitas.alarm_control_panel import (
+    CombinedVerisureOwaAlarmPanel,
+)
+from custom_components.securitas.const import (
+    CONF_FORCE_ARM_NOTIFICATIONS,
+    DEFAULT_FORCE_ARM_NOTIFICATIONS,
+)
+from custom_components.securitas.coordinators import (
+    AlarmCoordinator,
+    AlarmStatusData,
+)
+from custom_components.securitas.events import (
+    ARMING_EXCEPTION_DISMISSED_EVENT_TYPE,
+    FORCE_ARM_EXPIRED_EVENT_TYPE,
+)
+from custom_components.securitas.verisure_owa_api.command_resolver import (
+    AlarmState,
+    InteriorMode,
+    PerimeterMode,
 )
 from custom_components.securitas.verisure_owa_api.const import (
     PERI_DEFAULTS,
@@ -34,25 +49,10 @@ from custom_components.securitas.verisure_owa_api.exceptions import (
     ArmingExceptionError,
     VerisureOwaError,
 )
-from custom_components.securitas.alarm_control_panel import (
-    CombinedVerisureOwaAlarmPanel,
-)
-from custom_components.securitas.coordinators import (
-    AlarmCoordinator,
-    AlarmStatusData,
-)
-from custom_components.securitas.verisure_owa_api.command_resolver import (
-    AlarmState,
-    InteriorMode,
-    PerimeterMode,
-)
-from custom_components.securitas.const import (
-    CONF_FORCE_ARM_NOTIFICATIONS,
-    DEFAULT_FORCE_ARM_NOTIFICATIONS,
-)
-from custom_components.securitas.events import (
-    ARMING_EXCEPTION_DISMISSED_EVENT_TYPE,
-    FORCE_ARM_EXPIRED_EVENT_TYPE,
+from custom_components.securitas.verisure_owa_api.models import (
+    Installation,
+    OperationStatus,
+    SStatus,
 )
 
 
@@ -4801,11 +4801,11 @@ class TestExecuteTransitionRefusesUnknownState:
         (instead of the panel's later polled type-5xx 'Error conectando'
         message — which dedups against this synthetic row via the
         HA_INJECTABLE_CATEGORIES filter in the coordinator)."""
-        from custom_components.securitas.verisure_owa_api.models import (
-            ActivityCategory,
-        )
         from custom_components.securitas.verisure_owa_api.exceptions import (
             VerisureOwaError,
+        )
+        from custom_components.securitas.verisure_owa_api.models import (
+            ActivityCategory,
         )
 
         alarm = make_alarm()
@@ -4830,11 +4830,11 @@ class TestExecuteTransitionRefusesUnknownState:
         """A failed disarm round-trip (panel-side comms error) injects
         COMMUNICATION_FAILED so the timeline picks up the failure with HA
         context."""
-        from custom_components.securitas.verisure_owa_api.models import (
-            ActivityCategory,
-        )
         from custom_components.securitas.verisure_owa_api.exceptions import (
             VerisureOwaError,
+        )
+        from custom_components.securitas.verisure_owa_api.models import (
+            ActivityCategory,
         )
 
         alarm = make_alarm()
@@ -6122,13 +6122,14 @@ class TestPerimeterSubPanel:
         assert target.annex == AnnexMode.OFF  # preserved
 
     def test_extract_state(self):
+        from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
             AnnexMode,
             InteriorMode,
             PerimeterMode,
         )
-        from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 
         panel = _make_perimeter_panel()
         on = panel._extract_state(
@@ -6276,13 +6277,14 @@ class TestAnnexSubPanel:
         assert s.perimeter == PerimeterMode.ON  # preserved
 
     def test_extract_state(self):
+        from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
             AnnexMode,
             InteriorMode,
             PerimeterMode,
         )
-        from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 
         panel = _make_annex_panel()
         on = panel._extract_state(
@@ -6595,10 +6597,10 @@ class TestSubPanelSetup:
 
     def _setup_kwargs(self, *, options: dict, has_peri: bool, has_annex: bool):
         """Build hass/entry/coordinator suitable for invoking async_setup_entry."""
-        from custom_components.securitas.const import DOMAIN
         from custom_components.securitas import (
             VerisureDevice,
         )
+        from custom_components.securitas.const import DOMAIN
 
         installation = Installation(
             number="123456",
@@ -6644,8 +6646,8 @@ class TestSubPanelSetup:
     @pytest.mark.asyncio
     async def test_only_combined_when_no_toggles(self):
         from custom_components.securitas.alarm_control_panel import (
-            async_setup_entry,
             CombinedVerisureOwaAlarmPanel,
+            async_setup_entry,
         )
 
         hass, entry = self._setup_kwargs(options={}, has_peri=True, has_annex=True)
@@ -6673,8 +6675,8 @@ class TestSubPanelSetup:
         reload the integration to recover.
         """
         from custom_components.securitas.alarm_control_panel import (
-            async_setup_entry,
             PerimeterVerisureOwaAlarmPanel,
+            async_setup_entry,
         )
         from custom_components.securitas.const import CONF_ENABLE_PERIMETER_PANEL
 
@@ -6702,8 +6704,8 @@ class TestSubPanelSetup:
         for the rationale — saved toggle is the source of truth.
         """
         from custom_components.securitas.alarm_control_panel import (
-            async_setup_entry,
             AnnexVerisureOwaAlarmPanel,
+            async_setup_entry,
         )
         from custom_components.securitas.const import CONF_ENABLE_ANNEX_PANEL
 
@@ -6734,8 +6736,8 @@ class TestSubPanelSetup:
         entity-creation guard must match.
         """
         from custom_components.securitas.alarm_control_panel import (
-            async_setup_entry,
             InteriorVerisureOwaAlarmPanel,
+            async_setup_entry,
         )
         from custom_components.securitas.const import CONF_ENABLE_INTERIOR_PANEL
 
@@ -6765,8 +6767,8 @@ class TestSubPanelSetup:
         capability-detection failure at startup permanently hide the entity.
         """
         from custom_components.securitas.alarm_control_panel import (
-            async_setup_entry,
             InteriorVerisureOwaAlarmPanel,
+            async_setup_entry,
         )
         from custom_components.securitas.const import CONF_ENABLE_INTERIOR_PANEL
 
@@ -6792,9 +6794,9 @@ class TestSubPanelSetup:
             async_setup_entry,
         )
         from custom_components.securitas.const import (
+            CONF_ENABLE_ANNEX_PANEL,
             CONF_ENABLE_INTERIOR_PANEL,
             CONF_ENABLE_PERIMETER_PANEL,
-            CONF_ENABLE_ANNEX_PANEL,
         )
 
         hass, entry = self._setup_kwargs(
@@ -6827,14 +6829,14 @@ class TestSubPanelSetup:
     async def test_alarm_entities_lookup_only_combined(self):
         """Combined panel is the one registered in alarm_entities for force_arm services."""
         from custom_components.securitas.alarm_control_panel import (
-            async_setup_entry,
             CombinedVerisureOwaAlarmPanel,
+            async_setup_entry,
         )
         from custom_components.securitas.const import (
-            DOMAIN,
+            CONF_ENABLE_ANNEX_PANEL,
             CONF_ENABLE_INTERIOR_PANEL,
             CONF_ENABLE_PERIMETER_PANEL,
-            CONF_ENABLE_ANNEX_PANEL,
+            DOMAIN,
         )
 
         hass, entry = self._setup_kwargs(
@@ -6932,9 +6934,9 @@ class TestBuildPartialDisarmTarget:
         )
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         current = AlarmState(
@@ -6953,9 +6955,9 @@ class TestBuildPartialDisarmTarget:
         )
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         current = AlarmState(
@@ -6974,9 +6976,9 @@ class TestBuildPartialDisarmTarget:
         )
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         current = AlarmState(
@@ -7016,9 +7018,9 @@ class TestExecutePartialDisarm:
     async def test_returns_true_on_success_and_calls_execute_transition(self):
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         panel = make_alarm()  # existing helper
@@ -7046,9 +7048,9 @@ class TestExecutePartialDisarm:
         from custom_components.securitas.verisure_owa_api import VerisureOwaError
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         panel = make_alarm()
@@ -7073,14 +7075,15 @@ class TestExecutePartialDisarm:
         so the UI reflects an in-flight auto-disarm instead of jumping silently
         from armed to disarmed when the next coordinator poll arrives.
         """
-        from custom_components.securitas.verisure_owa_api.models import (
-            AlarmState,
-            InteriorMode,
-            PerimeterMode,
-            AnnexMode,
-        )
         from homeassistant.components.alarm_control_panel.const import (
             AlarmControlPanelState,
+        )
+
+        from custom_components.securitas.verisure_owa_api.models import (
+            AlarmState,
+            AnnexMode,
+            InteriorMode,
+            PerimeterMode,
         )
 
         panel = make_alarm()
@@ -7109,9 +7112,9 @@ class TestExecutePartialDisarm:
         rather than waiting for the next poll."""
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         panel = make_alarm()
@@ -7135,15 +7138,16 @@ class TestExecutePartialDisarm:
         execute_partial_disarm should drive its state through DISARMING and into
         the post-result state too — so users see the same animation as a direct
         sub-panel disarm."""
-        from custom_components.securitas.verisure_owa_api.models import (
-            AlarmState,
-            InteriorMode,
-            PerimeterMode,
-            AnnexMode,
-        )
-        from custom_components.securitas.const import DOMAIN
         from homeassistant.components.alarm_control_panel.const import (
             AlarmControlPanelState,
+        )
+
+        from custom_components.securitas.const import DOMAIN
+        from custom_components.securitas.verisure_owa_api.models import (
+            AlarmState,
+            AnnexMode,
+            InteriorMode,
+            PerimeterMode,
         )
 
         panel = make_alarm()
@@ -7588,7 +7592,7 @@ class TestCombinedPanelEntityIdHealer:
         rewritten to canonical. Otherwise a delete/re-add cycle would silently
         discard the user's chosen slug on re-add.
         """
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         from homeassistant.helpers import entity_registry as er
 
@@ -7614,7 +7618,7 @@ class TestCombinedPanelEntityIdHealer:
             "alarm_control_panel.chiesa_nuova_alarm_corso_vittorio_emanuele_252_roma"
         )
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         ent_reg.deleted_entities[("alarm_control_panel", DOMAIN, unique_id)] = (
             DeletedRegistryEntry(
                 entity_id=custom_entity_id,
@@ -7856,7 +7860,7 @@ class TestSubPanelEntityIdHealer:
         The healer must rewrite the tombstone's ``entity_id`` to the canonical
         slot so the next async_get_or_create restores onto the correct slug.
         """
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         from homeassistant.helpers import entity_registry as er
         from homeassistant.util import slugify
@@ -7885,7 +7889,7 @@ class TestSubPanelEntityIdHealer:
 
         # Seed the tombstone HA would have left behind after the user
         # deleted the config entry from the UI.
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         ent_reg.deleted_entities[("alarm_control_panel", DOMAIN, unique_id)] = (
             DeletedRegistryEntry(
                 entity_id=broken,
@@ -7990,7 +7994,7 @@ class TestSubPanelEntityIdHealer:
         """A sub-panel tombstone holding a user-customized entity_id must NOT
         be rewritten to canonical.
         """
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         from homeassistant.helpers import entity_registry as er
 
@@ -8015,7 +8019,7 @@ class TestSubPanelEntityIdHealer:
         circuit = suffix.lstrip("_")
         custom_entity_id = f"alarm_control_panel.chiesa_nuova_{circuit}"
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         ent_reg.deleted_entities[("alarm_control_panel", DOMAIN, unique_id)] = (
             DeletedRegistryEntry(
                 entity_id=custom_entity_id,
@@ -8059,6 +8063,7 @@ class TestCombinedPanelRegistration:
 
     def _make_client(self):
         from unittest.mock import MagicMock
+
         from custom_components.securitas.verisure_owa_api.const import STD_DEFAULTS
 
         client = MagicMock()
@@ -8086,6 +8091,7 @@ class TestCombinedPanelRegistration:
 
     async def _run_setup(self, hass, entry, async_add_entities):
         from unittest.mock import MagicMock, patch
+
         from custom_components.securitas.alarm_control_panel import (
             CombinedVerisureOwaAlarmPanel,
             async_setup_entry,
@@ -8118,10 +8124,11 @@ class TestCombinedPanelRegistration:
     async def test_combined_panels_keyed_by_installation_number_multi(self):
         """With two installations, combined_alarm_panels must be a dict with one entry per installation."""
         from unittest.mock import MagicMock
+
+        from custom_components.securitas import DOMAIN
         from custom_components.securitas.alarm_control_panel import (
             CombinedVerisureOwaAlarmPanel,
         )
-        from custom_components.securitas import DOMAIN
         from custom_components.securitas.coordinators import AlarmCoordinator
 
         device_a = self._make_device("111111", "Main Home")
@@ -8167,10 +8174,11 @@ class TestCombinedPanelRegistration:
     async def test_combined_panel_per_installation_with_single_install(self):
         """With one installation, combined_alarm_panels must be a dict with exactly one entry."""
         from unittest.mock import MagicMock
+
+        from custom_components.securitas import DOMAIN
         from custom_components.securitas.alarm_control_panel import (
             CombinedVerisureOwaAlarmPanel,
         )
-        from custom_components.securitas import DOMAIN
         from custom_components.securitas.coordinators import AlarmCoordinator
 
         device = self._make_device("654321", "Test Home")
@@ -8299,7 +8307,9 @@ async def test_disarm_timeout_is_provisional_not_failed():
     """OperationTimeoutError after accepted disarm => optimistic disarmed +
     provisional flag + unconfirmed notification, NOT a rollback/failure."""
     from unittest.mock import AsyncMock
+
     from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+
     from custom_components.securitas.verisure_owa_api.exceptions import (
         OperationTimeoutError,
     )
@@ -8328,7 +8338,9 @@ async def test_arm_timeout_is_provisional_not_failed():
     """OperationTimeoutError after accepted arm => optimistic target state +
     provisional flag + unconfirmed notification, NOT a rollback/failure."""
     from unittest.mock import AsyncMock
+
     from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+
     from custom_components.securitas.verisure_owa_api.exceptions import (
         OperationTimeoutError,
     )
@@ -8452,6 +8464,7 @@ async def test_disarm_reentry_guard_ignores_overlapping_call():
 async def test_arm_reentry_guard_ignores_overlapping_call():
     """A second arm while one is in progress is ignored (no duplicate command)."""
     from unittest.mock import AsyncMock
+
     from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 
     alarm = make_alarm()

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -120,10 +120,13 @@ def _find_bare_dict_violations(files: list[Path]) -> list[str]:
                         )
 
             # Check variable annotations
-            if isinstance(node, ast.AnnAssign) and node.annotation:
-                if _has_bare_dict(node.annotation):
-                    target = ast.dump(node.target) if node.target else "?"
-                    violations.append(f"{path.name}:{node.lineno} (variable {target})")
+            if (
+                isinstance(node, ast.AnnAssign)
+                and node.annotation
+                and _has_bare_dict(node.annotation)
+            ):
+                target = ast.dump(node.target) if node.target else "?"
+                violations.append(f"{path.name}:{node.lineno} (variable {target})")
 
     return violations
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,5 @@
 """Tests for VerisureOwaClient authentication flow."""
 
-import asyncio
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock
 
@@ -10,8 +9,8 @@ from custom_components.securitas.verisure_owa_api.exceptions import (
     AccountBlockedError,
     AuthenticationError,
     SessionExpiredError,
-    VerisureOwaError,
     TwoFactorRequiredError,
+    VerisureOwaError,
 )
 
 from .conftest import (
@@ -22,7 +21,6 @@ from .conftest import (
     refresh_response,
     validate_device_response,
 )
-
 
 # ── login() ──────────────────────────────────────────────────────────────────
 
@@ -257,7 +255,7 @@ class TestCheckAuthenticationToken:
         api.authentication_token = FAKE_JWT
         api.authentication_token_exp = datetime.min
         api.refresh_token_value = "has-refresh-token"
-        api.refresh_token = AsyncMock(side_effect=asyncio.TimeoutError())
+        api.refresh_token = AsyncMock(side_effect=TimeoutError())
         api.login = AsyncMock()
 
         with pytest.raises(VerisureOwaError):
@@ -272,7 +270,7 @@ class TestCheckAuthenticationToken:
         api.authentication_token = FAKE_JWT
         api.authentication_token_exp = datetime.min
         api.refresh_token_value = "has-refresh-token"
-        api.refresh_token = AsyncMock(side_effect=asyncio.TimeoutError())
+        api.refresh_token = AsyncMock(side_effect=TimeoutError())
         api.login = AsyncMock()
 
         with pytest.raises(VerisureOwaError) as exc_info:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -11,9 +11,7 @@ from custom_components.securitas.coordinators import (
     AlarmStatusData,
 )
 from custom_components.securitas.verisure_owa_api.models import SStatus
-
 from tests.conftest import make_installation
-
 
 # ---------------------------------------------------------------------------
 # Helper

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,20 +1,19 @@
 """Tests for button entity (VerisureRefreshButton)."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from custom_components.securitas import DOMAIN
 from custom_components.securitas.button import (
     VerisureRefreshButton,
     async_setup_entry,
 )
-from custom_components.securitas import DOMAIN
-
 from tests.conftest import (
     make_installation,
     make_securitas_hub_mock,
     setup_integration_data,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helper

--- a/tests/test_camera_api.py
+++ b/tests/test_camera_api.py
@@ -3,12 +3,10 @@
 import base64
 import json
 
-
 from custom_components.securitas.verisure_owa_api.models import (
     CameraDevice,
     ThumbnailResponse,
 )
-
 
 # ── Dataclass tests ──────────────────────────────────────────────────────────
 

--- a/tests/test_camera_platform.py
+++ b/tests/test_camera_platform.py
@@ -1,18 +1,18 @@
 """Tests for camera platform entities."""
 
 import base64
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
 
+from custom_components.securitas import DOMAIN
+from custom_components.securitas.coordinators import CameraCoordinator, CameraData
+from custom_components.securitas.entity import camera_device_info
+from custom_components.securitas.verisure_owa_api import Installation
 from custom_components.securitas.verisure_owa_api.models import (
     CameraDevice,
     ThumbnailResponse,
 )
-from custom_components.securitas.verisure_owa_api import Installation
-from custom_components.securitas import DOMAIN
-from custom_components.securitas.coordinators import CameraCoordinator, CameraData
-from custom_components.securitas.entity import camera_device_info
 
 
 class TestCameraDeviceInfo:
@@ -117,6 +117,7 @@ class TestVerisureCamera:
     ):
         """Camera is the primary entity of its device -- no name suffix is set."""
         from homeassistant.helpers.entity import UNDEFINED
+
         from custom_components.securitas.camera import VerisureCamera
 
         cam = VerisureCamera(mock_coordinator, mock_hub, installation, camera_device)
@@ -220,7 +221,7 @@ class TestVerisureCamera:
 
         mock_hass.async_add_executor_job.assert_called_once()
         assert result == placeholder_bytes
-        assert cam_module._PLACEHOLDER_IMAGE == placeholder_bytes
+        assert placeholder_bytes == cam_module._PLACEHOLDER_IMAGE
 
     @pytest.mark.asyncio
     async def test_placeholder_cached_after_first_load(
@@ -249,8 +250,8 @@ class TestVerisureCamera:
     def test_device_info_uses_camera_sub_device(
         self, mock_coordinator, mock_hub, installation, camera_device
     ):
-        from custom_components.securitas.camera import VerisureCamera
         from custom_components.securitas import DOMAIN
+        from custom_components.securitas.camera import VerisureCamera
 
         cam = VerisureCamera(mock_coordinator, mock_hub, installation, camera_device)
         info = cam.device_info
@@ -506,8 +507,8 @@ class TestVerisureCaptureButton:
     def test_device_info_uses_camera_sub_device(
         self, mock_hub, installation, camera_device
     ):
-        from custom_components.securitas.button import VerisureCaptureButton
         from custom_components.securitas import DOMAIN
+        from custom_components.securitas.button import VerisureCaptureButton
 
         btn = VerisureCaptureButton(mock_hub, installation, camera_device)
         info = btn.device_info
@@ -614,11 +615,11 @@ class TestVerisureCameraFull:
         self, mock_coordinator, mock_hub, installation, camera_device
     ):
         """Both camera entities must share the same HA device (same identifiers)."""
+        from custom_components.securitas import DOMAIN
         from custom_components.securitas.camera import (
             VerisureCamera,
             VerisureCameraFull,
         )
-        from custom_components.securitas import DOMAIN
 
         thumb_cam = VerisureCamera(
             mock_coordinator, mock_hub, installation, camera_device

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,7 +1,7 @@
 """Tests for capability JWT decoding and detection helpers."""
 
-from datetime import datetime, timedelta
 import json
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from custom_components.securitas.verisure_owa_api.client import (

--- a/tests/test_client_activity.py
+++ b/tests/test_client_activity.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
@@ -25,7 +25,7 @@ SECRET = "test-secret"
 
 
 def _make_jwt(**claims) -> str:
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=15)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=15)
     return jwt.encode(
         {"exp": exp, "sub": "test-user", **claims}, SECRET, algorithm="HS256"
     )

--- a/tests/test_client_alarm.py
+++ b/tests/test_client_alarm.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
@@ -25,7 +25,6 @@ from custom_components.securitas.verisure_owa_api.models import (
     SStatus,
 )
 
-
 # ── JWT helpers ──────────────────────────────────────────────────────────────
 
 SECRET = "test-secret"
@@ -33,7 +32,7 @@ SECRET = "test-secret"
 
 def make_jwt(exp_minutes: int = 15, **extra_claims) -> str:
     """Create a real HS256 JWT with a known expiry."""
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=exp_minutes)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=exp_minutes)
     payload = {"exp": exp, "sub": "test-user", **extra_claims}
     return jwt.encode(payload, SECRET, algorithm="HS256")
 

--- a/tests/test_client_auth.py
+++ b/tests/test_client_auth.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
@@ -17,8 +17,8 @@ from custom_components.securitas.verisure_owa_api.exceptions import (
     AccountBlockedError,
     AuthenticationError,
     OperationTimeoutError,
-    VerisureOwaError,
     TwoFactorRequiredError,
+    VerisureOwaError,
 )
 from custom_components.securitas.verisure_owa_api.http_transport import (
     HttpTransport,
@@ -28,7 +28,6 @@ from custom_components.securitas.verisure_owa_api.responses import (
     GeneralStatusEnvelope,
 )
 
-
 # ── JWT helpers ──────────────────────────────────────────────────────────────
 
 SECRET = "test-secret"
@@ -36,7 +35,7 @@ SECRET = "test-secret"
 
 def make_jwt(exp_minutes: int = 15, **extra_claims) -> str:
     """Create a real HS256 JWT with a known expiry."""
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=exp_minutes)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=exp_minutes)
     payload = {"exp": exp, "sub": "test-user", **extra_claims}
     return jwt.encode(payload, SECRET, algorithm="HS256")
 
@@ -280,7 +279,7 @@ class TestLogin:
         verify signatures (the token comes from a trusted HTTPS endpoint), so
         the decode path must accept any algorithm.
         """
-        exp = datetime.now(tz=timezone.utc) + timedelta(minutes=15)
+        exp = datetime.now(tz=UTC) + timedelta(minutes=15)
         non_hs256_token = jwt.encode(
             {"exp": exp, "sub": "test"}, "k", algorithm="HS512"
         )

--- a/tests/test_client_camera.py
+++ b/tests/test_client_camera.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
@@ -22,7 +22,6 @@ from custom_components.securitas.verisure_owa_api.models import (
     ThumbnailResponse,
 )
 
-
 # ── JWT helpers ──────────────────────────────────────────────────────────────
 
 SECRET = "test-secret"
@@ -30,7 +29,7 @@ SECRET = "test-secret"
 
 def make_jwt(exp_minutes: int = 15, **extra_claims) -> str:
     """Create a real HS256 JWT with a known expiry."""
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=exp_minutes)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=exp_minutes)
     payload = {"exp": exp, "sub": "test-user", **extra_claims}
     return jwt.encode(payload, SECRET, algorithm="HS256")
 

--- a/tests/test_client_lock.py
+++ b/tests/test_client_lock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
@@ -24,7 +24,6 @@ from custom_components.securitas.verisure_owa_api.models import (
     SmartLockModeStatus,
 )
 
-
 # ── JWT helpers ──────────────────────────────────────────────────────────────
 
 SECRET = "test-secret"
@@ -32,7 +31,7 @@ SECRET = "test-secret"
 
 def make_jwt(exp_minutes: int = 15, **extra_claims) -> str:
     """Create a real HS256 JWT with a known expiry."""
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=exp_minutes)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=exp_minutes)
     payload = {"exp": exp, "sub": "test-user", **extra_claims}
     return jwt.encode(payload, SECRET, algorithm="HS256")
 

--- a/tests/test_client_misc.py
+++ b/tests/test_client_misc.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt
@@ -22,7 +22,6 @@ from custom_components.securitas.verisure_owa_api.models import (
     Service,
 )
 
-
 # ── JWT helpers ──────────────────────────────────────────────────────────────
 
 SECRET = "test-secret"
@@ -30,7 +29,7 @@ SECRET = "test-secret"
 
 def make_jwt(exp_minutes: int = 15, **extra_claims) -> str:
     """Create a real HS256 JWT with a known expiry."""
-    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=exp_minutes)
+    exp = datetime.now(tz=UTC) + timedelta(minutes=exp_minutes)
     payload = {"exp": exp, "sub": "test-user", **extra_claims}
     return jwt.encode(payload, SECRET, algorithm="HS256")
 

--- a/tests/test_command_resolver.py
+++ b/tests/test_command_resolver.py
@@ -3,13 +3,13 @@
 import pytest
 
 from custom_components.securitas.verisure_owa_api.command_resolver import (
+    ALARM_STATE_TO_PROTO,
+    PROTO_TO_ALARM_STATE,
+    VERISURE_OWA_STATE_TO_ALARM_STATE,
     AlarmState,
     CommandResolver,
     InteriorMode,
     PerimeterMode,
-    PROTO_TO_ALARM_STATE,
-    ALARM_STATE_TO_PROTO,
-    VERISURE_OWA_STATE_TO_ALARM_STATE,
 )
 from custom_components.securitas.verisure_owa_api.const import VerisureOwaState
 from custom_components.securitas.verisure_owa_api.models import AnnexMode

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,6 +3,18 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.const import (
+    CONF_CODE,
+    CONF_DEVICE_ID,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_TOKEN,
+    CONF_UNIQUE_ID,
+    CONF_USERNAME,
+)
+from homeassistant.data_entry_flow import FlowResultType, section
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.securitas import (
     CONF_ADVANCED,
@@ -27,28 +39,16 @@ from custom_components.securitas.const import (
     CONF_REFRESH_TOKEN,
 )
 from custom_components.securitas.verisure_owa_api import (
+    PERI_DEFAULTS,
+    STD_DEFAULTS,
     AccountBlockedError,
     Attribute,
     AuthenticationError,
     OtpPhone,
-    PERI_DEFAULTS,
-    STD_DEFAULTS,
+    TwoFactorRequiredError,
     VerisureOwaError,
     VerisureOwaState,
-    TwoFactorRequiredError,
 )
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import (
-    CONF_CODE,
-    CONF_DEVICE_ID,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_TOKEN,
-    CONF_UNIQUE_ID,
-    CONF_USERNAME,
-)
-from homeassistant.data_entry_flow import FlowResultType, section
-
 from tests.conftest import (
     FAKE_JWT,
     FAKE_REFRESH_TOKEN,
@@ -56,8 +56,6 @@ from tests.conftest import (
     make_installation,
     make_securitas_hub_mock,
 )
-
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,7 +4,6 @@ import pytest
 
 from custom_components.securitas.const import COUNTRY_CODES, SENTINEL_SERVICE_NAMES
 from custom_components.securitas.verisure_owa_api.const import (
-    CommandType,
     PERI_DEFAULTS,
     PERI_OPTIONS,
     PROTO_TO_STATE,
@@ -12,10 +11,10 @@ from custom_components.securitas.verisure_owa_api.const import (
     STATE_TO_COMMAND,
     STD_DEFAULTS,
     STD_OPTIONS,
+    CommandType,
     VerisureOwaState,
     dropdown_options,
 )
-
 
 # ── SENTINEL_SERVICE_NAMES ───────────────────────────────────────────────────
 
@@ -438,10 +437,10 @@ class TestCountryCodes:
 
 def test_lock_automations_constants_exist():
     from custom_components.securitas.const import (
-        CONF_LOCK_AUTOMATIONS,
+        CIRCUIT_ANNEX,
         CIRCUIT_INTERIOR,
         CIRCUIT_PERIMETER,
-        CIRCUIT_ANNEX,
+        CONF_LOCK_AUTOMATIONS,
         LOCK_CIRCUITS,
     )
 

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -7,11 +7,11 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from custom_components.securitas.api_queue import ApiQueue
 from custom_components.securitas.coordinators import (
     ActivityCoordinator,
     ActivityData,
@@ -24,14 +24,13 @@ from custom_components.securitas.coordinators import (
     SentinelCoordinator,
     SentinelData,
 )
-from custom_components.securitas.api_queue import ApiQueue
 from custom_components.securitas.verisure_owa_api.client import (
     VerisureOwaClient,
 )
 from custom_components.securitas.verisure_owa_api.exceptions import (
     AuthenticationError,
-    VerisureOwaError,
     SessionExpiredError,
+    VerisureOwaError,
     WAFBlockedError,
 )
 from custom_components.securitas.verisure_owa_api.models import (
@@ -46,6 +45,7 @@ from custom_components.securitas.verisure_owa_api.models import (
     SStatus,
     ThumbnailResponse,
 )
+
 from .conftest import make_installation
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -289,7 +289,6 @@ class TestAlarmCoordinator:
     async def test_session_expired_login_timeout_raises_update_failed(self):
         """A raw asyncio.TimeoutError from relogin is treated as transient
         (UpdateFailed + recorded), not an uncaught traceback or reauth."""
-        import asyncio as _asyncio
 
         hass = _make_hass()
         client = _make_client()
@@ -297,7 +296,7 @@ class TestAlarmCoordinator:
         installation = _make_installation()
 
         client.get_general_status.side_effect = SessionExpiredError("expired")
-        client.login.side_effect = _asyncio.TimeoutError()
+        client.login.side_effect = TimeoutError()
 
         coord = self._make_coordinator(hass, client, queue, installation)
         with pytest.raises(UpdateFailed):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.securitas.const import DOMAIN
 from custom_components.securitas.coordinators import (
     ActivityCoordinator,
     ActivityData,
@@ -18,12 +19,11 @@ from custom_components.securitas.events import (
     make_synthetic_event,
     resolve_ha_user,
 )
-from custom_components.securitas.const import DOMAIN
-from custom_components.securitas.verisure_owa_api.models import Installation
 from custom_components.securitas.verisure_owa_api.models import (
     ActivityCategory,
     ActivityEvent,
     ActivityException,
+    Installation,
 )
 
 
@@ -52,7 +52,7 @@ class TestFireActivityEvents:
 
         fire_activity_events(hass, "2654190", events)
 
-        # 2 events × 2 names each = 4 fires
+        # 2 events x 2 names each = 4 fires
         assert hass.bus.async_fire.call_count == 4
 
     def test_both_event_types_are_emitted(self):
@@ -109,7 +109,7 @@ class TestFireActivityEvents:
         fire_activity_events(hass, "2654190", [ev1, ev2])
 
         calls = hass.bus.async_fire.call_args_list
-        # Pair per event: (verisure_owa_activity, securitas_activity) × 2
+        # Pair per event: (verisure_owa_activity, securitas_activity) x 2
         assert [c[0][0] for c in calls] == [
             "verisure_owa_activity",
             "securitas_activity",
@@ -144,7 +144,7 @@ class TestAttachActivityListener:
         callback = coord.async_add_listener.call_args[0][0]
         callback()
 
-        # 1 event × 2 names = 2 fires
+        # 1 event x 2 names = 2 fires
         assert hass.bus.async_fire.call_count == 2
         types = [c[0][0] for c in hass.bus.async_fire.call_args_list]
         assert types == ["verisure_owa_activity", "securitas_activity"]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,23 +5,22 @@ from __future__ import annotations
 import pytest
 
 from custom_components.securitas.verisure_owa_api.exceptions import (
+    AccountBlockedError,
     APIConnectionError,
     APIResponseError,
-    AccountBlockedError,
     ArmingExceptionError,
     AuthenticationError,
     ImageCaptureError,
     OperationFailedError,
     OperationTimeoutError,
-    VerisureOwaError,
     SessionExpiredError,
     TwoFactorRequiredError,
     UnexpectedStateError,
+    VerisureOwaError,
     WAFBlockedError,
     _error_code_from_body,
     is_genuine_auth_failure,
 )
-
 
 # ── Subclass checks ───────────────────────────────────────────────────────────
 

--- a/tests/test_execute_request.py
+++ b/tests/test_execute_request.py
@@ -5,7 +5,6 @@ from custom_components.securitas.verisure_owa_api.client import (
     generate_uuid,
 )
 
-
 # ── generate_uuid tests ──────────────────────────────────────────────────────
 
 

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -7,6 +7,23 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
+from custom_components.securitas.api_queue import ApiQueue
+from custom_components.securitas.coordinators import (
+    ActivityData,
+    LockData,
+    SentinelData,
+)
+from custom_components.securitas.lock import VerisureLock
+from custom_components.securitas.sensor import (
+    ActivityLogSensor,
+    SentinelAirQuality,
+    SentinelAirQualityStatus,
+    SentinelHumidity,
+    SentinelTemperature,
+)
+from custom_components.securitas.verisure_owa_api.exceptions import (
+    VerisureOwaError,
+)
 from custom_components.securitas.verisure_owa_api.models import (
     ActivityEvent,
     AirQuality,
@@ -20,24 +37,6 @@ from custom_components.securitas.verisure_owa_api.models import (
     SmartLockMode,
     SmartLockModeStatus,
 )
-from custom_components.securitas.verisure_owa_api.exceptions import (
-    VerisureOwaError,
-)
-from custom_components.securitas.sensor import (
-    ActivityLogSensor,
-    SentinelAirQuality,
-    SentinelAirQualityStatus,
-    SentinelHumidity,
-    SentinelTemperature,
-)
-from custom_components.securitas.coordinators import (
-    ActivityData,
-    LockData,
-    SentinelData,
-)
-from custom_components.securitas.api_queue import ApiQueue
-from custom_components.securitas.lock import VerisureLock
-
 
 # ---------------------------------------------------------------------------
 # Helper factories
@@ -1331,9 +1330,9 @@ class TestVerisureLockAlarmListener:
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         return AlarmState(
@@ -1363,12 +1362,12 @@ class TestVerisureLockAlarmListener:
         assert lock._state == "1"
 
     def test_armed_circuits_helper_excludes_off_modes(self):
-        from custom_components.securitas.lock import _armed_circuits
         from custom_components.securitas.const import (
+            CIRCUIT_ANNEX,
             CIRCUIT_INTERIOR,
             CIRCUIT_PERIMETER,
-            CIRCUIT_ANNEX,
         )
+        from custom_components.securitas.lock import _armed_circuits
 
         s = self._state(i="OFF", p="ON", a="OFF")
         assert _armed_circuits(s) == {CIRCUIT_PERIMETER}
@@ -1401,9 +1400,9 @@ class TestVerisureLockAutoLockOnArm:
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         return AlarmState(
@@ -2398,9 +2397,9 @@ class TestVerisureLockUnlockDisarm:
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         return AlarmState(
@@ -2522,9 +2521,9 @@ class TestVerisureLockUnlockDisarmFailure:
     def _state(self, *, i="OFF", p="OFF", a="OFF"):
         from custom_components.securitas.verisure_owa_api.models import (
             AlarmState,
+            AnnexMode,
             InteriorMode,
             PerimeterMode,
-            AnnexMode,
         )
 
         return AlarmState(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,5 @@
 """Tests for VerisureOwaClient helper methods."""
 
-import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock
 
@@ -12,7 +11,6 @@ from custom_components.securitas.verisure_owa_api.exceptions import (
 )
 
 from .conftest import make_jwt
-
 
 # ── _decode_auth_token() ────────────────────────────────────────────────────
 
@@ -153,7 +151,7 @@ class TestPollOperation:
         """Should catch asyncio.TimeoutError and continue polling."""
         check_fn = AsyncMock(
             side_effect=[
-                asyncio.TimeoutError("connection timeout"),
+                TimeoutError("connection timeout"),
                 {"res": "OK", "msg": "done"},
             ]
         )
@@ -248,7 +246,7 @@ class TestCheckAuthenticationTokenErrorHandling:
         VerisureOwaError and propagated (transient), not funneled into login."""
         api.authentication_token = None
         api.refresh_token_value = "some-refresh-token"
-        api.refresh_token = AsyncMock(side_effect=asyncio.TimeoutError())
+        api.refresh_token = AsyncMock(side_effect=TimeoutError())
         api.login = AsyncMock()
 
         with pytest.raises(VerisureOwaError):

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -16,7 +16,6 @@ from custom_components.securitas.verisure_owa_api.http_transport import (
     HttpTransport,
 )
 
-
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
 
@@ -118,12 +117,14 @@ class TestHttpTransport:
         )
         _mock_post(session, [dns_err1, dns_err2])
 
-        with patch(
-            "custom_components.securitas.verisure_owa_api.http_transport.asyncio.sleep",
-            new_callable=AsyncMock,
+        with (
+            patch(
+                "custom_components.securitas.verisure_owa_api.http_transport.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            pytest.raises(VerisureOwaError, match="Connection error"),
         ):
-            with pytest.raises(VerisureOwaError, match="Connection error"):
-                await transport.execute(content={}, headers={})
+            await transport.execute(content={}, headers={})
 
     async def test_rate_limit_retry_with_retry_after(self, transport, session):
         """403 with Retry-After header retries after the specified delay."""

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -4,7 +4,6 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from homeassistant.const import CONF_PASSWORD
 
 from custom_components.securitas.api_queue import ApiQueue

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,10 +1,10 @@
 """Tests for custom_components/verisure_owa/__init__.py."""
 
+import contextlib
 from collections import OrderedDict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from homeassistant.const import (
     CONF_CODE,
     CONF_DEVICE_ID,
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.securitas import (
@@ -22,6 +21,7 @@ from custom_components.securitas import (
     CONF_COUNTRY,
     CONF_DELAY_CHECK_OPERATION,
     CONF_DEVICE_INDIGITALL,
+    CONF_FORCE_ARM_NOTIFICATIONS,
     CONF_INSTALLATION,
     CONF_MAP_AWAY,
     CONF_MAP_CUSTOM,
@@ -29,7 +29,6 @@ from custom_components.securitas import (
     CONF_MAP_NIGHT,
     CONF_MAP_VACATION,
     CONF_NOTIFY_GROUP,
-    CONF_FORCE_ARM_NOTIFICATIONS,
     DOMAIN,
     PLATFORMS,
     VerisureDevice,
@@ -50,16 +49,14 @@ from custom_components.securitas.verisure_owa_api.const import (
 )
 from custom_components.securitas.verisure_owa_api.exceptions import (
     AuthenticationError,
-    VerisureOwaError,
     TwoFactorRequiredError,
+    VerisureOwaError,
 )
-
 from tests.conftest import (
     make_config_entry_data,
     make_installation,
     make_securitas_hub_mock,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helper: patch VerisureHub preserving __name__
@@ -1899,6 +1896,7 @@ class TestDiscoverCameras:
     async def test_exception_from_get_camera_devices_is_caught(self, caplog):
         """An exception in get_camera_devices must not propagate — log warning and continue."""
         import logging
+
         from custom_components.securitas import _discover_cameras
         from tests.conftest import make_installation
 
@@ -2032,6 +2030,7 @@ class TestAsyncDiscoverDevices:
         async def boom(*_args, **_kwargs):
             raise RuntimeError("discovery exploded")
 
+        # Whether or not the function re-raises, the event must be set.
         with (
             patch(
                 "custom_components.securitas.discovery._discover_cameras",
@@ -2041,12 +2040,9 @@ class TestAsyncDiscoverDevices:
                 "custom_components.securitas.discovery._discover_locks",
                 new=boom,
             ),
+            contextlib.suppress(RuntimeError),
         ):
-            # Whether or not the function re-raises, the event must be set.
-            try:
-                await _async_discover_devices(hass, entry)
-            except RuntimeError:
-                pass
+            await _async_discover_devices(hass, entry)
 
         assert event.is_set()
 
@@ -2062,7 +2058,7 @@ class TestStaticPathAliases:
     @pytest.fixture
     def mock_hub(self):
         """Create a mock VerisureHub for setup tests."""
-        from tests.conftest import make_securitas_hub_mock, make_installation
+        from tests.conftest import make_installation, make_securitas_hub_mock
 
         hub = make_securitas_hub_mock()
         hub.client.list_installations = AsyncMock(return_value=[make_installation()])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,12 +7,13 @@ runs (header construction, JSON parsing, error handling), unlike the unit tests
 which patch _execute_request directly.
 """
 
+import contextlib
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.securitas import DOMAIN, async_setup_entry, async_unload_entry
 from custom_components.securitas.verisure_owa_api.exceptions import (
@@ -32,14 +33,13 @@ from .mock_graphql import (
     graphql_installations,
     graphql_login,
     graphql_login_error,
-    graphql_services,
     graphql_sentinel,
+    graphql_services,
     make_doorlock_service,
     make_jwt,
     make_sentinel_service,
     queue_standard_setup,
 )
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -75,15 +75,17 @@ async def _setup(
     """
     entry = _make_entry(hass, **overrides)
     mock_http = server.make_http_client()
-    with patch(
-        "custom_components.securitas.async_get_clientsession",
-        return_value=mock_http,
-    ):
-        with patch(
+    with (
+        patch(
+            "custom_components.securitas.async_get_clientsession",
+            return_value=mock_http,
+        ),
+        patch(
             "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
-        ) as mock_fwd:
-            mock_fwd.return_value = True
-            result = await async_setup_entry(hass, entry)
+        ) as mock_fwd,
+    ):
+        mock_fwd.return_value = True
+        result = await async_setup_entry(hass, entry)
     _SETUP_ENTRIES.append((hass, entry))
     return entry, result
 
@@ -95,10 +97,8 @@ async def _unload_setup_entries():
     while _SETUP_ENTRIES:
         hass, entry = _SETUP_ENTRIES.pop()
         if hass.data.get(DOMAIN, {}).get(entry.entry_id) is not None:
-            try:
+            with contextlib.suppress(Exception):
                 await async_unload_entry(hass, entry)
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
 
 
 # ── Setup & entity creation ───────────────────────────────────────────────────
@@ -474,12 +474,14 @@ async def test_setup_connection_error_raises_not_ready(
         def post(self, url, **kwargs):
             raise ClientConnectorError(_conn_key, OSError("connection refused"))
 
-    with patch(
-        "custom_components.securitas.async_get_clientsession",
-        return_value=_FailPost(),
+    with (
+        patch(
+            "custom_components.securitas.async_get_clientsession",
+            return_value=_FailPost(),
+        ),
+        pytest.raises(ConfigEntryNotReady),
     ):
-        with pytest.raises(ConfigEntryNotReady):
-            await async_setup_entry(hass, entry)
+        await async_setup_entry(hass, entry)
 
 
 # ── Services create correct entities ─────────────────────────────────────────

--- a/tests/test_migrate_unique_ids.py
+++ b/tests/test_migrate_unique_ids.py
@@ -12,7 +12,6 @@ HACS upgraders don't see duplicated entities with ``_2`` suffixes.
 from __future__ import annotations
 
 import pytest
-
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,9 @@ from custom_components.securitas.verisure_owa_api.exceptions import (
     UnexpectedStateError,
 )
 from custom_components.securitas.verisure_owa_api.models import (
+    PROTO_TO_STATE,
+    STATE_TO_COMMAND,
+    STATE_TO_PROTO,
     ActivityCategory,
     ActivityEvent,
     ActivityException,
@@ -24,7 +27,6 @@ from custom_components.securitas.verisure_owa_api.models import (
     OperationStatus,
     OtpPhone,
     PerimeterMode,
-    PROTO_TO_STATE,
     ProtoCode,
     Sentinel,
     Service,
@@ -32,12 +34,9 @@ from custom_components.securitas.verisure_owa_api.models import (
     SmartLockMode,
     SmartLockModeStatus,
     SStatus,
-    STATE_TO_COMMAND,
-    STATE_TO_PROTO,
     ThumbnailResponse,
     parse_proto_code,
 )
-
 
 # ── Enums ─────────────────────────────────────────────────────────────────────
 

--- a/tests/test_orphan_directory_repair.py
+++ b/tests/test_orphan_directory_repair.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components.securitas import async_setup

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 from custom_components.securitas.verisure_owa_api.responses import (
     ActivityEnvelope,
     ArmStatusEnvelope,
@@ -16,7 +15,6 @@ from custom_components.securitas.verisure_owa_api.responses import (
     SmartlockConfigEnvelope,
     ThumbnailEnvelope,
 )
-
 
 # ── LoginEnvelope ─────────────────────────────────────────────────────────────
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,6 +5,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from custom_components.securitas.verisure_owa_api.exceptions import (
+    VerisureOwaError,
+)
 from custom_components.securitas.verisure_owa_api.models import (
     Attribute,
     Installation,
@@ -12,12 +15,8 @@ from custom_components.securitas.verisure_owa_api.models import (
     Service,
     SmartLockMode,
 )
-from custom_components.securitas.verisure_owa_api.exceptions import (
-    VerisureOwaError,
-)
 
 from .conftest import make_jwt
-
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why CI is about to break

The `lint` job installs ruff **unpinned** and runs a bare `ruff check` with **no rule set of its own**, so it follows ruff's *defaults*. **ruff 0.16.0** (released this week) expanded those defaults and began formatting Python fenced in Markdown — which reddens the job on an untouched tree:

| | ruff 0.15.22 | ruff 0.16.0 |
|---|---|---|
| `ruff check .` | clean | **291 findings** |
| `ruff format --check .` | clean | 1 file (a `docs/` snippet) |

None of that came from a code change — the last green run just predated 0.16.0.

## Pin the rules, not the version

Rather than pin `ruff==0.15.x` and freeze the linter, this pins the **rules**. `pyproject.toml` now declares an explicit `[tool.ruff.lint].select` — the same set the sibling integrations use — so the rules we enforce are stable across ruff releases while CI keeps installing the latest ruff:

```toml
[tool.ruff]
exclude = [".claude", "docs"]   # docs/ is prose; 0.16 began reformatting its snippets
target-version = "py313"

[tool.ruff.lint]
select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
ignore = ["E501"]               # line width is the formatter's job

[tool.ruff.lint.per-file-ignores]
"tests/**/*.py" = ["RUF012", "B017"]   # fixture mutables / blind-exception asserts are fine in tests
```

## The findings

Almost all mechanical, applied by ruff itself (`--fix`, then `--unsafe-fixes` per reviewed rule):

| Rule | n | Change |
|---|---|---|
| `I001` | 85 | import blocks sorted |
| `RUF100` | 63 | stale `# noqa` for rules we don't enforce removed |
| `UP037` | 17 | quoted annotations unquoted |
| `UP017` | 14 | `timezone.utc` → `UTC` |
| `UP041` | 8 | `asyncio.TimeoutError` → `TimeoutError` |
| `RUF003/002` | 7 | ambiguous `×` → `x` in comments/docstrings |
| `SIM105` | 4 | `try/except/pass` → `contextlib.suppress` |
| assorted | | `SIM108/118/300`, `RUF005/036` |

**Five hand-fixes** (ruff wouldn't autofix these):

- **`_auth.py` SIM102** — the `xSLoginToken` / `needDeviceAuthorization` guard, one nested `if` collapsed to a short-circuit `and`. The inner key is still only indexed when the outer is truthy → behaviour identical.
- **`test_architecture.py` SIM102** — same collapse.
- **`card_resources.py` + `test_integration.py` SIM105** — bare `try/except/pass` (carrying a `# pylint: disable=broad-exception-caught`) → `contextlib.suppress(Exception)`, dropping the now-needless pragma.
- **`test_init.py` SIM117** — a patch-`with` wrapping a suppress-`with` folded into one.

## Verification (ruff 0.16.0)

- `ruff check .` → **All checks passed!**
- `ruff format --check .` → 106 files already formatted
- `pyright custom_components/` → **0 errors**
- `pylint custom_components/securitas/` → **10.00/10**
- `pytest tests/` → **1685 passed**

No production behaviour changes.