### PR TITLE
fix: pre-fill the saved auto-force-arm option when reopening Options

### DIFF
--- a/custom_components/securitas/config_flow.py
+++ b/custom_components/securitas/config_flow.py
@@ -1128,6 +1128,9 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_FORCE_ARM_NOTIFICATIONS: self._get(
                     CONF_FORCE_ARM_NOTIFICATIONS, DEFAULT_FORCE_ARM_NOTIFICATIONS
                 ),
+                CONF_AUTO_FORCE_ARM: self._get(
+                    CONF_AUTO_FORCE_ARM, DEFAULT_AUTO_FORCE_ARM
+                ),
                 CONF_SCAN_INTERVAL: self._get(
                     CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                 ),

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1076,6 +1076,46 @@ async def test_options_enabling_auto_force_arm_persists(hass):
     assert result["data"]["auto_force_arm"] is True
 
 
+async def test_options_init_prefills_saved_auto_force_arm(hass):
+    """Reopening Options must pre-fill a previously saved auto_force_arm.
+
+    Regression for the bug where CONF_AUTO_FORCE_ARM was missing from the
+    defaults dict passed to _build_settings_schema in async_step_init, so the
+    tick box always showed the schema default (False) instead of the saved
+    value — the option came up unchecked even after being enabled.
+    """
+    from custom_components.securitas.const import (
+        CONF_AUTO_FORCE_ARM,
+        DEFAULT_AUTO_FORCE_ARM,
+    )
+
+    saved_value = True
+    assert saved_value != DEFAULT_AUTO_FORCE_ARM, (
+        "test value must differ from the schema default to be meaningful"
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=make_config_entry_data(),
+        options={CONF_AUTO_FORCE_ARM: saved_value},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    marker = _section_inner_marker(
+        result["data_schema"], "notifications", CONF_AUTO_FORCE_ARM
+    )
+    assert marker is not None, "auto_force_arm field not found in notifications section"
+    assert marker.default() == saved_value, (
+        f"Expected pre-filled default {saved_value!r}, got {marker.default()!r}. "
+        "CONF_AUTO_FORCE_ARM is missing from the async_step_init defaults dict."
+    )
+
+
 # ===================================================================
 # TestSubpanelsNote
 # ===================================================================


### PR DESCRIPTION
## Problem

The **"Offer an auto-force-arm tick box on the alarm card"** setting (added in #572 / #566) always came up **unchecked** when reopening the integration Options — even after it had been enabled and saved.

## Root cause

`VerisureOptionsFlowHandler.async_step_init` hand-builds the `defaults` dict passed to `_build_settings_schema`. When #572 added the `CONF_AUTO_FORCE_ARM` field to the schema builder, it was **never added to that defaults dict** — every sibling field (notify group, force-arm notifications, scan interval, …) is listed there, but this one wasn't.

So `_build_settings_schema` fell back to `defaults.get(CONF_AUTO_FORCE_ARM, DEFAULT_AUTO_FORCE_ARM)` → `False` on every render. The value was persisted correctly (via `_flatten_sections` → `entry.options`); it just was never read back into the form.

## Fix

Read the saved value via `self._get(CONF_AUTO_FORCE_ARM, DEFAULT_AUTO_FORCE_ARM)` in the defaults dict, exactly like the neighbouring fields.

One-line production change. A regression test asserts the reopened options form pre-fills a saved `auto_force_arm=True` — it fails before the fix (marker default is `False`) and passes after. This mirrors the existing `test_options_init_prefills_saved_operation_poll_timeout` guard for the same class of omission.

No changelog entry: the feature is still unreleased (5.8.0-beta.1), and the v5.8.0 "Added" note already describes the intended behaviour this fix makes true.