### PR TITLE
chore: pre-bump to 5.8.0-beta.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,17 @@ Most recent at the top.  For changes prior to v5, see [the GitHub release notes]
 
 ## v5.8.0
 
-A new opt-in auto-force-arm tick box on the alarm card, plus opt-in DEBUG diagnostics to help pin down a refresh-login crash that a few accounts still hit on every restart after the v5.7.0 fix.
+A new opt-in auto-force-arm tick box on the alarm card and opt-in DEBUG diagnostics to help pin down a refresh-login crash that a few accounts still hit on every restart after the v5.7.0 fix — plus a fix for cleared alarm-state mappings reappearing on their own.
 
 ### Added
 
 **Auto-force-arm past open sensors, straight from the card ([#566](https://github.com/guerrerotook/securitas-direct-new-api/issues/566)).**  When you arm with a door or window left open, the alarm blocks and waits for you to tap **Force Arm** — easy to miss, and until you do the alarm never arms.  A new opt-in setting, **"Offer an auto-force-arm tick box on the alarm card"**, adds a *force-arm past open sensors* tick box below the arm buttons on the alarm card; with it ticked, arming from that card and hitting an open sensor force-arms past the open zones automatically instead of waiting for you to confirm.  Rather than flashing the "arm blocked — force arm?" prompt and clearing it a beat later, an auto-forced arm skips that prompt and sends a single **"force-armed"** confirmation naming the sensors it bypassed (a manual **Force Arm** tap is unchanged).  The bypassed zones are still recorded in the activity log as *Armed with exceptions*.  It is off by default — force-arming silently bypasses open doors and windows, and some panels (Spain has been observed) don't support it at all — and the tick box is remembered per device in the browser, so it only ever affects arming from that card and never changes how automations or the stock alarm card behave.  Thanks to [@WSorban](https://github.com/WSorban) for the request.
 
 **Opt-in diagnostics for the refresh-login crash that persists after v5.7.0 ([#568](https://github.com/guerrerotook/securitas-direct-new-api/issues/568)).**  v5.7.0 fixed one cause of the `xSRefreshLogin failed: Cannot read properties of undefined (reading 'fr')` crash that leaves the integration stuck until it is deleted and re-added, but a few accounts still hit it.  This release re-adds DEBUG-level logging — off by default and with no behaviour change — that fingerprints the refresh token across a restart, records each rotation and whether it was persisted, and tags the raw server response for the refresh call.  Together these tell apart the two remaining possibilities: a stale token loaded from disk (something our side still isn't persisting) versus the server crashing on a token that is actually current (a server-side fault, which re-authenticating would not fix).  If you are affected, enable debug logging for `custom_components.securitas` — a `logs:` entry under `logger:` in `configuration.yaml` — then leave Home Assistant running for half an hour, restart it, and share the log on the issue.  Thanks to [@amullr](https://github.com/amullr) for the report.
+
+### Fixed
+
+**A cleared alarm-state mapping came back on its own ([#575](https://github.com/guerrerotook/securitas-direct-new-api/pull/575)).**  Clearing one of the alarm-state mappings in the integration's options — setting a button to *not used* — didn't stick: reopen the options dialog and the field had reverted to its default, and saving again silently restored it.  It was most visible on perimeter-capable installations, where a cleared *custom* mapping reappeared as *perimeter only* every time.  The cleared state (recorded internally as an explicit empty value) is now honoured on redisplay, so cleared mappings stay cleared.
 
 ## v5.7.0
 

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.8.0-beta.1"
+    "version": "5.8.0-beta.2"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.8.0-beta.1";
-import "./verisure-owa-alarm-chip.js?v=5.8.0-beta.1";
+import "./verisure-owa-alarm-card.js?v=5.8.0-beta.2";
+import "./verisure-owa-alarm-chip.js?v=5.8.0-beta.2";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.8.0-beta.1";
+import "./verisure-owa-camera-card.js?v=5.8.0-beta.2";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,7 +21,7 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0-beta.1";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
 import {
   _t,
   STATE_CFG,
@@ -37,7 +37,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.1";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.2";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -47,7 +47,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.1";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.2";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,7 +13,7 @@ import {
   defaultArmState,
   attachGesture,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.1";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.2";
 
 class VerisureOwaAlarmBadge extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,7 +8,7 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.1";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Release-prep for **5.8.0-beta.2**: bumps `manifest.json` and re-stamps every card `?v=` cache-bust token from `5.8.0-beta.1` → `5.8.0-beta.2`. The manifest/token cache-busting guards pass (Python `test_card_cache_busting.py` + JS `card-cache-busting.test.js`), and `check_docs.py` is clean.

## Merge order (this goes LAST)

This beta ships four in-flight PRs, so merge in this order:

1. **#574** — entity.py Pyright fix (unblocks CI on every branch)
2. **#573** — auto-force-arm option pre-fill fix
3. **#575** — cleared-mapping-repopulates fix
4. **#576** — force-arm confirmation notification
5. **this PR** — the version bump

After #574 + the three land on `main`, I'll rebase this branch onto the updated `main` (`reset --hard upstream/main` + re-apply the bump) and **finalise the `## v5.8.0` changelog section** to cover everything shipping (the workflow reads that section verbatim as the release notes). Then dispatch `release.yaml` with `version=5.8.0-beta.2 prerelease=true`.

## CI note

Pyright is red only on the unrelated `entity.py:53` `via_device` issue (HA 2026.9.0b0 removed the key), fixed by #574 above. Every other check is green. Once #574 merges and this rebases, Pyright clears.