### PR TITLE
fix: map activity event 702 (partial-mode arm) so it isn't Unknown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
+## v5.7.0
+
+One fix: a partial-arming entry in the activity log that showed up as an unknown event now reads as an arm.
+
+### Fixed
+
+**A partial arm showed as "Unknown event" in the activity log ([#555](https://github.com/guerrerotook/securitas-direct-new-api/issues/555)).**  When the panel armed a partial mode it emitted event code `702`, which the integration did not recognise, so the activity log listed it as an *Unknown event* instead of an arm.  Code `702` is now mapped alongside the other arm signals, so a partial activation appears as an armed event — correctly grouped, iconed and coloured — like any other arm.  Thanks to [@philippemezzadri](https://github.com/philippemezzadri) for reporting it with the event details.
+
 ## v5.6.0
 
 One fix, for anyone whose alarm has been reset remotely by Securitas' monitoring centre: disarming from Home Assistant no longer fails afterwards with an "unknown state" error.

--- a/custom_components/securitas/verisure_owa_api/models/activity.py
+++ b/custom_components/securitas/verisure_owa_api/models/activity.py
@@ -93,6 +93,7 @@ _ACTIVITY_TYPE_TO_CATEGORY: dict[int, ActivityCategory] = {
     40: ActivityCategory.ARMED,  # Spanish panel: armed exterior ("Conexión modo exterior")
     46: ActivityCategory.ARMED,
     701: ActivityCategory.ARMED,
+    702: ActivityCategory.ARMED,  # partial-mode activation (70x arm series). GitHub #555
     721: ActivityCategory.ARMED,
     801: ActivityCategory.ARMED,  # "Attivazione modalità totale" — Italian interior total arm
     802: ActivityCategory.ARMED,  # "Attivazione modalità parziale" / "Connection Main partial"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1057,7 +1057,7 @@ class TestActivityEventCategory:
     def test_armed_codes(self):
         # Includes panel-emitted arm signals (802, 821, 823, 824) — the
         # "Connection ..." aliases are alarm-armed events, not network state.
-        for code in (2, 37, 40, 46, 701, 721, 802, 821, 823, 824):
+        for code in (2, 37, 40, 46, 701, 702, 721, 802, 821, 823, 824):
             assert self._ev(code).category == ActivityCategory.ARMED, code
 
     def test_disarmed_codes(self):
@@ -1146,6 +1146,13 @@ class TestActivityEventCategory:
         Routines are user-scheduled automations that can arm/disarm the alarm.
         Seen as "Routine exécutée". GitHub #513."""
         assert self._ev(70).category == ActivityCategory.ROUTINE_EXECUTED
+
+    def test_partial_mode_activation(self):
+        """702 is a partial-mode activation — the panel arming a partial mode.
+
+        Reported as an "Unknown event" until mapped; it belongs with the other
+        arm signals in the 70x series (701 armed / 700 disarmed). GitHub #555."""
+        assert self._ev(702).category == ActivityCategory.ARMED
 
     def test_unknown_codes(self):
         """Codes we haven't seen fall through to UNKNOWN — future-proofing."""


### PR DESCRIPTION
## What

Maps panel activity event code **702** (a partial-mode activation) to `ActivityCategory.ARMED`, so it renders as an arm in the activity log instead of an *Unknown event*.

Fixes #555.

## Why

Per the report in #555, the panel emits event type `702` when it arms a partial mode. The integration did not catalogue that code, so:

- the activity-log row showed as **"Unknown event"**, and
- being uncategorised, it also escaped the polled-echo dedup filter (which requires a known category).

`702` sits in the same `70x` arm/disarm series already handled (`701` armed / `700` disarmed) and is the direct analogue of the `802` "Attivazione modalità parziale" partial-arm code that's already mapped to `ARMED`.

## How

- `custom_components/securitas/verisure_owa_api/models/activity.py` — add `702 → ActivityCategory.ARMED` to `_ACTIVITY_TYPE_TO_CATEGORY`.

It reuses the existing `armed` category, so the frontend card icons/colours/labels it correctly with **no frontend change** and no new translation strings.

## Tests

TDD — added `TestActivityEventCategory::test_partial_mode_activation` (and `702` to `test_armed_codes`), watched them fail (`702 → unknown`), then added the mapping to go green.

Full suite green (`1798 passed`); Ruff / Pylint (10.00/10) / Pyright / `check_docs` all clean.

Thanks to @philippemezzadri for reporting it with the event screenshot.