### PR TITLE
fix: silence via_device TypedDict error on HA 2026.9+ (removed key)

### DIFF
--- a/custom_components/securitas/entity.py
+++ b/custom_components/securitas/entity.py
@@ -50,7 +50,7 @@ def _link_to_installation(
         if device is not None:
             info["via_device_id"] = device.id  # type: ignore[typeddict-unknown-key]
             return
-    info["via_device"] = parent
+    info["via_device"] = parent  # type: ignore[typeddict-unknown-key]
 
 
 def securitas_device_info(installation: Installation) -> DeviceInfo:


### PR DESCRIPTION
## Problem

The **Pyright** CI job started failing on every branch:

```
custom_components/securitas/entity.py:53:5 - error: Could not assign item in TypedDict
```

This is **not** caused by any recent code change. `main` (b0671eb) passed CI at 13:37; the same commit's Pyright would fail now. The cause is environmental: `pytest-homeassistant-custom-component` released **0.13.358**, which pulls **`homeassistant==2026.9.0b0`**, and HA 2026.9 **removes `via_device` from the `DeviceInfo` TypedDict** (superseded by `via_device_id`, added in 2026.8). Pyright then rejects the fallback assignment `info["via_device"] = parent`.

## Fix

Add `# type: ignore[typeddict-unknown-key]` to line 53, exactly mirroring the sibling `via_device_id` assignment on line 51 (which needs the same ignore on HA < 2026.8, where *that* key is unknown).

- **No runtime change** on any supported HA version. The feature-detect logic is untouched: `via_device_id` is used on HA ≥ 2026.8 when the parent device is registered; `via_device` remains the fallback everywhere else.
- Pyright's `reportUnnecessaryTypeIgnoreComment` is off by default (confirmed: line 51's ignore is already "unnecessary" on the 2026.9 beta yet CI is green), so the added ignore is safe across all supported versions.

## Verification

Reproduced locally by installing the exact CI stack (`homeassistant==2026.9.0b0`, `pytest-homeassistant-custom-component==0.13.358`, pyright 1.1.411): `via_device` is gone from the TypedDict and `pyright custom_components/` fails on entity.py:53 before the change and passes after. Full Python test suite (811 tests) and the device-info/entity tests (69) pass on the beta HA.