### PR TITLE
chore: bump to 5.7.0 for release

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.7.0-rc.1"
+    "version": "5.7.0"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.7.0-rc.1";
-import "./verisure-owa-alarm-chip.js?v=5.7.0-rc.1";
+import "./verisure-owa-alarm-card.js?v=5.7.0";
+import "./verisure-owa-alarm-chip.js?v=5.7.0";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.7.0-rc.1";
+import "./verisure-owa-camera-card.js?v=5.7.0";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,7 +21,7 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.7.0";
 import {
   _t,
   STATE_CFG,
@@ -37,7 +37,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0-rc.1";
+} from "./verisure-owa-alarm-shared.js?v=5.7.0";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -47,7 +47,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0-rc.1";
+} from "./verisure-owa-alarm-shared.js?v=5.7.0";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,7 +13,7 @@ import {
   defaultArmState,
   attachGesture,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0-rc.1";
+} from "./verisure-owa-alarm-shared.js?v=5.7.0";
 
 class VerisureOwaAlarmBadge extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,7 +8,7 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0-rc.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Final-release pre-bump for **5.7.0**, the last step before dispatching the Release workflow.

- `manifest.json` version `5.7.0-rc.1` → `5.7.0`
- Card cache-bust tokens `?v=5.7.0-rc.1` → `?v=5.7.0` across `custom_components/securitas/www/*.js`

The `## v5.7.0` changelog section is already complete (landed with #556 and #562) and becomes the GitHub release notes verbatim. Its two fixes:

- Refresh-login crash on every restart left some accounts stuck ([#557](https://github.com/guerrerotook/securitas-direct-new-api/issues/557))
- A partial arm showed as "Unknown event" in the activity log ([#555](https://github.com/guerrerotook/securitas-direct-new-api/issues/555))

Once merged I'll dispatch `release.yaml` with `version=5.7.0`, then open the follow-up dev-bump PR to 5.8.0.

### Verified locally
- `tests/test_card_cache_busting.py` ✅ and `tests-js/integration/card-cache-busting.test.js` ✅ (manifest ↔ card tokens in sync)
- Full JS suite (401 tests) ✅, ESLint + Prettier ✅, ruff check/format ✅