### PR TITLE
chore: pre-bump to 5.7.0-rc.1

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.7.0-beta.1"
+    "version": "5.7.0-rc.1"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.7.0-beta.1";
-import "./verisure-owa-alarm-chip.js?v=5.7.0-beta.1";
+import "./verisure-owa-alarm-card.js?v=5.7.0-rc.1";
+import "./verisure-owa-alarm-chip.js?v=5.7.0-rc.1";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.7.0-beta.1";
+import "./verisure-owa-camera-card.js?v=5.7.0-rc.1";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-beta.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,7 +21,7 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.7.0-beta.1";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
 import {
   _t,
   STATE_CFG,
@@ -37,7 +37,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0-beta.1";
+} from "./verisure-owa-alarm-shared.js?v=5.7.0-rc.1";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -47,7 +47,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0-beta.1";
+} from "./verisure-owa-alarm-shared.js?v=5.7.0-rc.1";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,7 +13,7 @@ import {
   defaultArmState,
   attachGesture,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0-beta.1";
+} from "./verisure-owa-alarm-shared.js?v=5.7.0-rc.1";
 
 class VerisureOwaAlarmBadge extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,7 +8,7 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-beta.1";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-beta.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

Pre-bump PR to promote the **5.7.0** pre-release from `beta.1` to **`rc.1`**. Opening it now so it can be reviewed/approved alongside #561 in one pass.

## What

- Bump `manifest.json` `version` `5.7.0-beta.1` → `5.7.0-rc.1`.
- Re-stamp every card `?v=` cache-bust token → `5.7.0-rc.1` (kept in sync with the manifest by `tests/test_card_cache_busting.py` and `tests-js/integration/card-cache-busting.test.js`).
- **No changelog change** — an rc suffix resolves to the same `## v5.7.0` release notes (the event-702 fix + the opt-in refresh-login diagnostics).

Pre-bumping here (rather than letting the Release workflow write the version) is required because the workflow's commit step cannot push a version bump to protected `main`; with the manifest already at the target, it finds no diff and just tags.

## After merge

Dispatch the Release workflow with `version=5.7.0-rc.1` and `prerelease=true`. The roll-forward-to-next-minor step is gated to final releases only, so the pre-release run goes fully green.

## Verification

- Python + JS cache-busting guards pass locally; `check_docs` ok.
- Simulated the workflow's release-notes extraction against `## v5.7.0` — resolves and is non-empty.
- Pre-push suite green.