### PR TITLE
fix: use via_device_id on HA 2026.8+, keep via_device for <2026.8

### DIFF
--- a/custom_components/securitas/button.py
+++ b/custom_components/securitas/button.py
@@ -130,7 +130,9 @@ class VerisureCaptureButton(VerisureEntity, ButtonEntity):
         self._attr_unique_id = (
             f"v4_securitas_direct.{installation.number}_capture_{camera_device.zone_id}"
         )
-        self._attr_device_info = camera_device_info(installation, camera_device)
+        self._attr_device_info = camera_device_info(
+            installation, camera_device, client.hass
+        )
 
     async def async_press(self) -> None:
         """Delegate to the camera entity's async_manual_capture."""

--- a/custom_components/securitas/camera.py
+++ b/custom_components/securitas/camera.py
@@ -97,7 +97,9 @@ class VerisureCamera(CoordinatorEntity[CameraCoordinator], Camera):
         )
         if self._mode == "full":
             self._attr_name = "Full Image"
-        self._attr_device_info = camera_device_info(installation, camera_device)
+        self._attr_device_info = camera_device_info(
+            installation, camera_device, hub.hass
+        )
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/custom_components/securitas/entity.py
+++ b/custom_components/securitas/entity.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -11,7 +13,44 @@ from . import DOMAIN
 from .verisure_owa_api.models import CameraDevice, Installation
 
 if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
     from .hub import VerisureHub
+    from .verisure_owa_api.models import SmartLock
+
+
+# `via_device` (the identifier-tuple form) is deprecated in HA 2026.8 and
+# removed in 2027.8; its replacement is `via_device_id`, the parent device's
+# registry id.  But `via_device_id` is only accepted by
+# `async_get_or_create` — into which HA unpacks DeviceInfo — from 2026.8 on;
+# on the older cores we still support (>= 2025.2) it raises TypeError.  Probe
+# the real signature so one build works on both: the kwargs that method
+# accepts are exactly what gates whether `via_device_id` is usable.
+_SUPPORTS_VIA_DEVICE_ID: bool = (
+    "via_device_id"
+    in inspect.signature(dr.DeviceRegistry.async_get_or_create).parameters
+)
+
+
+def _link_to_installation(
+    info: DeviceInfo, installation: Installation, hass: HomeAssistant | None
+) -> None:
+    """Point a child DeviceInfo at its installation parent, version-safely.
+
+    On HA >= 2026.8 the deprecated `via_device` identifier tuple is replaced
+    by `via_device_id`, resolved from the registry.  When the parent isn't
+    registered yet (e.g. first setup, before the installation device exists)
+    or no `hass` is available, we fall back to `via_device` so HA links the
+    child exactly as before — no behaviour change.  On older cores
+    `via_device_id` isn't accepted, so `via_device` is always used.
+    """
+    parent = (DOMAIN, f"v4_securitas_direct.{installation.number}")
+    if _SUPPORTS_VIA_DEVICE_ID and hass is not None:
+        device = dr.async_get(hass).async_get_device(identifiers={parent})
+        if device is not None:
+            info["via_device_id"] = device.id  # type: ignore[typeddict-unknown-key]
+            return
+    info["via_device"] = parent
 
 
 def securitas_device_info(installation: Installation) -> DeviceInfo:
@@ -26,10 +65,12 @@ def securitas_device_info(installation: Installation) -> DeviceInfo:
 
 
 def camera_device_info(
-    installation: Installation, camera_device: CameraDevice
+    installation: Installation,
+    camera_device: CameraDevice,
+    hass: HomeAssistant | None = None,
 ) -> DeviceInfo:
     """Build DeviceInfo for a per-camera child device."""
-    return DeviceInfo(
+    info = DeviceInfo(
         identifiers={
             (
                 DOMAIN,
@@ -39,8 +80,34 @@ def camera_device_info(
         name=camera_device.name,
         manufacturer="Verisure",
         model="Camera",
-        via_device=(DOMAIN, f"v4_securitas_direct.{installation.number}"),
     )
+    _link_to_installation(info, installation, hass)
+    return info
+
+
+def lock_device_info(
+    installation: Installation,
+    device_id: str,
+    name: str | None,
+    lock_config: SmartLock | None,
+    hass: HomeAssistant | None = None,
+) -> DeviceInfo:
+    """Build DeviceInfo for a per-lock child device linked to the installation."""
+    info = DeviceInfo(
+        identifiers={
+            (DOMAIN, f"v4_securitas_direct.{installation.number}_lock_{device_id}")
+        },
+        name=name,
+        manufacturer="Verisure",
+        model=lock_config.family if lock_config and lock_config.family else None,
+        serial_number=(
+            lock_config.serial_number
+            if lock_config and lock_config.serial_number
+            else None
+        ),
+    )
+    _link_to_installation(info, installation, hass)
+    return info
 
 
 class VerisureEntity(Entity):

--- a/custom_components/securitas/lock.py
+++ b/custom_components/securitas/lock.py
@@ -12,7 +12,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_CODE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -28,7 +27,7 @@ from .const import (
     CONF_LOCK_CODE_REQUIRED,
 )
 from .coordinators import LockCoordinator
-from .entity import VerisureEntity
+from .entity import VerisureEntity, lock_device_info
 from .pin_crypto import verify_pin
 from .verisure_owa_api import (
     Installation,
@@ -191,21 +190,10 @@ class VerisureLock(  # type: ignore[override]
             f"v4_securitas_direct.{installation.number}_lock_{device_id}"
         )
 
-        # Override device_info: each lock gets its own device, linked to
-        # the installation device via via_device.
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, f"v4_securitas_direct.{installation.number}_lock_{device_id}")
-            },
-            via_device=(DOMAIN, f"v4_securitas_direct.{installation.number}"),
-            name=name,
-            manufacturer="Verisure",
-            model=lock_config.family if lock_config and lock_config.family else None,
-            serial_number=(
-                lock_config.serial_number
-                if lock_config and lock_config.serial_number
-                else None
-            ),
+        # Override device_info: each lock gets its own device, linked to the
+        # installation device (via_device_id on HA >= 2026.8, else via_device).
+        self._attr_device_info = lock_device_info(
+            installation, device_id, name, lock_config, client.hass
         )
 
         # Reuse the alarm's local PIN to gate lock/unlock/open — opt-in via
@@ -251,18 +239,12 @@ class VerisureLock(  # type: ignore[override]
         self._lock_config = lock_config
         if lock_config.location:
             self._attr_name = lock_config.location
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (
-                    DOMAIN,
-                    f"v4_securitas_direct.{self._installation.number}_lock_{self._device_id}",
-                )
-            },
-            via_device=(DOMAIN, f"v4_securitas_direct.{self._installation.number}"),
-            name=self._attr_name,
-            manufacturer="Verisure",
-            model=lock_config.family or None,
-            serial_number=lock_config.serial_number or None,
+        self._attr_device_info = lock_device_info(
+            self._installation,
+            self._device_id,
+            self._attr_name,
+            lock_config,
+            self._client.hass,
         )
         self.async_write_ha_state()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,10 @@ def make_config_entry_data(
 def make_securitas_hub_mock(**overrides) -> MagicMock:
     """Create a MagicMock mimicking VerisureHub."""
     hub = MagicMock(spec=VerisureHub)
+    # spec=VerisureHub doesn't expose the instance attribute `hass`; None keeps
+    # device-info construction on the deterministic via_device fallback (no
+    # registry lookup) regardless of the installed HA version.
+    hub.hass = None
     hub.client = AsyncMock()
     hub.client.get_supported_commands = MagicMock(return_value=frozenset())
     hub.country = "ES"

--- a/tests/test_camera_platform.py
+++ b/tests/test_camera_platform.py
@@ -59,6 +59,9 @@ def camera_device():
 @pytest.fixture
 def mock_hub():
     hub = MagicMock()
+    # None keeps device-info construction on the deterministic via_device
+    # fallback (no registry lookup) regardless of the installed HA version.
+    hub.hass = None
     hub.camera_images = {}
     hub.get_camera_image = MagicMock(return_value=None)
     hub.is_capturing = MagicMock(return_value=False)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,5 +1,11 @@
 """Tests for the shared entity helpers in entity.py."""
 
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.securitas import DOMAIN
+from custom_components.securitas import entity as entity_mod
+from custom_components.securitas.entity import camera_device_info
 from custom_components.securitas.verisure_owa_api.models import (
     CameraDevice,
     Installation,
@@ -27,8 +33,18 @@ def _make_camera_device():
     )
 
 
+def _register_installation_device(hass) -> dr.DeviceEntry:
+    """Register the installation parent device in the real registry."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    return dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "v4_securitas_direct.100001")},
+        manufacturer="Verisure",
+    )
+
+
 def test_securitas_device_info_uses_v5_schema():
-    from custom_components.securitas import DOMAIN
     from custom_components.securitas.entity import securitas_device_info
 
     inst = _make_installation()
@@ -38,12 +54,45 @@ def test_securitas_device_info_uses_v5_schema():
 
 
 def test_camera_device_info_uses_v5_schema():
-    from custom_components.securitas import DOMAIN
-    from custom_components.securitas.entity import camera_device_info
-
     inst = _make_installation()
     cam = _make_camera_device()
     info = camera_device_info(inst, cam)
     assert (DOMAIN, "v4_securitas_direct.100001_camera_YR08") in info["identifiers"]
     assert info["via_device"] == (DOMAIN, "v4_securitas_direct.100001")
     assert info["manufacturer"] == "Verisure"
+
+
+def test_camera_device_info_uses_via_device_when_id_unsupported(monkeypatch):
+    """On HA < 2026.8 (no via_device_id), the parent link stays via_device."""
+    monkeypatch.setattr(entity_mod, "_SUPPORTS_VIA_DEVICE_ID", False)
+    info = camera_device_info(_make_installation(), _make_camera_device())
+    assert info["via_device"] == (DOMAIN, "v4_securitas_direct.100001")
+    assert "via_device_id" not in info
+
+
+async def test_camera_device_info_uses_via_device_id_when_supported(hass, monkeypatch):
+    """On HA >= 2026.8, link the child by the parent's registry id."""
+    monkeypatch.setattr(entity_mod, "_SUPPORTS_VIA_DEVICE_ID", True)
+    parent = _register_installation_device(hass)
+    # via_device_id isn't a defined DeviceInfo key before HA 2026.8; read the
+    # DeviceInfo as a plain dict so the assertion type-checks on any core.
+    info = dict(camera_device_info(_make_installation(), _make_camera_device(), hass))
+    assert info["via_device_id"] == parent.id
+    assert "via_device" not in info
+
+
+async def test_camera_device_info_falls_back_when_parent_missing(hass, monkeypatch):
+    """via_device_id supported but the parent isn't registered yet → keep
+    via_device so HA links it exactly as before (no first-setup regression)."""
+    monkeypatch.setattr(entity_mod, "_SUPPORTS_VIA_DEVICE_ID", True)
+    info = camera_device_info(_make_installation(), _make_camera_device(), hass)
+    assert info["via_device"] == (DOMAIN, "v4_securitas_direct.100001")
+    assert "via_device_id" not in info
+
+
+def test_camera_device_info_without_hass_uses_via_device(monkeypatch):
+    """No hass (can't resolve the registry) → keep via_device even on new HA."""
+    monkeypatch.setattr(entity_mod, "_SUPPORTS_VIA_DEVICE_ID", True)
+    info = camera_device_info(_make_installation(), _make_camera_device(), None)
+    assert info["via_device"] == (DOMAIN, "v4_securitas_direct.100001")
+    assert "via_device_id" not in info

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -6,9 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.securitas import DOMAIN, _build_config_dict
+from custom_components.securitas import entity as entity_mod
 from custom_components.securitas.api_queue import ApiQueue
 from custom_components.securitas.const import (
     CONF_CODE_HASH,
@@ -115,6 +117,7 @@ def make_lock(
     code: str | None = None,
     code_required: bool = False,
     config: dict | None = None,
+    registry_hass=None,
 ):
     """Create a VerisureLock with mocked dependencies.
 
@@ -131,10 +134,15 @@ def make_lock(
         config: Full ``client.config`` override, bypassing ``code``/
             ``code_required``. Use to drive the entity from a config dict
             built by production code.
+        registry_hass: Real ``hass`` to expose as ``client.hass`` so
+            device-info construction can resolve ``via_device_id`` from the
+            registry (HA >= 2026.8). Defaults to ``None`` — the deterministic
+            ``via_device`` fallback used by the schema tests.
     """
     installation = make_installation()
     code_hash, code_is_numeric = encode_pin(code)
     client = MagicMock()
+    client.hass = registry_hass
     client.config = config or {
         "scan_interval": 120,
         CONF_CODE_HASH: code_hash,
@@ -968,6 +976,47 @@ class TestVerisureLockV5Schema:
         info = lk._attr_device_info
         assert (DOMAIN, "v4_securitas_direct.123456_lock_02") in info["identifiers"]
         assert info["via_device"] == (DOMAIN, "v4_securitas_direct.123456")
+
+    async def test_device_info_uses_via_device_id_when_supported(
+        self, hass, monkeypatch
+    ):
+        """On HA >= 2026.8 the lock links to the installation by registry id."""
+        monkeypatch.setattr(entity_mod, "_SUPPORTS_VIA_DEVICE_ID", True)
+        entry = MockConfigEntry(domain=DOMAIN, data={})
+        entry.add_to_hass(hass)
+        parent = dr.async_get(hass).async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, "v4_securitas_direct.123456")},
+            manufacturer="Verisure",
+        )
+        lk = make_lock(device_id="01", registry_hass=hass)
+        # via_device_id isn't a defined DeviceInfo key before HA 2026.8; read
+        # the DeviceInfo as a plain dict so the assertion type-checks on any core.
+        info = dict(lk._attr_device_info or {})
+        assert info["via_device_id"] == parent.id
+        assert "via_device" not in info
+
+    async def test_update_lock_config_uses_via_device_id_when_supported(
+        self, hass, monkeypatch
+    ):
+        """update_lock_config takes the same via_device_id path on new HA."""
+        from custom_components.securitas.verisure_owa_api.models import SmartLock
+
+        monkeypatch.setattr(entity_mod, "_SUPPORTS_VIA_DEVICE_ID", True)
+        entry = MockConfigEntry(domain=DOMAIN, data={})
+        entry.add_to_hass(hass)
+        parent = dr.async_get(hass).async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, "v4_securitas_direct.123456")},
+            manufacturer="Verisure",
+        )
+        lk = make_lock(device_id="02", registry_hass=hass)
+        lk.update_lock_config(
+            SmartLock(location="Front", family="DANALOCK", serial_number="sn")
+        )
+        info = dict(lk._attr_device_info or {})
+        assert info["via_device_id"] == parent.id
+        assert "via_device" not in info
 
 
 class TestVerisureLockActions:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -24,6 +24,7 @@ EXPECTED_INTEGRATION_FILES = frozenset(
         "test_camera_platform.py",
         "test_config_flow.py",
         "test_coordinators.py",
+        "test_entity.py",
         "test_ha_platforms.py",
         "test_hub.py",
         "test_init.py",


### PR DESCRIPTION
## What & why

HA **2026.8** deprecates the `DeviceInfo["via_device"]` identifier tuple (and `DeviceRegistry.async_get_or_create(via_device=...)`), scheduling removal for **2027.8**, in favour of **`via_device_id`** — the parent device's registry id. Passing both raises `HomeAssistantError`. Source: [device-registry: single config entry per device](https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry).

We set `via_device=` in three places (installation → camera child, and the two lock DeviceInfo builders). This migrates them **while keeping BWC down to our minimum supported core, HA 2025.2** (`hacs.json`).

## The constraint

`via_device_id` is only accepted by `async_get_or_create` **from 2026.8 on**. On the cores we still support (2025.2–2026.7) passing it raises `TypeError`. So a single build must choose at runtime.

## Approach

- **Feature-detect** against the real `async_get_or_create` signature — the kwargs that method accepts are exactly what HA unpacks `DeviceInfo` into, so it's the precise gate (`_SUPPORTS_VIA_DEVICE_ID`).
- On **2026.8+**: resolve the installation device's registry id and set `via_device_id`.
- On **older cores**: keep `via_device`.
- **Graceful fallback**: if the parent device isn't registered yet (first setup, before the alarm-panel device exists) or no `hass` is available, fall back to `via_device` — HA links the child exactly as before. Strictly no worse than today. On every restart the parent device is already loaded from the registry, so the `via_device_id` path is taken.

DeviceInfo construction for child devices is centralised in `entity.py` (`camera_device_info` + new `lock_device_info`, both delegating to a shared `_link_to_installation`); the hub's `hass` is threaded through the camera, capture-button and lock call sites.

## Tests

- New tests exercise **both branches deterministically** via the feature flag plus a **real device registry** (camera + lock, `__init__` and `update_lock_config`), including the parent-missing and no-hass fallbacks.
- Existing schema tests keep asserting `via_device` on the fallback path; hub mocks now expose `hass=None` so that path is version-independent.
- Full suite green (1777 passed), Ruff + Pylint (10.00) + Pyright (0 errors) clean.

> Note: the 2026.8+ `via_device_id` path is unit-tested (feature flag + real registry) but can't be integration-tested end-to-end until 2026.8 is a public release; the feature detection guarantees we never pass `via_device_id` to a core that doesn't accept it.