### PR TITLE
chore: changelog for #542 and pre-bump to 5.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Most recent at the top.  For changes prior to v5, see [the GitHub release notes]
 
 ## v5.5.0
 
-The local alarm PIN can now guard your smart locks as well as the alarm panel — and it is stored hashed rather than in plain text.  Three fixes besides: a long-standing bug that silently discarded your PIN and alarm mappings shortly after a fresh install, an integration left permanently down by a network blip during Home Assistant startup, and camera capture delivering nothing for long-idle cameras.
+The local alarm PIN can now guard your smart locks as well as the alarm panel — and it is stored hashed rather than in plain text.  Four fixes besides: a long-standing bug that silently discarded your PIN and alarm mappings shortly after a fresh install, an integration left permanently down by a network blip during Home Assistant startup, camera capture delivering nothing for long-idle cameras, and forward compatibility with Home Assistant 2026.8's device-registry change.
 
 ### Added
 
@@ -22,6 +22,8 @@ The local alarm PIN can now guard your smart locks as well as the alarm panel �
 **A fresh install silently lost its PIN and alarm mappings minutes after setup ([#537](https://github.com/guerrerotook/securitas-direct-new-api/pull/537)).**  If you enabled any of the optional sub-panels (Interior, Perimeter, Annex) while first setting the integration up, your PIN, all five alarm-state mappings, the scan interval and the notify settings were quietly discarded on the first successful login — within minutes of finishing setup.  The visible symptoms were an alarm panel that had stopped asking for the PIN and accepted *any* code, and mapped buttons reverting to defaults.  Only installs that turned a sub-panel on during the initial wizard were affected; enabling one later, from the options dialog, was always safe.  The cause was that setup stores the sub-panel toggles separately from everything else, and the routine that keeps options and stored settings in step mistook that partial state for "the user has saved every setting", so it discarded the ones it could not see.  This bug predates the PIN work above — it is only now that its consequence was a disabled PIN rather than lost mappings.
 
 If you were affected, the settings are gone and cannot be recovered: open the integration options once, re-enter your PIN and mappings, and save.  From then on this cannot recur on that installation.
+
+**Forward compatibility with Home Assistant 2026.8's device-registry change ([#542](https://github.com/guerrerotook/securitas-direct-new-api/pull/542)).**  Home Assistant 2026.8 deprecates the `via_device` link this integration uses to nest each camera and smart lock under its alarm panel — removing it in 2027.8 — in favour of `via_device_id`.  The integration now feature-detects which one the running Home Assistant expects and uses it: `via_device_id` on 2026.8 and later, the original `via_device` on the cores it still supports back to 2025.2.  Child devices keep nesting under the panel exactly as before, with no deprecation warning on new Home Assistant and no break when the old link is removed.
 
 ### Security
 

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.5.0-rc1"
+    "version": "5.5.0"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.5.0-rc1";
-import "./verisure-owa-alarm-chip.js?v=5.5.0-rc1";
+import "./verisure-owa-alarm-card.js?v=5.5.0";
+import "./verisure-owa-alarm-chip.js?v=5.5.0";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.5.0-rc1";
+import "./verisure-owa-camera-card.js?v=5.5.0";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.5.0-rc1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.5.0";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,7 +21,7 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.5.0-rc1";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.5.0";
 import {
   _t,
   STATE_CFG,
@@ -37,7 +37,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.5.0-rc1";
+} from "./verisure-owa-alarm-shared.js?v=5.5.0";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -47,7 +47,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.5.0-rc1";
+} from "./verisure-owa-alarm-shared.js?v=5.5.0";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,7 +13,7 @@ import {
   defaultArmState,
   attachGesture,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.5.0-rc1";
+} from "./verisure-owa-alarm-shared.js?v=5.5.0";
 
 class VerisureOwaAlarmBadge extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,7 +8,7 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.5.0-rc1";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.5.0";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.5.0-rc1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.5.0";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Release-prep PR for the **v5.5.0 final** release.

Since `5.5.0-rc1` (#538) the only user-facing change to land on `main` is #542 (`via_device` → `via_device_id` device-registry migration for HA 2026.8+). This PR:

- Adds the **#542** entry to the `## v5.5.0` changelog section (in `### Fixed`), and updates the summary paragraph to "Four fixes besides".
- Bumps `manifest.json` `5.5.0-rc1` → `5.5.0`.
- Re-stamps every card `?v=` cache-bust token `5.5.0-rc1` → `5.5.0` (10 import specifiers across `www/*.js`).

With the manifest already at the target, the Release workflow's commit step will find no diff, skip the push to protected `main`, and just tag + release.

### Verification
- `tests/test_card_cache_busting.py` — pass (manifest ↔ token sync guard)
- `tests-js/integration/card-cache-busting.test.js` — pass
- Full JS suite: 401 passed; `npm run lint` clean; `ruff check`/`ruff format --check` clean
- Simulated the workflow's release-notes extraction for `5.5.0` locally — resolves the `## v5.5.0` section (24 lines, includes #542)

@guerrerotook this one needs your approval to merge before I can dispatch the Release workflow.