### PR TITLE
chore: refresh-login diagnostics for #568 (DEBUG-only, no behaviour change)

### DIFF
--- a/custom_components/securitas/hub.py
+++ b/custom_components/securitas/hub.py
@@ -45,6 +45,7 @@ from .verisure_owa_api import (
     VerisureOwaError,
 )
 from .verisure_owa_api.client import VerisureOwaClient
+from .verisure_owa_api.client._base import _token_fingerprint
 from .verisure_owa_api.exceptions import is_genuine_auth_failure
 from .verisure_owa_api.http_transport import HttpTransport
 
@@ -525,15 +526,33 @@ class VerisureHub:
 
         Also scrubs any legacy CONF_PASSWORD on the first capture. No-op when
         the hub is detached from a config entry (config-flow construction).
+
+        Emits a DEBUG diagnostic for issue #557 recording which branch ran:
+        ``persisted`` (write issued), ``already-current`` (disk already holds
+        this token), or ``no-config-entry`` (detached hub). This proves the
+        in-memory rotation reached the config entry — the memory->disk half
+        that the client-side ``rotated_fp`` line cannot by itself confirm.
         """
+        fp = _token_fingerprint(value)
         if self.config_entry is None:
-            return
-        existing = self.config_entry.data
-        if existing.get(CONF_REFRESH_TOKEN) == value and CONF_PASSWORD not in existing:
-            return
-        new_data = {**existing, CONF_REFRESH_TOKEN: value}
-        new_data.pop(CONF_PASSWORD, None)
-        self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+            outcome = "no-config-entry"
+        else:
+            existing = self.config_entry.data
+            if (
+                existing.get(CONF_REFRESH_TOKEN) == value
+                and CONF_PASSWORD not in existing
+            ):
+                outcome = "already-current"
+            else:
+                new_data = {**existing, CONF_REFRESH_TOKEN: value}
+                new_data.pop(CONF_PASSWORD, None)
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=new_data
+                )
+                outcome = "persisted"
+        _LOGGER.debug(
+            "[refresh] persist refresh token: persist_fp=%s outcome=%s", fp, outcome
+        )
 
     def persist_current_refresh_token(self) -> None:
         """Write the current in-memory refresh token to the config entry now.

--- a/custom_components/securitas/verisure_owa_api/client/_auth.py
+++ b/custom_components/securitas/verisure_owa_api/client/_auth.py
@@ -19,7 +19,7 @@ from ..graphql_queries import (
     VALIDATE_DEVICE_MUTATION,
 )
 from ..models import OtpPhone
-from ._base import API_CALLBY, _ClientBase
+from ._base import API_CALLBY, _ClientBase, _token_fingerprint
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,6 +122,25 @@ class _AuthMixin(_ClientBase):
 
     async def refresh_token(self) -> bool:
         """Refresh the authentication token. Returns True on success."""
+        # Diagnostic for issue #557: emit *before* the request so it survives a
+        # server-side crash. token_fp fingerprints the refresh token actually
+        # presented (a stale/consumed token loaded from disk after a reboot
+        # would carry a different fingerprint than the last one rotated);
+        # had_prior_auth=False localises the call to startup rather than a
+        # steady-state renewal; the *_len fields flag an empty device field
+        # (a String! the server might dereference by language) without logging
+        # the identifiers themselves.
+        _LOGGER.debug(
+            "[refresh] RefreshLogin attempt: token_fp=%s had_prior_auth=%s "
+            "country=%s lang=%s idDevice_len=%d uuid_len=%d indigitall_len=%d",
+            _token_fingerprint(self.refresh_token_value),
+            self.authentication_token is not None,
+            self.country,
+            self.language,
+            len(self.device_id or ""),
+            len(self.uuid or ""),
+            len(self.id_device_indigitall or ""),
+        )
         content = {
             "operationName": "RefreshLogin",
             "variables": {

--- a/custom_components/securitas/verisure_owa_api/client/_base.py
+++ b/custom_components/securitas/verisure_owa_api/client/_base.py
@@ -9,6 +9,7 @@ each extend ``_ClientBase`` so they have access to ``self._execute_graphql``,
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import secrets
@@ -59,6 +60,22 @@ def _format_graphql_error(
         if message:
             return f"{field_name} failed: {message}"
     return fallback
+
+
+def _token_fingerprint(token: str | None) -> str:
+    """Return a short, stable, non-reversible fingerprint of a token.
+
+    The refresh/auth tokens are redacted wholesale by ``SensitiveDataFilter``
+    (raw value -> ``[REFRESH_TOKEN]``), so logging them directly makes every
+    generation look identical. A truncated *unsalted* sha256 gives each token
+    a distinct id that survives the redaction filter, never leaks the value,
+    and — crucially for issue #557 — is stable across process restarts, so the
+    fingerprint persisted before a reboot can be compared with the one loaded
+    from disk afterwards. Falsy tokens map to ``<none>``.
+    """
+    if not token:
+        return "<none>"
+    return hashlib.sha256(token.encode()).hexdigest()[:12]
 
 
 T = TypeVar("T", bound=BaseModel)
@@ -196,6 +213,19 @@ class _ClientBase:
         """
         self.refresh_token_value = value
         self._register_secret("refresh_token", value)
+        # Diagnostic for issue #557: the fingerprint of the newly-rotated token.
+        # This fires at the *in-memory* rotation, BEFORE the persist callback
+        # below — so rotated_fp marks a rotation, not a completed disk write
+        # (hub._persist_refresh_token's persist_fp/outcome line confirms the
+        # write reached the config entry). Comparing the next boot's
+        # RefreshLogin token_fp against the last rotated_fp/persist_fp reveals a
+        # stale on-disk token (mismatch, e.g. a rotation that never reached
+        # storage before an ungraceful stop) vs a genuinely broken refresh
+        # (match — the token loaded is the last valid one and still crashes).
+        _LOGGER.debug(
+            "[refresh] refresh token rotated: rotated_fp=%s",
+            _token_fingerprint(value),
+        )
         if self._on_refresh_token_changed is not None:
             try:
                 self._on_refresh_token_changed(value)
@@ -316,6 +346,14 @@ class _ClientBase:
             return None
         if "exp" in decoded:
             self._authentication_token_exp = datetime.fromtimestamp(decoded["exp"])
+            # Diagnostic for issue #557: measure the real auth-token lifetime on
+            # the account rather than relying on the ~15-minute value inferred
+            # from fixtures — it underpins the "reboot forces a refresh we'd
+            # otherwise rarely hit" reasoning.
+            ttl_s = int(
+                (self._authentication_token_exp - datetime.now()).total_seconds()
+            )
+            _LOGGER.debug("[auth] auth token accepted: auth_token_ttl_s=%d", ttl_s)
         return decoded
 
     # ── Response extraction ──────────────────────────────────────────────

--- a/custom_components/securitas/verisure_owa_api/http_transport.py
+++ b/custom_components/securitas/verisure_owa_api/http_transport.py
@@ -116,8 +116,16 @@ class HttpTransport:
                     f"Connection error with URL {self._base_url}: {os_err}",
                 ) from err
 
+            # Tag the raw response with the operation and HTTP status so a
+            # diagnostic log can pick, say, the RefreshLogin response out of the
+            # request stream and see the exact structure/status it returned
+            # (issue #557/#568). Secrets are scrubbed by the handler-level
+            # SensitiveDataFilter; _sanitize_response_for_log only trims bulky
+            # non-secret fields (images, schedules).
             _LOGGER.debug(
-                "response=%s",
+                "[http] op=%s status=%s response=%s",
+                content.get("operationName", "?"),
+                http_status,
                 _sanitize_response_for_log(response_text),
             )
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -95,6 +95,36 @@ class TestHttpTransport:
         assert kwargs["headers"]["content-type"] == "application/json; charset=utf-8"
         assert kwargs["headers"]["X-Custom"] == "value"
 
+    async def test_debug_log_labels_response_with_operation_and_status(
+        self, transport, session, caplog
+    ):
+        """The raw-response DEBUG line is tagged with operation name + HTTP status.
+
+        So a diagnostic log (issue #568) can pick the RefreshLogin response out
+        of the request stream and see the exact status/structure it came back
+        with, instead of an anonymous ``response=...`` line.
+        """
+        import logging
+
+        body = {
+            "errors": [{"path": ["xSRefreshLogin"]}],
+            "data": {"xSRefreshLogin": None},
+        }
+        _mock_post(session, [_make_response(status=200, text=json.dumps(body))])
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger="custom_components.securitas.verisure_owa_api.http_transport",
+        ):
+            await transport.execute(
+                content={"operationName": "RefreshLogin", "query": "..."},
+                headers={},
+            )
+
+        assert "op=RefreshLogin" in caplog.text
+        assert "status=200" in caplog.text
+        assert '"xSRefreshLogin": null' in caplog.text
+
     async def test_dns_retry_succeeds_on_second_attempt(self, transport, session):
         """DNS error on first attempt is retried; success on second attempt."""
         dns_err = ClientConnectorDNSError(

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,6 +1,7 @@
 """Tests for VerisureHub orchestration methods."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,12 +19,17 @@ from custom_components.securitas.verisure_owa_api import (
     AuthenticationError,
     VerisureOwaError,
 )
+from custom_components.securitas.verisure_owa_api.client._base import (
+    _token_fingerprint,
+)
 from custom_components.securitas.verisure_owa_api.models import (
     CameraDevice,
     ThumbnailResponse,
 )
 
 from .conftest import make_installation
+
+_HUB_LOGGER = "custom_components.securitas.hub"
 
 
 def make_hub(*, mock_client: bool = True, **config_overrides) -> VerisureHub:
@@ -167,6 +173,55 @@ class TestRefreshTokenPersistence:
 
         new_data = hub.hass.config_entries.async_update_entry.call_args.kwargs["data"]
         assert new_data[CONF_REFRESH_TOKEN] == "current-token"
+
+    def test_diagnostic_logs_persisted_outcome(self, caplog):
+        """Issue #557: an actual write logs the fingerprint + outcome=persisted.
+
+        This closes the memory->disk seam: rotated_fp proves an in-memory
+        rotation, but only this line proves we asked HA to persist that value.
+        """
+        hub, _ = self._hub_with_entry(
+            {"username": "test@example.com", CONF_REFRESH_TOKEN: "old-token"}
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=_HUB_LOGGER):
+            hub._persist_refresh_token("rotated-token")
+
+        assert f"persist_fp={_token_fingerprint('rotated-token')}" in caplog.text
+        assert "outcome=persisted" in caplog.text
+
+    def test_diagnostic_logs_already_current_outcome(self, caplog):
+        """A no-op rotation logs outcome=already-current, not a false 'persisted'."""
+        hub, _ = self._hub_with_entry(
+            {"username": "test@example.com", CONF_REFRESH_TOKEN: "same-token"}
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=_HUB_LOGGER):
+            hub._persist_refresh_token("same-token")
+
+        assert f"persist_fp={_token_fingerprint('same-token')}" in caplog.text
+        assert "outcome=already-current" in caplog.text
+
+    def test_diagnostic_logs_no_config_entry_outcome(self, caplog):
+        """The detached (config-flow) path logs outcome=no-config-entry."""
+        hub = make_hub()  # config_entry=None
+
+        with caplog.at_level(logging.DEBUG, logger=_HUB_LOGGER):
+            hub._persist_refresh_token("anything")
+
+        assert "outcome=no-config-entry" in caplog.text
+
+    def test_diagnostic_does_not_leak_token(self, caplog):
+        """The persist diagnostic must never contain the raw token."""
+        secret = "super-secret-rotated-token"
+        hub, _ = self._hub_with_entry(
+            {"username": "test@example.com", CONF_REFRESH_TOKEN: "old-token"}
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=_HUB_LOGGER):
+            hub._persist_refresh_token(secret)
+
+        assert secret not in caplog.text
 
 
 class TestLogin:

--- a/tests/test_refresh_diagnostics.py
+++ b/tests/test_refresh_diagnostics.py
@@ -1,0 +1,259 @@
+"""Diagnostics for issue #557 (xSRefreshLogin 'fr' crash on restart).
+
+These tests cover the strategic logging added to tell apart the competing
+explanations for the reboot-only failure: a stale/consumed refresh token
+loaded from disk vs. a genuinely broken refresh for the account. The signal
+is a stable content *fingerprint* of the refresh token (the raw value is
+redacted by SensitiveDataFilter, so every generation would otherwise look
+identical in logs) plus the request context at the failing call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+
+import pytest
+
+from custom_components.securitas.verisure_owa_api.client import VerisureOwaClient
+from custom_components.securitas.verisure_owa_api.client._base import (
+    _token_fingerprint,
+)
+from custom_components.securitas.verisure_owa_api.exceptions import (
+    VerisureOwaError,
+    is_genuine_auth_failure,
+)
+
+from .conftest import refresh_response
+
+_AUTH_LOGGER = "custom_components.securitas.verisure_owa_api.client._auth"
+_BASE_LOGGER = "custom_components.securitas.verisure_owa_api.client._base"
+
+
+# The exact server crash from issue #557: xSRefreshLogin resolver throws a
+# JS TypeError and returns a null field.
+FR_CRASH_RESPONSE = {
+    "errors": [
+        {
+            "message": "Cannot read properties of undefined (reading 'fr')",
+            "path": ["xSRefreshLogin"],
+            "locations": [{"line": 2, "column": 3}],
+            "extensions": {},
+            "data": {},
+        }
+    ],
+    "data": {"xSRefreshLogin": None},
+}
+
+
+def _make_client(mock_transport, *, refresh_token: str) -> VerisureOwaClient:
+    """An FR client with a mocked transport and a preloaded refresh token.
+
+    The shared ``api`` fixture is ES with no refresh token, so this file needs
+    its own factory for the FR locale and the on-disk token these tests exercise.
+    """
+    return VerisureOwaClient(
+        transport=mock_transport,
+        country="FR",
+        language="fr",
+        username="user@example.com",
+        password="",
+        device_id="dev-id",
+        uuid="uuid-value",
+        id_device_indigitall="indigitall-value",
+        refresh_token=refresh_token,
+    )
+
+
+class TestTokenFingerprint:
+    def test_is_stable_content_hash(self) -> None:
+        """Same token -> same fingerprint, computed as a sha256 prefix.
+
+        Stability as a pure content hash is the whole point: the fingerprint
+        persisted before a restart must equal the one computed after it, so we
+        can tell whether the token loaded from disk is the last one rotated.
+        """
+        token = "some-refresh-token-value"
+        expected = hashlib.sha256(token.encode()).hexdigest()[:12]
+
+        assert _token_fingerprint(token) == expected
+
+    def test_distinguishes_different_tokens(self) -> None:
+        """Different tokens -> different fingerprints (so generations differ)."""
+        assert _token_fingerprint("token-a") != _token_fingerprint("token-b")
+
+    def test_does_not_leak_the_raw_token(self) -> None:
+        """The fingerprint must not contain the raw token (safe to log)."""
+        token = "super-secret-refresh-token"
+        fp = _token_fingerprint(token)
+
+        assert token not in fp
+        assert len(fp) < len(token)
+
+    def test_empty_and_none_use_a_sentinel(self) -> None:
+        """Falsy tokens fingerprint to a sentinel instead of crashing."""
+        assert _token_fingerprint("") == "<none>"
+        assert _token_fingerprint(None) == "<none>"
+
+
+class TestRefreshAttemptDiagnostics:
+    async def test_logs_fingerprint_and_startup_context_on_the_crash(
+        self, mock_transport, caplog
+    ) -> None:
+        """The #557 crash still emits a diagnostic pinning fingerprint + context.
+
+        The diagnostic must be logged *before* the request, so it survives the
+        server crash — that is the only line that ties the failing generation
+        to the reboot (no prior auth token) rather than a steady-state renewal.
+        """
+        mock_transport.execute.return_value = FR_CRASH_RESPONSE
+        client = _make_client(mock_transport, refresh_token="on-disk-refresh-token")
+        # Fresh process after a reboot: no in-memory auth token yet.
+        assert client.authentication_token is None
+
+        with (
+            caplog.at_level(logging.DEBUG, logger=_AUTH_LOGGER),
+            pytest.raises(VerisureOwaError),
+        ):
+            await client.refresh_token()
+
+        fp = _token_fingerprint("on-disk-refresh-token")
+        assert f"token_fp={fp}" in caplog.text
+        assert "had_prior_auth=False" in caplog.text
+
+    async def test_does_not_leak_the_raw_refresh_token(
+        self, mock_transport, caplog
+    ) -> None:
+        """The raw refresh token must never reach the diagnostic log line."""
+        mock_transport.execute.return_value = FR_CRASH_RESPONSE
+        secret = "super-secret-on-disk-refresh-token"
+        client = _make_client(mock_transport, refresh_token=secret)
+
+        with (
+            caplog.at_level(logging.DEBUG, logger=_AUTH_LOGGER),
+            pytest.raises(VerisureOwaError),
+        ):
+            await client.refresh_token()
+
+        assert secret not in caplog.text
+
+    async def test_distinguishes_steady_state_renewal_from_startup(
+        self, mock_transport, caplog
+    ) -> None:
+        """A renewal with a live auth token logs had_prior_auth=True.
+
+        This flag is the startup-vs-steady discriminator: only the reboot path
+        reaches refresh with no prior auth token, so a crash tagged
+        had_prior_auth=False localises the failure to startup.
+        """
+        mock_transport.execute.return_value = FR_CRASH_RESPONSE
+        client = _make_client(mock_transport, refresh_token="on-disk-refresh-token")
+        client.authentication_token = "a-live-though-near-expiry-token"
+
+        with (
+            caplog.at_level(logging.DEBUG, logger=_AUTH_LOGGER),
+            pytest.raises(VerisureOwaError),
+        ):
+            await client.refresh_token()
+
+        assert "had_prior_auth=True" in caplog.text
+
+
+class TestRotationDiagnostics:
+    async def test_logs_new_token_fingerprint_on_rotation(
+        self, mock_transport, caplog
+    ) -> None:
+        """A rotated refresh token logs its fingerprint.
+
+        This is the other half of the cross-restart timeline: the last
+        ``rotated_fp`` persisted before a shutdown is what the next boot's
+        ``token_fp`` should match — a mismatch proves a stale token was loaded.
+        """
+        new_refresh = "rotated-refresh-token"
+        mock_transport.execute.return_value = refresh_response(
+            refresh_token=new_refresh
+        )
+        client = _make_client(mock_transport, refresh_token="old-refresh-token")
+
+        with caplog.at_level(logging.DEBUG, logger=_BASE_LOGGER):
+            ok = await client.refresh_token()
+
+        assert ok is True
+        assert f"rotated_fp={_token_fingerprint(new_refresh)}" in caplog.text
+
+    async def test_rotation_log_does_not_leak_new_token(
+        self, mock_transport, caplog
+    ) -> None:
+        """The raw rotated token must never reach the log line."""
+        new_refresh = "super-secret-rotated-token"
+        mock_transport.execute.return_value = refresh_response(
+            refresh_token=new_refresh
+        )
+        client = _make_client(mock_transport, refresh_token="old-refresh-token")
+
+        with caplog.at_level(logging.DEBUG, logger=_BASE_LOGGER):
+            await client.refresh_token()
+
+        assert new_refresh not in caplog.text
+
+
+class TestAuthTokenLifetimeDiagnostics:
+    async def test_logs_measured_auth_token_ttl_on_success(
+        self, mock_transport, caplog
+    ) -> None:
+        """A minted auth token logs its real remaining lifetime.
+
+        We have only *inferred* the ~15-minute JWT life from test fixtures; this
+        line measures it on the reporter's own account. If the real value were
+        hours, the "reboot only forces the refresh we'd otherwise rarely hit"
+        reasoning would need revisiting — so it is worth confirming, not assuming.
+        """
+        mock_transport.execute.return_value = refresh_response(
+            refresh_token="rotated-refresh-token"
+        )
+        client = _make_client(mock_transport, refresh_token="old-refresh-token")
+
+        with caplog.at_level(logging.DEBUG, logger=_BASE_LOGGER):
+            ok = await client.refresh_token()
+
+        assert ok is True
+        match = re.search(r"auth_token_ttl_s=(\d+)", caplog.text)
+        assert match is not None
+        ttl = int(match.group(1))
+        # refresh_response defaults its hash to a 15-minute JWT (~900s), with
+        # clock-skew slack for the test's own runtime.
+        assert 840 <= ttl <= 905
+
+
+class TestRefreshCrashIsAnUnrecoverableTrap:
+    """Characterisation of *existing* behaviour (these pass as-is).
+
+    They pin down why the reporter must delete the entry: the #557 crash is
+    classified transient AND leaves the on-disk token untouched, so every retry
+    re-presents the exact same token and hits the exact same crash forever.
+    """
+
+    async def test_crash_leaves_the_on_disk_token_unchanged(
+        self, mock_transport
+    ) -> None:
+        """The failing refresh does not rotate the token — the retry reuses it."""
+        mock_transport.execute.return_value = FR_CRASH_RESPONSE
+        client = _make_client(mock_transport, refresh_token="on-disk-refresh-token")
+
+        with pytest.raises(VerisureOwaError):
+            await client.refresh_token()
+
+        assert client.refresh_token_value == "on-disk-refresh-token"
+
+    async def test_crash_is_classified_transient_not_a_reauth_signal(
+        self, mock_transport
+    ) -> None:
+        """The crash is NOT a genuine auth failure, so it retries, never reauths."""
+        mock_transport.execute.return_value = FR_CRASH_RESPONSE
+        client = _make_client(mock_transport, refresh_token="on-disk-refresh-token")
+
+        with pytest.raises(VerisureOwaError) as excinfo:
+            await client.refresh_token()
+
+        assert is_genuine_auth_failure(excinfo.value) is False


### PR DESCRIPTION
Diagnostics for #568 — **no behaviour change, DEBUG-level only.** Intended to ship as a beta so @amullr (and anyone else still hitting the `xSRefreshLogin ... reading 'fr'` crash on **v5.7.0**, i.e. *with* the #562 fix) can tell us why.

## Why

We fixed one cause of a stale on-disk refresh token in #562 (the detached config-flow hub dropping rotations). But a user is still crashing on v5.7.0, and we don't actually know how the token is going stale — or even *whether* it is. A cleanly rejected token returns coded `err 60067` (we reauth on that immediately); this crash is **uncoded null-data**, which could equally be a server-side resolver fault on a perfectly valid token. Before shipping any recovery logic (held in #569), we need data.

## What it logs

Re-applies the #558 instrumentation (reverted in #562) on top of current `main`, plus a transport tag. Per token, only a **non-reversible fingerprint** is logged, never the raw value:

- **RefreshLogin attempt** — `token_fp` + startup-vs-steady-state + country/lang + device-field lengths
- **rotation** — `rotated_fp` of each newly issued refresh token
- **persist** — `persist_fp` + `outcome` (`persisted` / `already-current` / `no-config-entry`) at the config-entry write
- **auth-token TTL** — the measured JWT lifetime
- **transport** — each raw response is now tagged `[http] op=<name> status=<code> response=<body>` so the RefreshLogin response is identifiable and its exact structure is visible (secrets scrubbed by the `SensitiveDataFilter`)

## The decisive comparison

`persist_fp` written **before** a restart vs `token_fp` used in the RefreshLogin attempt **after** it:

- **Different** → the on-disk token is genuinely **stale** (a persistence gap / unclean shutdown / clobber) → hunt the leak.
- **Identical** (the exact token we persisted still crashes) → the token is **fine**, the crash is **server-side** → recovery-via-reauth (#569) would be the wrong fix.

The `[http] op=RefreshLogin` line also shows whether the server *ever* returns a coded `60067` vs only the uncoded crash.

## Tests
Reintroduced diagnostic tests (`tests/test_refresh_diagnostics.py`, `tests/test_hub.py`) + a new transport-label test. Full suite **1821 passed**; 401 JS tests pass; Ruff / Pylint 10.00 / Pyright clean.

Related: #557, #562, #569 (held).
