### PR TITLE
fix: keep a cleared alarm-state mapping cleared on reopening Options

### DIFF
--- a/custom_components/securitas/config_flow.py
+++ b/custom_components/securitas/config_flow.py
@@ -1171,13 +1171,21 @@ class VerisureOptionsFlowHandler(config_entries.OptionsFlow):
         def _suggested_map(key: str) -> str | None:
             """Return the value to pre-fill in the form, or None for blank.
 
-            Saved value wins when it's still in the current option set;
-            otherwise falls back to the default. Pre-v5 saved values of
-            ``"not_used"`` (or anything else outside the dropdown) collapse
-            to blank, so the user sees a cleared field instead of a stale
-            unselectable choice.
+            An explicit empty string is a mapping the user deliberately
+            cleared (``_normalize_mapping_input`` records the cleared state as
+            ``""``): honour it as blank rather than resurrecting the per-mode
+            default, which would repopulate the field on every reopen and let
+            a subsequent save silently un-clear it.
+
+            Otherwise the saved value wins when it's still in the current
+            option set; failing that we fall back to the default. Pre-v5 saved
+            values of ``"not_used"`` (or anything else outside the dropdown)
+            collapse to the default, so the user sees a usable choice instead
+            of a stale unselectable one.
             """
             val = self._get(key)
+            if val == "":
+                return None
             if val and val in valid_values:
                 return val
             return defaults.get(key)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1250,6 +1250,42 @@ async def test_options_mappings_invalid_mapping_falls_back(hass):
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
+async def test_options_mappings_cleared_field_stays_cleared_on_reopen(hass):
+    """A mapping the user explicitly cleared must not be repopulated on reopen.
+
+    Regression: clearing a mapping records it as "" in options, but
+    _suggested_map treated that empty string as "unset" and fell back to the
+    per-mode default — so e.g. a cleared map_custom on a perimeter install
+    came back as peri_only every time the Options dialog was reopened, and
+    re-saving would silently un-clear it.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=make_config_entry_data(has_peri=True),
+        options={CONF_MAP_CUSTOM: ""},  # user explicitly cleared map_custom
+    )
+    entry.add_to_hass(hass)
+    coord = MagicMock()
+    coord.has_peri = True
+    coord.has_annex = False
+    coord.capabilities_populated = True
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"alarm_coordinator": coord}
+
+    result = await _show_mappings(hass, entry)
+    assert result["step_id"] == "mappings"
+
+    marker = next(
+        m
+        for m in result["data_schema"].schema
+        if getattr(m, "schema", m) == CONF_MAP_CUSTOM
+    )
+    suggested = (getattr(marker, "description", None) or {}).get("suggested_value")
+    assert suggested in (None, ""), (
+        f"Cleared map_custom must stay blank on reopen, got {suggested!r} — "
+        "_suggested_map resurrected the default from the cleared empty string."
+    )
+
+
 async def test_options_mappings_submitting_creates_entry(hass):
     """Submitting mappings form should create the options entry."""
     entry = MockConfigEntry(


### PR DESCRIPTION
## Problem

Clearing an alarm-state mapping in the Options dialog doesn't stick: reopen the dialog and the cleared field is **repopulated with its per-mode default**, and re-saving then silently un-clears it. Most visible on a **perimeter install**, where clearing `map_custom` brings back `peri_only` on every reopen. Reported by a user with a perimeter panel who cleared a mapping and watched it come back.

## Root cause

Clearing a mapping is recorded as an explicit empty string `""` in `entry.options` (that's the whole point of `_normalize_mapping_input` — so the update listener sees a diff). But the redisplay helper `_suggested_map` did:

```python
val = self._get(key)
if val and val in valid_values:   # "" is falsy → skipped
    return val
return defaults.get(key)          # ← cleared field resurrected from the default
```

An explicit `""` (deliberately cleared) is falsy, so it fell through to `defaults.get(key)` — identical treatment to a never-set field. On a perimeter install `PERI_DEFAULTS["map_custom"]` is `peri_only`, so the cleared field came back populated.

## Fix

`_suggested_map` now honours an explicit `""` as blank, while a genuinely-unset field (key absent → `_get` returns `None`) still shows the mode default:

```python
val = self._get(key)
if val == "":
    return None          # deliberately cleared → stay blank
if val and val in valid_values:
    return val
return defaults.get(key)
```

One-line behavioural change plus a doc update. TDD: the regression test (cleared `map_custom` on a perimeter install must stay blank on reopen) fails before the change — pre-fills `'peri_only'` — and passes after. Full Python suite (1827) and frontend tests (416) green.

## CI note

The **Pyright** job here is red for an unrelated reason — HA `2026.9.0b0` removed `via_device` from the `DeviceInfo` TypedDict, failing `entity.py:53` on every branch. Fixed separately in #574; I'll rebase this once that lands and CI will clear. All other jobs pass.

## Not addressed here (separate, unconfirmed)

There's a latent robustness issue where a *non-empty* perimeter/annex mapping value can collapse to a standard default if capability detection resolves to "standard" as Options opens. That's a different code path (`_resolve_flow_capabilities` treating "unknown" as "standard") and wasn't what this reporter hit — leaving it for a follow-up.