### PR TITLE
fix: recover from a permanently-rejected refresh token via reauth (#568)

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -573,7 +573,7 @@ async def _get_or_create_session(
                     raise ConfigEntryAuthFailed(
                         "The stored refresh token is no longer valid — "
                         "please reauthenticate."
-                    ) from None
+                    ) from err
                 raise ConfigEntryNotReady(
                     f"Unable to connect to Verisure: {err.message}"
                 ) from None

--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -136,8 +136,21 @@ from .verisure_owa_api import (
     generate_device_id,
     generate_uuid,
 )
+from .verisure_owa_api.exceptions import is_refresh_token_crash
 
 _LOGGER = logging.getLogger(__name__)
+
+# A stale on-disk refresh token makes xSRefreshLogin crash on every setup
+# attempt (issue #557/#568). The crash is transient-by-classification, so setup
+# retries forever and never prompts reauth -- historically the user had to
+# delete and re-add the integration. After a sustained, unbroken run of this
+# *specific* crash we escalate to ConfigEntryAuthFailed so HA offers its
+# Reauthenticate flow (a password login mints a fresh, working token). Both a
+# count and a duration must be crossed so a brief server-side wobble -- which
+# clears well within them -- is ridden out rather than forcing a needless
+# reauth; only a genuinely dead token persists past both.
+_REFRESH_CRASH_REAUTH_MIN_COUNT = 3
+_REFRESH_CRASH_REAUTH_MIN_DURATION = timedelta(minutes=30)
 
 # Inert: this integration is config-entry only and ``async_setup`` ignores the
 # YAML config entirely. The schema exists so a legacy ``securitas:`` block from
@@ -453,6 +466,41 @@ def _build_config_dict(entry: ConfigEntry) -> tuple[dict[str, Any], bool]:
     return config, need_sign_in
 
 
+def _note_refresh_token_crash(hass: HomeAssistant, username: str) -> bool:
+    """Record a setup-path xSRefreshLogin crash; return True once it's sustained.
+
+    Tracks consecutive crashes per username across ``ConfigEntryNotReady``
+    setup retries (the state lives in ``hass.data[DOMAIN]``, which survives
+    those retries within an HA run). Returns True only when the streak has
+    crossed BOTH ``_REFRESH_CRASH_REAUTH_MIN_COUNT`` and
+    ``_REFRESH_CRASH_REAUTH_MIN_DURATION`` -- the signal that the on-disk
+    refresh token is genuinely dead and a reauth prompt is warranted.
+    """
+    tracker = hass.data[DOMAIN].setdefault("refresh_crash_tracker", {})
+    now = time.monotonic()
+    record = tracker.get(username)
+    if record is None:
+        record = {"count": 0, "first_seen": now}
+        tracker[username] = record
+    record["count"] += 1
+    return (
+        record["count"] >= _REFRESH_CRASH_REAUTH_MIN_COUNT
+        and now - record["first_seen"]
+        >= _REFRESH_CRASH_REAUTH_MIN_DURATION.total_seconds()
+    )
+
+
+def _clear_refresh_token_crash(hass: HomeAssistant, username: str) -> None:
+    """Forget any recorded crash streak -- the token authenticated successfully.
+
+    Resets both the count and the first-seen timestamp so a later, unrelated
+    crash starts a fresh grace window instead of escalating immediately.
+    """
+    tracker = hass.data.get(DOMAIN, {}).get("refresh_crash_tracker")
+    if tracker:
+        tracker.pop(username, None)
+
+
 async def _get_or_create_session(
     hass: HomeAssistant, config: dict[str, Any], entry: ConfigEntry
 ) -> VerisureHub:
@@ -507,11 +555,34 @@ async def _get_or_create_session(
                     "Unable to connect to Verisure: %s",
                     err.log_detail(),
                 )
+                # A stale on-disk refresh token makes xSRefreshLogin crash on
+                # every setup; the crash is transient-by-classification, so
+                # retrying forever never recovers (issue #557/#568). Once the
+                # crash has persisted long enough to rule out a server wobble,
+                # escalate to a reauth prompt so a password login can mint a
+                # fresh token, instead of looping until the user deletes and
+                # re-adds the integration.
+                if is_refresh_token_crash(err) and _note_refresh_token_crash(
+                    hass, username
+                ):
+                    _LOGGER.error(
+                        "Verisure refresh token appears permanently rejected "
+                        "(xSRefreshLogin keeps crashing); prompting for "
+                        "re-authentication."
+                    )
+                    raise ConfigEntryAuthFailed(
+                        "The stored refresh token is no longer valid — "
+                        "please reauthenticate."
+                    ) from None
                 raise ConfigEntryNotReady(
                     f"Unable to connect to Verisure: {err.message}"
                 ) from None
             sessions[username] = {"hub": client, "ref_count": 1}
 
+    # Reaching here means authentication succeeded (a reused healthy session or
+    # a fresh login), so any recorded dead-token crash streak is stale — clear
+    # it to restore a full grace window before the next possible escalation.
+    _clear_refresh_token_crash(hass, username)
     return client
 
 

--- a/custom_components/securitas/verisure_owa_api/exceptions.py
+++ b/custom_components/securitas/verisure_owa_api/exceptions.py
@@ -182,11 +182,12 @@ def is_refresh_token_crash(err: VerisureOwaError) -> bool:
     operation *path*, not the text.
 
     This is deliberately narrower than ``is_genuine_auth_failure`` returning
-    False: it isolates *this specific* crash (an uncoded null-data error on the
-    RefreshLogin resolver) from generic transient errors (5xx, WAF, network) so
-    a *persistent* occurrence on the setup path can be escalated to a reauth
-    prompt, while everything else keeps retrying. It excludes coded rejections
-    (err 60052 / 60067), which ``is_genuine_auth_failure`` already handles.
+    False: it isolates *this specific* crash (an uncoded error rooted at the
+    RefreshLogin resolver that returned a null result) from generic transient
+    errors (5xx, WAF, network) so a *persistent* occurrence on the setup path
+    can be escalated to a reauth prompt, while everything else keeps retrying.
+    It excludes coded rejections (err 60052 / 60067), which
+    ``is_genuine_auth_failure`` already handles.
     """
     body = err.response_body
     if not isinstance(body, dict):
@@ -196,5 +197,13 @@ def is_refresh_token_crash(err: VerisureOwaError) -> bool:
     errors = body.get("errors")
     if not (isinstance(errors, list) and errors and isinstance(errors[0], dict)):
         return False
+    # The errored path must be *rooted* at the operation, not merely mention it.
     path = errors[0].get("path")
-    return isinstance(path, list) and "xSRefreshLogin" in path
+    if not (isinstance(path, list) and path and path[0] == "xSRefreshLogin"):
+        return False
+    # ...and the resolver crashed, i.e. it returned a null result for that field
+    # (top-level ``data`` is either null or carries ``xSRefreshLogin: None``).
+    data = body.get("data")
+    if data is None:
+        return True
+    return isinstance(data, dict) and data.get("xSRefreshLogin", True) is None

--- a/custom_components/securitas/verisure_owa_api/exceptions.py
+++ b/custom_components/securitas/verisure_owa_api/exceptions.py
@@ -170,3 +170,31 @@ def is_genuine_auth_failure(err: VerisureOwaError) -> bool:
     if isinstance(err, (AuthenticationError, TwoFactorRequiredError)):
         return True
     return _error_code(err) in _GENUINE_AUTH_ERROR_CODES
+
+
+def is_refresh_token_crash(err: VerisureOwaError) -> bool:
+    """True for the xSRefreshLogin server crash that signals a dead refresh token.
+
+    The OWA backend's ``xSRefreshLogin`` resolver throws a JS ``TypeError`` and
+    returns a null field when handed a stale/invalidated refresh token (issue
+    #557 / #568 -- e.g. "Cannot read properties of undefined (reading 'fr')").
+    The locale word in the message varies by account, so this matches on the
+    operation *path*, not the text.
+
+    This is deliberately narrower than ``is_genuine_auth_failure`` returning
+    False: it isolates *this specific* crash (an uncoded null-data error on the
+    RefreshLogin resolver) from generic transient errors (5xx, WAF, network) so
+    a *persistent* occurrence on the setup path can be escalated to a reauth
+    prompt, while everything else keeps retrying. It excludes coded rejections
+    (err 60052 / 60067), which ``is_genuine_auth_failure`` already handles.
+    """
+    body = err.response_body
+    if not isinstance(body, dict):
+        return False
+    if _error_code_from_body(body) is not None:
+        return False
+    errors = body.get("errors")
+    if not (isinstance(errors, list) and errors and isinstance(errors[0], dict)):
+        return False
+    path = errors[0].get("path")
+    return isinstance(path, list) and "xSRefreshLogin" in path

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2732,6 +2732,8 @@ class TestSetupRefreshTokenCrashEscalation:
                 hass, entry, crashing_hub, mono, _DURATION_S + 1
             )
         assert isinstance(escalated, ConfigEntryAuthFailed)
+        # The originating crash is preserved as the cause, for diagnostics.
+        assert isinstance(escalated.__cause__, VerisureOwaError)
 
     async def test_count_reached_but_too_brief_keeps_retrying(self, hass, crashing_hub):
         """A burst of crashes with no time elapsed must not force reauth."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.securitas import (
     _OPTIONS_MANAGED_FIELDS,
+    _REFRESH_CRASH_REAUTH_MIN_COUNT,
+    _REFRESH_CRASH_REAUTH_MIN_DURATION,
     CONF_CODE_ARM_REQUIRED,
     CONF_CODE_HASH,
     CONF_CODE_IS_NUMERIC,
@@ -41,6 +43,8 @@ from custom_components.securitas import (
     VerisureDevice,
     VerisureHub,
     _build_config_dict,
+    _clear_refresh_token_crash,
+    _note_refresh_token_crash,
     _options_are_authoritative,
     _synced_entry_data,
     add_device_information,
@@ -2653,3 +2657,149 @@ class TestServiceDescriptionTargets:
                         f"of strings so it survives async_set_service_schema's "
                         f"unvalidated copy; got {domain!r}"
                     )
+
+
+# ===========================================================================
+# N. Setup-path escalation of a persistent dead-token xSRefreshLogin crash
+# ===========================================================================
+
+
+_DURATION_S = int(_REFRESH_CRASH_REAUTH_MIN_DURATION.total_seconds())
+
+
+def _fr_crash_error() -> VerisureOwaError:
+    """The exact issue #557 xSRefreshLogin dead-token crash, as raised on setup."""
+    err = VerisureOwaError(
+        "xSRefreshLogin failed: Cannot read properties of undefined (reading 'fr')"
+    )
+    err.response_body = {
+        "errors": [
+            {
+                "message": "Cannot read properties of undefined (reading 'fr')",
+                "path": ["xSRefreshLogin"],
+                "extensions": {},
+                "data": {},
+            }
+        ],
+        "data": {"xSRefreshLogin": None},
+    }
+    return err
+
+
+class TestSetupRefreshTokenCrashEscalation:
+    """A stale on-disk refresh token crashes xSRefreshLogin on every setup.
+
+    The crash is classified transient, so setup retries forever and the user is
+    never prompted to reauthenticate -- issue #557/#568, where the only escape
+    was deleting and re-adding the integration. Once the crash has *persisted*
+    (both a minimum count AND a minimum elapsed time, so a brief server wobble is
+    ridden out) setup escalates to ConfigEntryAuthFailed, which drives HA's
+    Reauthenticate flow (a fresh password login mints a working token).
+    """
+
+    @pytest.fixture
+    def crashing_hub(self):
+        hub = make_securitas_hub_mock()
+        hub.login = AsyncMock(side_effect=_fr_crash_error())
+        return hub
+
+    async def _attempt(self, hass, entry, hub, mono, at):
+        """Run one async_setup_entry at monotonic time *at*; return what it raised."""
+        mono.return_value = at
+        with (
+            _patch_hub(hub),
+            patch("custom_components.securitas.async_get_clientsession"),
+            patch.object(
+                hass.config_entries,
+                "async_forward_entry_setups",
+                new_callable=AsyncMock,
+            ),
+        ):
+            try:
+                return await async_setup_entry(hass, entry)
+            except (ConfigEntryNotReady, ConfigEntryAuthFailed) as err:
+                return err
+
+    async def test_sustained_crash_escalates_to_reauth(self, hass, crashing_hub):
+        """After the count and duration thresholds are both crossed -> reauth."""
+        entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
+        entry.add_to_hass(hass)
+        with patch("custom_components.securitas.time.monotonic") as mono:
+            for _ in range(_REFRESH_CRASH_REAUTH_MIN_COUNT - 1):
+                early = await self._attempt(hass, entry, crashing_hub, mono, 0)
+                assert isinstance(early, ConfigEntryNotReady)
+            escalated = await self._attempt(
+                hass, entry, crashing_hub, mono, _DURATION_S + 1
+            )
+        assert isinstance(escalated, ConfigEntryAuthFailed)
+
+    async def test_count_reached_but_too_brief_keeps_retrying(self, hass, crashing_hub):
+        """A burst of crashes with no time elapsed must not force reauth."""
+        entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
+        entry.add_to_hass(hass)
+        with patch("custom_components.securitas.time.monotonic") as mono:
+            results = [
+                await self._attempt(hass, entry, crashing_hub, mono, 0)
+                for _ in range(_REFRESH_CRASH_REAUTH_MIN_COUNT + 2)
+            ]
+        assert all(isinstance(r, ConfigEntryNotReady) for r in results)
+
+    async def test_duration_passed_but_too_few_keeps_retrying(self, hass, crashing_hub):
+        """One crash, even long after the first, is too few to force reauth."""
+        entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
+        entry.add_to_hass(hass)
+        with patch("custom_components.securitas.time.monotonic") as mono:
+            first = await self._attempt(hass, entry, crashing_hub, mono, 0)
+            second = await self._attempt(
+                hass, entry, crashing_hub, mono, _DURATION_S + 1
+            )
+        assert isinstance(first, ConfigEntryNotReady)
+        assert isinstance(second, ConfigEntryNotReady)
+
+    async def test_generic_transient_error_never_escalates(self, hass, crashing_hub):
+        """A non-crash transient error (5xx/WAF/network) keeps retrying forever.
+
+        Only the specific dead-token crash fingerprint may escalate; a plain
+        VerisureOwaError with no crash body must stay ConfigEntryNotReady no
+        matter how long it persists.
+        """
+        crashing_hub.login = AsyncMock(
+            side_effect=VerisureOwaError("connection failed")
+        )
+        entry = MockConfigEntry(domain=DOMAIN, data=make_config_entry_data())
+        entry.add_to_hass(hass)
+        with patch("custom_components.securitas.time.monotonic") as mono:
+            results = [
+                await self._attempt(
+                    hass, entry, crashing_hub, mono, i * (_DURATION_S + 1)
+                )
+                for i in range(_REFRESH_CRASH_REAUTH_MIN_COUNT + 1)
+            ]
+        assert all(isinstance(r, ConfigEntryNotReady) for r in results)
+
+
+class TestRefreshCrashTracker:
+    """The per-username crash streak that gates setup-path reauth escalation."""
+
+    def _hass(self):
+        h = MagicMock()
+        h.data = {DOMAIN: {}}
+        return h
+
+    def test_streak_clears_so_a_later_crash_gets_a_fresh_grace_window(self):
+        """A successful setup clears the streak: a later lone crash is not enough.
+
+        Clearing must reset both the count and the first-seen timestamp, so a
+        single new crash long afterwards does not immediately re-escalate.
+        """
+        hass = self._hass()
+        with patch("custom_components.securitas.time.monotonic", return_value=0):
+            for _ in range(_REFRESH_CRASH_REAUTH_MIN_COUNT):
+                _note_refresh_token_crash(hass, "user@example.com")
+        _clear_refresh_token_crash(hass, "user@example.com")
+        with patch(
+            "custom_components.securitas.time.monotonic",
+            return_value=_DURATION_S * 10,
+        ):
+            escalate = _note_refresh_token_crash(hass, "user@example.com")
+        assert escalate is False

--- a/tests/test_refresh_crash_behaviour.py
+++ b/tests/test_refresh_crash_behaviour.py
@@ -173,3 +173,25 @@ class TestIsRefreshTokenCrash:
             "data": {"xSSomethingElse": None},
         }
         assert is_refresh_token_crash(self._err(body)) is False
+
+    def test_ignores_an_uncoded_error_with_a_non_null_result(self) -> None:
+        """Only the *null-result* resolver crash counts, not any uncoded error.
+
+        An uncoded GraphQL error that still returned a real xSRefreshLogin
+        payload is not the dead-token crash and must not trigger reauth.
+        """
+        body = {
+            "errors": [{"message": "partial", "path": ["xSRefreshLogin"], "data": {}}],
+            "data": {"xSRefreshLogin": {"res": "OK"}},
+        }
+        assert is_refresh_token_crash(self._err(body)) is False
+
+    def test_ignores_an_error_not_rooted_at_the_operation(self) -> None:
+        """The errored path must be rooted at xSRefreshLogin, not merely mention it."""
+        body = {
+            "errors": [
+                {"message": "boom", "path": ["other", "xSRefreshLogin"], "data": {}}
+            ],
+            "data": {"other": None},
+        }
+        assert is_refresh_token_crash(self._err(body)) is False

--- a/tests/test_refresh_crash_behaviour.py
+++ b/tests/test_refresh_crash_behaviour.py
@@ -18,6 +18,7 @@ from custom_components.securitas.verisure_owa_api.client import VerisureOwaClien
 from custom_components.securitas.verisure_owa_api.exceptions import (
     VerisureOwaError,
     is_genuine_auth_failure,
+    is_refresh_token_crash,
 )
 
 # The exact server crash from issue #557: xSRefreshLogin resolver throws a
@@ -88,3 +89,87 @@ class TestRefreshCrashHandling:
             await client.refresh_token()
 
         assert is_genuine_auth_failure(excinfo.value) is False
+
+    async def test_crash_is_recognised_as_a_refresh_token_crash(
+        self, mock_transport
+    ) -> None:
+        """End-to-end: the *real* error object matches the dead-token fingerprint.
+
+        Guards the seam between where the client raises the crash (its
+        ``response_body`` must carry the ``xSRefreshLogin`` path) and the
+        ``is_refresh_token_crash`` fingerprint the setup path escalates on.
+        """
+        mock_transport.execute.return_value = FR_CRASH_RESPONSE
+        client = _make_client(mock_transport, refresh_token="on-disk-refresh-token")
+
+        with pytest.raises(VerisureOwaError) as excinfo:
+            await client.refresh_token()
+
+        assert is_refresh_token_crash(excinfo.value) is True
+
+
+# The same resolver crash localised to a different language — the null field is
+# read via the account's locale, so the message word after "reading" varies.
+ES_CRASH_RESPONSE = {
+    "errors": [
+        {
+            "message": "Cannot read properties of undefined (reading 'es')",
+            "path": ["xSRefreshLogin"],
+            "locations": [{"line": 2, "column": 3}],
+            "extensions": {},
+            "data": {},
+        }
+    ],
+    "data": {"xSRefreshLogin": None},
+}
+
+# A genuine, coded refresh rejection (err 60067 "Invalid Session") — a real
+# reauth signal handled by is_genuine_auth_failure, NOT the uncoded crash.
+CODED_REJECTION_RESPONSE = {
+    "errors": [
+        {
+            "message": "Invalid Session",
+            "path": ["xSRefreshLogin"],
+            "data": {"err": "60067"},
+        }
+    ],
+    "data": {"xSRefreshLogin": None},
+}
+
+
+class TestIsRefreshTokenCrash:
+    """``is_refresh_token_crash`` fingerprints the dead-token xSRefreshLogin crash.
+
+    It identifies the *specific* server crash that signals a stale on-disk
+    refresh token (so the setup path can escalate a persistent one to reauth),
+    while excluding coded rejections (handled elsewhere) and generic transient
+    errors (5xx/WAF/network) that must keep retrying.
+    """
+
+    def _err(self, body: object) -> VerisureOwaError:
+        err = VerisureOwaError("xSRefreshLogin failed")
+        err.response_body = body
+        return err
+
+    def test_matches_the_fr_crash(self) -> None:
+        assert is_refresh_token_crash(self._err(FR_CRASH_RESPONSE)) is True
+
+    def test_matches_the_same_crash_in_another_locale(self) -> None:
+        """Matching is on the operation path, not the locale word in the message."""
+        assert is_refresh_token_crash(self._err(ES_CRASH_RESPONSE)) is True
+
+    def test_ignores_a_coded_rejection(self) -> None:
+        """A real err-coded rejection is a genuine auth failure, not this crash."""
+        assert is_refresh_token_crash(self._err(CODED_REJECTION_RESPONSE)) is False
+
+    def test_ignores_an_error_with_no_response_body(self) -> None:
+        """Network/timeout errors carry no GraphQL body and must not match."""
+        assert is_refresh_token_crash(VerisureOwaError("connection failed")) is False
+
+    def test_ignores_a_crash_in_a_different_operation(self) -> None:
+        """A null-data error on some other resolver is not the refresh crash."""
+        body = {
+            "errors": [{"message": "boom", "path": ["xSSomethingElse"], "data": {}}],
+            "data": {"xSSomethingElse": None},
+        }
+        assert is_refresh_token_crash(self._err(body)) is False


### PR DESCRIPTION
Fixes #568 (follow-up to #557).

## The problem

@amullr is still hitting the `xSRefreshLogin failed: Cannot read properties of undefined (reading 'fr')` crash on **v5.7.0** (340 occurrences, having to reconfigure each time), even though #562 shipped in that release.

The crash happens on the **setup path** ([`__init__.py` `_get_or_create_session`](../blob/main/custom_components/securitas/__init__.py)): a fresh hub calls `hub.login()`, which tries `xSRefreshLogin` with the stored refresh token; the OWA backend's resolver throws a JS `TypeError` and returns null data. That error is (correctly) classified **transient** by `is_genuine_auth_failure` — a server wobble must not force a reauth on a refresh-token-only account — so setup raises `ConfigEntryNotReady` and **retries forever with the same doomed token**. There is no recovery: the user must delete and re-add the integration.

#562 closed *one* cause of the token going stale (the detached config-flow hub dropping rotations). But it never addressed the **"no recovery once stale"** trap, and other staleness routes remain.

## On the "not flushed to disk in time" theory

I checked HA's storage layer to test the flush-timing hypothesis rather than assume it. `async_update_entry` schedules a debounced (`SAVE_DELAY = 1s`) save, **but** `Store.async_delay_save` also registers an `EVENT_HOMEASSISTANT_FINAL_WRITE` listener that writes pending data during shutdown ([`helpers/storage.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/storage.py)). So a **clean** restart (including a normal Supervisor/HAOS reboot, which SIGTERMs core for a graceful stop) flushes a just-rotated token — it is **not** lost. The token is only lost on an **unclean kill** (SIGKILL, power loss, OOM), which no in-process "flush on stop" listener can catch either. A shutdown-flush would therefore be redundant.

So rather than chase the flush window, this PR fixes the thing that actually keeps users broken regardless of *how* the token died: **the missing recovery path.**

## The fix

When the **specific** dead-token crash persists on the setup path, escalate to `ConfigEntryAuthFailed` so HA surfaces its **Reauthenticate** flow (a password login via `mkLoginToken` — a different, non-crashing resolver — mints a fresh token). Escalation requires an unbroken run past **both** a count and a duration threshold, so a brief server-side wobble is ridden out; only a genuinely dead token persists past both. This keeps the deliberate "don't reauth on a transient wobble" stance while closing the "loop forever" hole.

- **`is_refresh_token_crash()`** — fingerprints the crash by GraphQL operation *path* (locale-independent, so it catches the `'es'`/`'fr'`/… variants), excluding coded rejections (`60052`/`60067`, already handled by `is_genuine_auth_failure`) and generic transient errors (5xx/WAF/network). Only a genuinely dead token can escalate.
- **Per-username crash tracker** in `hass.data[DOMAIN]` survives `ConfigEntryNotReady` setup retries within an HA run; cleared on any successful auth to restore the full grace window.
- Thresholds: `_REFRESH_CRASH_REAUTH_MIN_COUNT = 3`, `_REFRESH_CRASH_REAUTH_MIN_DURATION = 30 min` (generous; easy to tune).

### Scoping
Deliberately **setup-path only**. The steady-state in-memory token is normally fresh, so a persistent crash there is more likely a server outage — escalating it would risk a false reauth. Setup is where the disk token is loaded and where a genuinely dead token produces an unambiguous signal (and where amullr's error is logged).

## Tests
- `is_refresh_token_crash` fingerprint: FR crash, another-locale variant, coded rejection, no-body error, different-operation crash, **and an end-to-end check that the real client's crash error matches the fingerprint**.
- Setup escalation: sustained crash → reauth; count-met-but-too-brief → retry; duration-met-but-too-few → retry; generic transient error → never escalates; streak cleared after a successful setup.

Full suite: **1814 passed**. Ruff/Pylint (10.00/10)/Pyright all clean.
