### PR TITLE
refactor: converge device_id minting on generate_uuid(), drop unused FCM generator

### DIFF
--- a/custom_components/securitas/__init__.py
+++ b/custom_components/securitas/__init__.py
@@ -135,7 +135,6 @@ from .verisure_owa_api import (
     Installation,
     TwoFactorRequiredError,
     VerisureOwaError,
-    generate_device_id,
     generate_uuid,
 )
 
@@ -218,7 +217,7 @@ def _resolve_flow_capabilities(
 def add_device_information[T: dict](config: T) -> T:
     """Add device information to the configuration."""
     if CONF_DEVICE_ID not in config:
-        config[CONF_DEVICE_ID] = generate_device_id()
+        config[CONF_DEVICE_ID] = generate_uuid()
 
     if CONF_UNIQUE_ID not in config:
         config[CONF_UNIQUE_ID] = generate_uuid()

--- a/custom_components/securitas/verisure_owa_api/__init__.py
+++ b/custom_components/securitas/verisure_owa_api/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from .client import VerisureOwaClient, generate_device_id, generate_uuid  # noqa: F401
+from .client import VerisureOwaClient, generate_uuid  # noqa: F401
 from .const import (  # noqa: F401
     PERI_DEFAULTS,
     PERI_OPTIONS,

--- a/custom_components/securitas/verisure_owa_api/client/__init__.py
+++ b/custom_components/securitas/verisure_owa_api/client/__init__.py
@@ -13,14 +13,13 @@ private sibling modules:
 - ``_sentinel`` — comfort sensors and air-quality.
 - ``_installation`` — installation list + service catalog.
 
-Module-level helpers (``generate_uuid``, ``generate_device_id``) and the
-public lock-device constants stay re-exported here so existing imports
-from ``verisure_owa_api.client`` keep working unchanged.
+Module-level helper (``generate_uuid``) and the public lock-device
+constants stay re-exported here so existing imports from
+``verisure_owa_api.client`` keep working unchanged.
 """
 
 from __future__ import annotations
 
-import secrets
 from uuid import uuid4
 
 from ._activity import _ActivityMixin
@@ -34,7 +33,6 @@ from ._sentinel import _SentinelMixin
 __all__ = [
     "SMARTLOCK_DEVICE_ID",
     "VerisureOwaClient",
-    "generate_device_id",
     "generate_uuid",
 ]
 
@@ -42,11 +40,6 @@ __all__ = [
 def generate_uuid() -> str:
     """Create a device id."""
     return str(uuid4()).replace("-", "")[0:16]
-
-
-def generate_device_id() -> str:
-    """Create a device identifier for the API."""
-    return secrets.token_urlsafe(16) + ":APA91b" + secrets.token_urlsafe(130)[0:134]
 
 
 class VerisureOwaClient(  # pylint: disable=too-many-ancestors

--- a/custom_components/securitas/verisure_owa_api/examples/basic_operations.py
+++ b/custom_components/securitas/verisure_owa_api/examples/basic_operations.py
@@ -42,7 +42,8 @@ async def main():
     country = "ES"
     async with aiohttp.ClientSession() as aiohttp_session:
         uuid = generate_uuid()
-        device_id = generate_uuid()
+        # Mirror the config flow's known-working path: idDevice == uuid.
+        device_id = uuid
         id_device_indigitall = str(uuid4())
         api_domains = ApiDomains()
         transport = HttpTransport(

--- a/custom_components/securitas/verisure_owa_api/examples/basic_operations.py
+++ b/custom_components/securitas/verisure_owa_api/examples/basic_operations.py
@@ -11,7 +11,6 @@ from verisure_owa_api import (
     HttpTransport,
     VerisureOwaClient,
     VerisureOwaError,
-    generate_device_id,
     generate_uuid,
 )
 
@@ -43,7 +42,7 @@ async def main():
     country = "ES"
     async with aiohttp.ClientSession() as aiohttp_session:
         uuid = generate_uuid()
-        device_id = generate_device_id()
+        device_id = generate_uuid()
         id_device_indigitall = str(uuid4())
         api_domains = ApiDomains()
         transport = HttpTransport(

--- a/tests/test_execute_request.py
+++ b/tests/test_execute_request.py
@@ -1,9 +1,6 @@
-"""Tests for generate_uuid and generate_device_id utility functions."""
+"""Tests for the generate_uuid utility function."""
 
-from custom_components.securitas.verisure_owa_api.client import (
-    generate_device_id,
-    generate_uuid,
-)
+from custom_components.securitas.verisure_owa_api.client import generate_uuid
 
 # ── generate_uuid tests ──────────────────────────────────────────────────────
 
@@ -25,27 +22,4 @@ class TestGenerateUuid:
         """Two calls return different UUIDs."""
         a = generate_uuid()
         b = generate_uuid()
-        assert a != b
-
-
-# ── generate_device_id tests ────────────────────────────────────────────────
-
-
-class TestGenerateDeviceId:
-    """Tests for the generate_device_id module-level function."""
-
-    def test_contains_apa91b_marker(self):
-        """Device ID contains the ':APA91b' marker."""
-        result = generate_device_id()
-        assert ":APA91b" in result
-
-    def test_returns_expected_length(self):
-        """Device ID is 163 chars: 22 (token_urlsafe(16)) + 7 (':APA91b') + 134."""
-        result = generate_device_id()
-        assert len(result) == 22 + 7 + 134
-
-    def test_two_calls_return_different_values(self):
-        """Two calls return different device IDs."""
-        a = generate_device_id()
-        b = generate_device_id()
         assert a != b

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -112,6 +112,19 @@ class TestAddDeviceInformation:
         assert isinstance(result[CONF_DEVICE_ID], str)
         assert len(result[CONF_DEVICE_ID]) > 0
 
+    def test_generated_device_id_uses_16_char_uuid_form(self):
+        """Generated device_id uses the 16-char uuid form, not the legacy FCM form.
+
+        The API distinguishes idDevice from uuid, but the FCM-token idDevice
+        was an accidental orphan (ed4a1e6): every UI install has minted a
+        16-char idDevice since Jan 2024 and Verisure accepts it. Both mint
+        paths now converge on generate_uuid().
+        """
+        config = OrderedDict({CONF_COUNTRY: "ES"})
+        result = add_device_information(config)
+        assert len(result[CONF_DEVICE_ID]) == 16
+        assert "-" not in result[CONF_DEVICE_ID]
+
     def test_generates_unique_id_when_missing(self):
         """Should generate a unique_id when not present in config."""
         config = OrderedDict({CONF_COUNTRY: "ES"})


### PR DESCRIPTION
## What

`add_device_information()` minted `CONF_DEVICE_ID` with the ~150-char FCM-token form (`generate_device_id()`), while the config flow mints it with the 16-char `generate_uuid()` form — the same value it uses for `CONF_UNIQUE_ID`. This PR converges both paths on `generate_uuid()` and deletes the now-orphaned `generate_device_id()` helper (plus its export, example use, and tests).

## Why this is safe (zero runtime change)

The API sends `idDevice` and `uuid` as two distinct GraphQL variables, and the real app puts an FCM push token in `idDevice` — which `generate_device_id()` mimicked. But:

- The config flow has minted a **16-char `idDevice`** (equal to `uuid`) since [`ed4a1e6` "making 2FA optional"](https://github.com/guerrerotook/securitas-direct-new-api/commit/ed4a1e6) (Jan 2024), which incidentally collapsed the two identifiers onto one locally-minted value.
- `add_device_information()`'s FCM-form value is **overwritten by `entry.data` during setup** (`__init__.py`: `entry.data[CONF_DEVICE_ID]` always wins; a missing key forces `need_sign_in` instead). So the FCM branch has not reached the wire for any live install.
- Net: **every UI install has sent a 16-char `idDevice` for 2+ years and Verisure accepts it.** Runtime `idDevice` is unchanged for every existing and new install; this only removes dead code and the mint-path divergence.

The FCM form was actually the *original* 2022 design (`0ce850f`); the 16-char override was the accidental regression. Given 2+ years of proof that the 16-char form works across the whole userbase, this converges on the proven form rather than resurrecting the FCM path.

## Tests (TDD)

- Added `test_generated_device_id_uses_16_char_uuid_form` — asserts `add_device_information` now mints a 16-char id (failed against the old ~163-char FCM form, passes after the change).
- Removed the `generate_device_id` unit tests (the function is gone).
- Full suite: **1824 passed**. Ruff / Pyright / Pylint clean.

No `CHANGES.md` entry — this is an invisible internal cleanup with no user-facing behaviour change.