### PR TITLE
chore: bump version to 5.8.0 for development

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.7.0"
+    "version": "5.8.0"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.7.0";
-import "./verisure-owa-alarm-chip.js?v=5.7.0";
+import "./verisure-owa-alarm-card.js?v=5.8.0";
+import "./verisure-owa-alarm-chip.js?v=5.8.0";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.7.0";
+import "./verisure-owa-camera-card.js?v=5.8.0";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,7 +21,7 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.7.0";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0";
 import {
   _t,
   STATE_CFG,
@@ -37,7 +37,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -47,7 +47,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,7 +13,7 @@ import {
   defaultArmState,
   attachGesture,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.7.0";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 class VerisureOwaAlarmBadge extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,7 +8,7 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.7.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Post-release development bump to **5.8.0**, opened alongside the 5.7.0 release PR (#564) so both can be approved together.

- `manifest.json` version → `5.8.0`
- Card cache-bust tokens `?v=…` → `?v=5.8.0` across `custom_components/securitas/www/*.js`

This is the follow-up that the Release workflow's "roll branch forward to next minor" step would normally do, but can't (it pushes to protected `main`).

### ⚠️ Merge order (I'll handle the merging)
This must land **after** the 5.7.0 release is cut, in this sequence:

1. Merge #564 (`main` → 5.7.0)
2. Dispatch `release.yaml` with `version=5.7.0` (tags `v5.7.0` + creates the release)
3. Rebase this branch onto the updated `main`, then merge it (`main` → 5.8.0)

Because both PRs touch the same manifest/card lines, this branch will need a trivial rebase onto `main` after #564 merges (resolution: keep 5.8.0). Approval now is all that's needed from your side.

### Verified locally
- `tests/test_card_cache_busting.py` ✅ and `tests-js/integration/card-cache-busting.test.js` ✅ (manifest ↔ card tokens in sync)