### PR TITLE
chore: pre-bump to 5.8.0-beta.3

### DIFF
--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.8.0-beta.2"
+    "version": "5.8.0-beta.3"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.8.0-beta.2";
-import "./verisure-owa-alarm-chip.js?v=5.8.0-beta.2";
+import "./verisure-owa-alarm-card.js?v=5.8.0-beta.3";
+import "./verisure-owa-alarm-chip.js?v=5.8.0-beta.3";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.8.0-beta.2";
+import "./verisure-owa-camera-card.js?v=5.8.0-beta.3";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.3";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,7 +21,7 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0-beta.3";
 import {
   _t,
   STATE_CFG,
@@ -37,7 +37,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.2";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.3";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -47,7 +47,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.2";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.3";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,7 +13,7 @@ import {
   defaultArmState,
   attachGesture,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.2";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-beta.3";
 
 class VerisureOwaAlarmBadge extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,7 +8,7 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.3";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.2";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-beta.3";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Pre-bump ahead of dispatching the **Release** workflow for **v5.8.0-beta.3** (a pre-release). `main` is protected, so the workflow can't push its own version-bump commit — the manifest has to already be at the target when it runs.

- `manifest.json` version `5.8.0-beta.2` → `5.8.0-beta.3`
- Re-stamp all **10** card `?v=` cache-bust tokens across `www/*.js` to `5.8.0-beta.3` (kept in sync with the manifest by `tests/test_card_cache_busting.py` + `tests-js/…/card-cache-busting.test.js`).

## Why now

The in-beta `## v5.8.0` `CHANGES.md` section gained the **type-41 tag/remote activation** fix ([#579](https://github.com/guerrerotook/securitas-direct-new-api/issues/579), merged in #580), so this beta ships that fix. No changelog change here — the section is already complete; the release notes extract it verbatim (base `## v5.8.0` heading, suffix resolved away).

## Verified locally

- `test_card_cache_busting.py` ✓ · JS `card-cache-busting.test.js` (9) ✓
- Simulated the workflow's release-notes extraction → resolves `## v5.8.0`, non-empty (4.2 kB)
- Full suites green: Python 1832, JS 419; eslint + prettier clean

After merge: dispatch `release.yaml` with `version=5.8.0-beta.3 prerelease=true`. Pre-releases skip the roll-forward step, so the run goes fully green, and `main` stays on `5.8.0-beta.3` (no dev-bump for betas).