### PR TITLE
docs: FAQ — why door/window contact states can't be exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,28 @@ chips:
 
 If your installation includes Sentinel devices, the integration automatically creates temperature, humidity, and air quality sensors for each one.
 
+## Door & Window Sensors
+
+**This integration can't expose your individual door and window contacts as `binary_sensor` entities, and the reason is the API, not the integration.** It's the single most-requested feature ([#440](https://github.com/guerrerotook/securitas-direct-new-api/issues/440), [#545](https://github.com/guerrerotook/securitas-direct-new-api/issues/545)), so here is the full picture.
+
+The Verisure OWA cloud API this integration talks to has no operation that returns each contact's open/closed state. The only place magnetic contacts show up at all is a list of **open or low-battery zones**, and the panel produces that list only when you **try to arm and a zone is in the way**. There is no "read all sensors" endpoint to poll, so there is nothing to build persistent contact entities from.
+
+Two community pull requests tried anyway ([#532](https://github.com/guerrerotook/securitas-direct-new-api/pull/532), [#544](https://github.com/guerrerotook/securitas-direct-new-api/pull/544)) and both had to be closed. The contacts could sometimes be _discovered_, but every request for their state was rejected by the server with _"Unauthorized request for current capabilities"_, and where entities did appear their state never changed. On every system tested so far, the **Verisure app itself doesn't show live contact state** either — which is the giveaway that the data isn't available to the web/API layer at all.
+
+### What you can see instead
+
+When arming is blocked by an open door or window, the open zones _are_ reported to you — as a notification, on the alarm card, and in the `zones` field of the [`verisure_owa_arming_exception` event](#the-verisure_owa_arming_exception-event) (see [Force Arming](#force-arming-advanced)). But that is a **snapshot taken at the moment you arm**, not a live state you can automate on (e.g. "warn me if a window has been open for 10 minutes").
+
+> [!NOTE]
+> The `door_opened` / `door_closed` events in the [activity log](#activity-log) are a **smart lock's** door opening and auto-locking again — not a door/window contact sensor.
+
+> [!NOTE]
+> Home Assistant's built-in **Verisure** integration _does_ show contact sensors, but it talks to a different Verisure backend (MyPages), not the OWA GraphQL API used here. Which backend your account can use depends on your country, so the two integrations aren't interchangeable — having contact sensors in one doesn't mean they can appear in the other.
+
+### If your app _does_ show live sensor state
+
+Then the request we'd need exists for your account, and a capture would be genuinely useful. Open and close a sensor while recording a [HAR file](#har-file-for-tricky-bugs) and attach it to [#545](https://github.com/guerrerotook/securitas-direct-new-api/issues/545) so the operation can be identified. One constraint any fix has to respect: continuous full-status polling was removed deliberately because it drains the sensors' batteries and trips Verisure's firewall — so a real solution can't rely on frequent refreshes.
+
 ## Smart Locks
 
 Smart door locks become lock entities you can operate from HA — multiple locks per installation, each with its own entity. If your lock supports latch hold-back, the entity also gets an **Open** action that unlatches the door without unlocking it.


### PR DESCRIPTION
## Summary

Reading individual door/window contact sensors is one of the most recurring requests — [#440](https://github.com/guerrerotook/securitas-direct-new-api/issues/440), [#545](https://github.com/guerrerotook/securitas-direct-new-api/issues/545), closed PRs [#532](https://github.com/guerrerotook/securitas-direct-new-api/pull/532) / [#544](https://github.com/guerrerotook/securitas-direct-new-api/pull/544), and most recently [discussion #560](https://github.com/guerrerotook/securitas-direct-new-api/discussions/560). This adds a canonical **Door & Window Sensors** section to the README (right after Sentinel Sensors) so the answer is discoverable and linkable instead of re-explained each time.

## What it says

- **The OWA cloud API exposes no per-contact open/closed state.** Magnetic contacts appear only as a list of *open or low-battery zones*, and only when an arm attempt is blocked — there's no "read all sensors" endpoint to poll, so no persistent `binary_sensor` entities can be built from it.
- **Why the two PR attempts were closed:** contacts could sometimes be discovered, but state requests were rejected with *"Unauthorized request for current capabilities"*, and where entities appeared their state never changed. On tested systems the Verisure app itself doesn't show live contact state either.
- **What you _can_ see:** open zones at arm time via the `verisure_owa_arming_exception` event / Force Arming flow (a snapshot, not automatable live state).
- **Clarifies two common confusions:** the `door_opened`/`door_closed` activity events are *smart-lock* door signals (not contacts), and the official HA **Verisure** integration shows contacts because it uses a different backend (MyPages), country-dependent.
- **How to help:** if an account's app _does_ show live state, capture a HAR on [#545](https://github.com/guerrerotook/securitas-direct-new-api/issues/545); notes that any fix must avoid the frequent full-status polling that drains sensor batteries and trips the WAF.

## Notes

- Docs-only change (README.md, +22 lines). No code, no tests affected.
- Emphasis/callout style matches the existing README (underscore emphasis; blank-line-separated GitHub alerts). The file has pre-existing Prettier table-padding warnings that are intentionally left untouched to avoid an unrelated whole-file reformat.