### PR TITLE
feat(activity): categorize badge/remote activation events (type 41)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Most recent at the top.  For changes prior to v5, see [the GitHub release notes]
 
 ## v5.8.0
 
-A new opt-in auto-force-arm tick box on the alarm card and opt-in DEBUG diagnostics to help pin down a refresh-login crash that a few accounts still hit on every restart after the v5.7.0 fix — plus a fix for cleared alarm-state mappings reappearing on their own.
+A new opt-in auto-force-arm tick box on the alarm card and opt-in DEBUG diagnostics to help pin down a refresh-login crash that a few accounts still hit on every restart after the v5.7.0 fix — plus fixes for cleared alarm-state mappings reappearing on their own and a badge or remote-control activation that showed as an unknown event in the activity log.
 
 ### Added
 
@@ -15,6 +15,8 @@ A new opt-in auto-force-arm tick box on the alarm card and opt-in DEBUG diagnost
 ### Fixed
 
 **A cleared alarm-state mapping came back on its own ([#575](https://github.com/guerrerotook/securitas-direct-new-api/pull/575)).**  Clearing one of the alarm-state mappings in the integration's options — setting a button to *not used* — didn't stick: reopen the options dialog and the field had reverted to its default, and saving again silently restored it.  It was most visible on perimeter-capable installations, where a cleared *custom* mapping reappeared as *perimeter only* every time.  The cleared state (recorded internally as an explicit empty value) is now honoured on redisplay, so cleared mappings stay cleared.
+
+**A badge or remote-control activation showed as "Unknown event" in the activity log ([#579](https://github.com/guerrerotook/securitas-direct-new-api/issues/579)).**  When you activate an RFID tag or remote control from the Verisure app — turning on one you normally keep deactivated — the panel emits event code `41`, which the integration did not recognise, so the activity log listed it as an *Unknown event*.  Code `41` is now catalogued under its own **tag or remote activated** category, so the entry appears with its own icon, colour and label — localised in all seven languages — instead of an unknown row.  Thanks to [@philippemezzadri](https://github.com/philippemezzadri) for reporting it with the event details.
 
 ## v5.7.0
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ If you want every event to fire on the bus, turn on continuous polling under **S
 
 Each entry carries a **category** — a stable label for the type of event. The full list:
 
-`armed`, `armed_with_exceptions`, `arming_failed`, `disarmed`, `alarm`, `alarm_resolved`, `tampering`, `sabotage`, `image_request`, `power_cut`, `power_restored`, `status_check`, `communication_failed`, `communication_restored`, `door_opened`, `door_closed`, `routine_executed`, `unknown`.
+`armed`, `armed_with_exceptions`, `arming_failed`, `disarmed`, `alarm`, `alarm_resolved`, `tampering`, `sabotage`, `image_request`, `power_cut`, `power_restored`, `status_check`, `communication_failed`, `communication_restored`, `door_opened`, `door_closed`, `routine_executed`, `tag_or_remote_activated`, `unknown`.
 
 ### Activity events vs the alarm panel entity
 

--- a/custom_components/securitas/verisure_owa_api/models/activity.py
+++ b/custom_components/securitas/verisure_owa_api/models/activity.py
@@ -77,6 +77,10 @@ class ActivityCategory(StrEnum):
     # A Verisure-app "routine" fired — a user-scheduled automation that can
     # arm/disarm the alarm on a schedule.
     ROUTINE_EXECUTED = "routine_executed"
+    # An RFID tag/badge or remote control was activated (enabled) from the
+    # Verisure app. Administrative device-management event, not an alarm-state
+    # change — users keep unused tags deactivated and enable them on demand.
+    TAG_OR_REMOTE_ACTIVATED = "tag_or_remote_activated"
     UNKNOWN = "unknown"
 
 
@@ -158,6 +162,10 @@ _ACTIVITY_TYPE_TO_CATEGORY: dict[int, ActivityCategory] = {
     # automation that can arm/disarm the alarm. Seen as "Routine exécutée".
     # GitHub #513.
     70: ActivityCategory.ROUTINE_EXECUTED,
+    # An RFID tag/badge or remote control was activated (enabled) from the app.
+    # Seen on a French panel as "Activation du badge ou de la télécommande",
+    # with the tag's colour name in `device`. GitHub #579.
+    41: ActivityCategory.TAG_OR_REMOTE_ACTIVATED,
 }
 
 

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -42,6 +42,7 @@ export const TRANSLATIONS = {
       door_opened: "Door opened",
       door_closed: "Door closed",
       routine_executed: "Routine executed",
+      tag_or_remote_activated: "Tag or remote activated",
       unknown: "Unknown event",
     },
     exception_status: {
@@ -85,6 +86,7 @@ export const TRANSLATIONS = {
       door_opened: "Puerta abierta",
       door_closed: "Puerta cerrada",
       routine_executed: "Rutina ejecutada",
+      tag_or_remote_activated: "Tag o mando activado",
       unknown: "Evento desconocido",
     },
     exception_status: {
@@ -128,6 +130,7 @@ export const TRANSLATIONS = {
       door_opened: "Porta aperta",
       door_closed: "Porta chiusa",
       routine_executed: "Routine eseguita",
+      tag_or_remote_activated: "Tag o telecomando attivato",
       unknown: "Evento sconosciuto",
     },
     exception_status: {
@@ -171,6 +174,7 @@ export const TRANSLATIONS = {
       door_opened: "Porte ouverte",
       door_closed: "Porte fermée",
       routine_executed: "Routine exécutée",
+      tag_or_remote_activated: "Badge ou télécommande activé",
       unknown: "Événement inconnu",
     },
     exception_status: {
@@ -214,6 +218,7 @@ export const TRANSLATIONS = {
       door_opened: "Porta aberta",
       door_closed: "Porta fechada",
       routine_executed: "Rotina executada",
+      tag_or_remote_activated: "Tag ou comando ativado",
       unknown: "Evento desconhecido",
     },
     exception_status: {
@@ -257,6 +262,7 @@ export const TRANSLATIONS = {
       door_opened: "Porta aberta",
       door_closed: "Porta fechada",
       routine_executed: "Rotina executada",
+      tag_or_remote_activated: "Tag ou controle ativado",
       unknown: "Evento desconhecido",
     },
     exception_status: {
@@ -300,6 +306,7 @@ export const TRANSLATIONS = {
       door_opened: "Porta oberta",
       door_closed: "Porta tancada",
       routine_executed: "Rutina executada",
+      tag_or_remote_activated: "Tag o comandament activat",
       unknown: "Esdeveniment desconegut",
     },
     exception_status: {
@@ -348,6 +355,7 @@ const CATEGORY_ICONS = {
   door_opened: "mdi:door-open",
   door_closed: "mdi:door-closed",
   routine_executed: "mdi:robot",
+  tag_or_remote_activated: "mdi:key-wireless",
   unknown: "mdi:help-circle",
 };
 
@@ -372,6 +380,8 @@ const CATEGORY_COLORS = {
   door_closed: "var(--success-color, #43a047)",
   // Routine fired — informational, neutral like status_check.
   routine_executed: "var(--secondary-text-color)",
+  // Tag/remote enabled from the app — administrative, neutral.
+  tag_or_remote_activated: "var(--secondary-text-color)",
   unknown: "var(--secondary-text-color)",
 };
 

--- a/tests-js/integration/activity-log-card.test.js
+++ b/tests-js/integration/activity-log-card.test.js
@@ -551,6 +551,7 @@ describe("verisure-owa-activity-log-card extra branches", () => {
     ["door_opened", "mdi:door-open", "Door opened"],
     ["door_closed", "mdi:door-closed", "Door closed"],
     ["routine_executed", "mdi:robot", "Routine executed"],
+    ["tag_or_remote_activated", "mdi:key-wireless", "Tag or remote activated"],
   ])(
     "renders the %s category with its own icon, label, and no unknown prompt",
     (category, icon, label) => {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1154,6 +1154,15 @@ class TestActivityEventCategory:
         arm signals in the 70x series (701 armed / 700 disarmed). GitHub #555."""
         assert self._ev(702).category == ActivityCategory.ARMED
 
+    def test_tag_or_remote_activated(self):
+        """41 fires when an RFID tag/badge or remote control is activated
+        (enabled) from the Verisure app.
+
+        Seen on a French panel as "Activation du badge ou de la télécommande",
+        with the tag's colour name in `device`. An administrative event, not
+        an alarm-state change. GitHub #579."""
+        assert self._ev(41).category == ActivityCategory.TAG_OR_REMOTE_ACTIVATED
+
     def test_unknown_codes(self):
         """Codes we haven't seen fall through to UNKNOWN — future-proofing."""
         assert self._ev(99999).category == ActivityCategory.UNKNOWN


### PR DESCRIPTION
## What

Event **type 41** was showing as an "Unknown event" in the activity log ([#579](https://github.com/guerrerotook/securitas-direct-new-api/issues/579)). It fires when an **RFID tag/badge or remote control is activated** (enabled) from the Verisure app — reported by @philippemezzadri on a French panel as `Activation du badge ou de la télécommande`, with the tag's colour name (`Rouge`) in `device`. Users keep unused tags deactivated and enable them on demand, so each toggle emits this.

<img width="408" alt="type 41 unknown event" src="https://github.com/user-attachments/assets/c4f6f04a-f502-491d-a453-13ddfca69340" />

## Change

- Add `ActivityCategory.TAG_OR_REMOTE_ACTIVATED` and map code `41` in `_ACTIVITY_TYPE_TO_CATEGORY`.
- Card: icon `mdi:key-wireless`, neutral color (`--secondary-text-color`), and labels in all 7 locales.
- README: add `tag_or_remote_activated` to the documented category list.

This is a **panel-only administrative signal** — not an alarm-state change and not something HA injects — so `HA_INJECTABLE_CATEGORIES` is left untouched. Follows the same pattern as the smart-lock door / routine categories in #514.

## Tests (TDD)

- `tests/test_models.py::TestActivityEventCategory::test_tag_or_remote_activated` — `type 41 → TAG_OR_REMOTE_ACTIVATED`.
- `tests-js/…/activity-log-card.test.js` — parametrised row asserts the icon + label render and no unknown prompt.

Full local suite green: Python 1832 passed, JS 419 passed; ruff/pylint/pyright/eslint/prettier clean.

Closes #579