### PR TITLE
chore: bump to 5.8.0 (final) + tidy v5.8.0 release notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,17 +4,15 @@ Most recent at the top.  For changes prior to v5, see [the GitHub release notes]
 
 ## v5.8.0
 
-The headline is a new optional tick box that arms past open doors and windows for you, so a forgotten open window no longer quietly stops the alarm from arming. The alarm also now works through Home Assistant's own alarm dialog throughout, plus a handful of fixes.
+The headline this release is that the integration now lives in Home Assistant's **native** UI: the standard alarm **More Info dialog**, the alarm **badge**, and the **Tile card** all surface open sensors and offer Force Arm, so arming past an open door or window no longer needs the custom card. Huge thanks to [@foxdalas](https://github.com/foxdalas) for contributing that work ([#586](https://github.com/guerrerotook/securitas-direct-new-api/pull/586)). Alongside it, a new optional tick box arms past open sensors for you automatically, plus a handful of fixes.
 
 ### Added
 
-**Arm past open doors and windows automatically ([#566](https://github.com/guerrerotook/securitas-direct-new-api/issues/566)).**  A new tick box, off by default, arms straight past any open sensor instead of stopping to ask you to confirm each time. Your choice is remembered per device and works from both the alarm card and Home Assistant's alarm dialog. Thanks to [@WSorban](https://github.com/WSorban) for the request.
+**Force Arm across Home Assistant's native UI ([#586](https://github.com/guerrerotook/securitas-direct-new-api/pull/586)).**  When an open door or window blocks arming, the standard alarm **More Info dialog** and the **Tile card** now list the open sensors and offer Force Arm and Cancel right there — the familiar Home Assistant controls, with no custom card required. Panels that don't allow forcing (such as in Spain) still get the list and a note to close the sensors first. Contributed by [@foxdalas](https://github.com/foxdalas).
 
-**Force Arm built into Home Assistant's own alarm dialog.**  When an open door or window blocks arming, the standard alarm dialog now lists the open sensors and offers Force Arm and Cancel right there, keeping all the familiar Home Assistant controls. Panels that don't allow forcing (such as in Spain) still get the list and a note to close the sensors first.
+**A first-class alarm badge ([#586](https://github.com/guerrerotook/securitas-direct-new-api/pull/586)).**  The Verisure alarm badge is now a proper native Home Assistant badge: a live preview when you add it, content settings for its name and icon, and the option to show the alarm state in the badges row. Contributed by [@foxdalas](https://github.com/foxdalas).
 
-**Live badge preview and content settings.**  The alarm badge now shows a live preview when you add it and can display the alarm state in the badges row, with the usual settings for its name, icon and what it shows.
-
-**Open sensors shown in the Tile card.**  A new tile option stays hidden until arming is blocked, then lists the open doors and windows below the alarm controls — with a Force Arm button where the panel allows it.
+**Arm past open doors and windows automatically ([#566](https://github.com/guerrerotook/securitas-direct-new-api/issues/566)).**  A new tick box, off by default, arms straight past any open sensor instead of stopping to ask you to confirm each time. Your choice is remembered per device and works from both the alarm card and Home Assistant's native UI. Thanks to [@WSorban](https://github.com/WSorban) for the request.
 
 **A clear heads-up for a rare restart problem ([#568](https://github.com/guerrerotook/securitas-direct-new-api/issues/568)).**  A few accounts still hit a server-side error on every restart that leaves the alarm unavailable until it is removed and set up again. This release adds optional detailed logging to help track down the cause, and now shows a single plain warning — with steps to help — the first time it happens, so affected users know what is going on instead of seeing an unexplained failure. Thanks to [@amullr](https://github.com/amullr) for the report.
 

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.8.0-rc.1"
+    "version": "5.8.0"
 }

--- a/custom_components/securitas/strings.json
+++ b/custom_components/securitas/strings.json
@@ -287,6 +287,7 @@
                             "door_closed": "Door closed",
                             "routine_executed": "Routine executed",
                             "tag_or_remote_activated": "Tag or remote activated",
+                            "high_temperature": "High temperature",
                             "unknown": "Unknown"
                         }
                     }

--- a/custom_components/securitas/translations/ca.json
+++ b/custom_components/securitas/translations/ca.json
@@ -287,6 +287,7 @@
                             "door_closed": "Porta tancada",
                             "routine_executed": "Rutina executada",
                             "tag_or_remote_activated": "Tag o comandament activat",
+                            "high_temperature": "Temperatura elevada",
                             "unknown": "Esdeveniment desconegut"
                         }
                     }

--- a/custom_components/securitas/translations/en.json
+++ b/custom_components/securitas/translations/en.json
@@ -287,6 +287,7 @@
                             "door_closed": "Door closed",
                             "routine_executed": "Routine executed",
                             "tag_or_remote_activated": "Tag or remote activated",
+                            "high_temperature": "High temperature",
                             "unknown": "Unknown"
                         }
                     }

--- a/custom_components/securitas/translations/es.json
+++ b/custom_components/securitas/translations/es.json
@@ -287,6 +287,7 @@
                             "door_closed": "Puerta cerrada",
                             "routine_executed": "Rutina ejecutada",
                             "tag_or_remote_activated": "Tag o mando activado",
+                            "high_temperature": "Temperatura elevada",
                             "unknown": "Evento desconocido"
                         }
                     }

--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -287,6 +287,7 @@
                             "door_closed": "Porte fermée",
                             "routine_executed": "Routine exécutée",
                             "tag_or_remote_activated": "Badge ou télécommande activé",
+                            "high_temperature": "Température élevée",
                             "unknown": "Événement inconnu"
                         }
                     }

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -287,6 +287,7 @@
                             "door_closed": "Porta chiusa",
                             "routine_executed": "Routine eseguita",
                             "tag_or_remote_activated": "Tag o telecomando attivato",
+                            "high_temperature": "Temperatura elevata",
                             "unknown": "Evento sconosciuto"
                         }
                     }

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -287,6 +287,7 @@
                             "door_closed": "Porta fechada",
                             "routine_executed": "Rotina executada",
                             "tag_or_remote_activated": "Tag ou controle ativado",
+                            "high_temperature": "Temperatura elevada",
                             "unknown": "Evento desconhecido"
                         }
                     }

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -287,6 +287,7 @@
                             "door_closed": "Porta fechada",
                             "routine_executed": "Rotina executada",
                             "tag_or_remote_activated": "Tag ou comando ativado",
+                            "high_temperature": "Temperatura elevada",
                             "unknown": "Evento desconhecido"
                         }
                     }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.8.0-rc.1";
-import "./verisure-owa-alarm-chip.js?v=5.8.0-rc.1";
+import "./verisure-owa-alarm-card.js?v=5.8.0";
+import "./verisure-owa-alarm-chip.js?v=5.8.0";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.8.0-rc.1";
+import "./verisure-owa-camera-card.js?v=5.8.0";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
@@ -7,7 +7,7 @@
 import {
   GESTURE_KEYS,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.1";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 const DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,12 +21,12 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0-rc.1";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0";
 import {
   autoForceActive,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.1";
+} from "./verisure-owa-arm-exception.js?v=5.8.0";
 import {
   _t,
   STATE_CFG,
@@ -42,7 +42,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.1";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -52,7 +52,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.1";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,8 +13,8 @@ import {
   attachGesture,
   _makeLegacyShim,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.1";
-import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.8.0-rc.1";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.8.0";
 
 const BADGE_DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,11 +8,11 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.1";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 import {
   ARM_EXCEPTION_TRANSLATIONS,
   notifyActionFailure,
-} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.1";
+} from "./verisure-owa-arm-exception.js?v=5.8.0";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.1";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-more-info.js
+++ b/custom_components/securitas/www/verisure-owa-more-info.js
@@ -11,7 +11,7 @@ import {
   hassLanguage,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.1";
+} from "./verisure-owa-arm-exception.js?v=5.8.0";
 
 class VerisureOwaMoreInfo extends HTMLElement {
   constructor() {


### PR DESCRIPTION
Final-release counterpart to the **5.8.0-rc.1** pre-bump (#591), opened in parallel so both can be approved in one pass. Same prep, `5.8.0` instead of `5.8.0-rc.1`.

## Changes
- `manifest.json` version → `5.8.0`
- Re-stamped all 15 card cache-bust `?v=` tokens → `5.8.0`
- Same concise, plain-language `## v5.8.0` release notes as #591

## Merge order (important)
**rc.1 first.** Sequence:
1. Approve **both** this and #591.
2. Merge #591 → dispatch `release.yaml version=5.8.0-rc.1 prerelease=true`.
3. Rebase this branch onto the released main (`git reset --hard upstream/main` + re-apply the 5.8.0 bump), force-push. The approval survives (dismiss-stale is off).
4. Merge this → dispatch `release.yaml version=5.8.0` (final; the roll-forward step will show red as always — the tag + release before it succeed).

## Verified locally
- `tests/test_card_cache_busting.py` ✓, JS `card-cache-busting.test.js` (13) ✓, `scripts/check_docs.py` ✓
- Release-workflow simulation for `5.8.0`: version validates, notes extract from `## v5.8.0` (non-empty), tag `v5.8.0` doesn't exist