### PR TITLE
feat(event): add activity-log event entity for native Logbook support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ The headline is a new optional tick box that arms past open doors and windows fo
 
 **A clear heads-up for a rare restart problem ([#568](https://github.com/guerrerotook/securitas-direct-new-api/issues/568)).**  A few accounts still hit a server-side error on every restart that leaves the alarm unavailable until it is removed and set up again. This release adds optional detailed logging to help track down the cause, and now shows a single plain warning — with steps to help — the first time it happens, so affected users know what is going on instead of seeing an unexplained failure. Thanks to [@amullr](https://github.com/amullr) for the report.
 
+**A native activity event entity ([#593](https://github.com/guerrerotook/securitas-direct-new-api/pull/593)).**  The panel's activity timeline — arms, disarms, intrusions, image requests, power events — is now also exposed as a Home Assistant `event` entity (`event.<alias>_activity`), so it appears in the built-in Logbook and can trigger automations directly, with no custom card. Each entry carries its category as the event type, translated in every supported language, and the newest event is always the one shown. The existing activity-log sensor, card and event bus are unchanged.
+
 ### Fixed
 
 **Blocked arming showed a confusing internal message.**  With a door or window open, some arm attempts showed a raw internal error instead of naming the open sensors. It now lists the sensors to close — on the card, in notifications and in the activity log.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Smart locks, with optional auto-lock when you arm and auto-disarm when you unloc
 
 Bundled Lovelace UI: alarm card, alarm badge, [Mushroom](https://github.com/piitaya/lovelace-mushroom) chip, Tile open-sensor feature, camera card, activity-log card.
 
-The activity log mirrors what you see in the Verisure app — arm/disarm, intrusions, image requests, power events — surfaced as a sensor, a card, and an event bus. Actions you take from HA are tagged with the real HA user and deduplicated against the panel's later echo, so automations fire once.
+The activity log mirrors what you see in the Verisure app — arm/disarm, intrusions, image requests, power events — surfaced as an event entity, a sensor, a card, and an event bus. Actions you take from HA are tagged with the real HA user and deduplicated against the panel's later echo, so automations fire once.
 
 Multiple installations per account work out of the box. 2FA is handled at setup. Your password isn't stored on disk — it gets used once to mint a refresh token, then discarded.
 
@@ -456,8 +456,9 @@ The Activity Log mirrors the history shown in the Verisure app: arm/disarm event
 
 ![Activity Log](docs/images/activity-log.png)
 
-The integration surfaces this history in three places:
+The integration surfaces this history in four places:
 
+- **An event entity** — `event.<alias>_activity` shows each new entry in the built-in **Logbook** and more-info, with the event's [category](#activity-log) as its `event_type` and the event's details in its attributes. Trigger automations on it directly — it's the Home Assistant-native way to consume the timeline, and needs no custom card.
 - **A Lovelace card** — Add Card → "Verisure OWA Activity Log Card". Click any row for details (including images for image-request entries); the refresh button is top-right.
 - **A sensor** — `sensor.<alias>_activity_log` exposes the most recent event as state, with the last 30 entries in its `events` attribute for templates and custom cards.
 - **The event bus** — each new entry fires a `verisure_owa_activity` event you can trigger automations on.
@@ -469,7 +470,7 @@ By default the integration **doesn't poll the activity log on a timer** — fetc
 - The **card** pulls the latest entries while it's on screen — once on open, then once a minute. Close the dashboard and the polling stops.
 - The **refresh button** (top-right of the card) and the **`verisure_owa.refresh_activity_log`** service fetch immediately.
 
-There's a side effect on the **`verisure_owa_activity` event bus**: with on-demand refresh, remote events don't fire on the bus (otherwise you'd get a burst of stale events the next time you open a dashboard — the sensor and card update silently instead). The exception is actions **you take from HA** — those fire as they happen, regardless of the polling setting. So with polling off, automations catch HA-originated activity but miss events from elsewhere (someone arming at the physical panel, an intrusion, a power cut).
+There's a side effect on the **`event.<alias>_activity` entity and the `verisure_owa_activity` event bus** (both fire from the same new-event feed): with on-demand refresh, remote events don't fire (otherwise you'd get a burst of stale events the next time you open a dashboard — the sensor and card update silently instead). The exception is actions **you take from HA** — those fire as they happen, regardless of the polling setting. So with polling off, automations catch HA-originated activity but miss events from elsewhere (someone arming at the physical panel, an intrusion, a power cut).
 
 If you want every event to fire on the bus, turn on continuous polling under **Settings → Integrations → Verisure OWA → Configure → Activity Log and Events**.
 

--- a/custom_components/securitas/const.py
+++ b/custom_components/securitas/const.py
@@ -134,6 +134,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CAMERA,
+    Platform.EVENT,
     Platform.SENSOR,
     Platform.LOCK,
 ]

--- a/custom_components/securitas/event.py
+++ b/custom_components/securitas/event.py
@@ -65,14 +65,7 @@ class ActivityLogEvent(  # type: ignore[override]
 ):
     """The alarm panel's activity timeline as an ``event`` entity."""
 
-    # has_entity_name is False (like the sibling ActivityLogSensor) so the
-    # entity_id derives from the explicit name below — `event.<alias>_activity`
-    # — rather than HA's has_entity_name path, which prefixes the device's area
-    # (e.g. `event.kitchen_<alias>_activity` when the alarm device sits in an
-    # area). translation_key is still set so the event_type STATE labels stay
-    # translated; it drives state-attribute translations regardless of
-    # has_entity_name (the entity name comes from `_attr_name`).
-    _attr_has_entity_name = False
+    _attr_has_entity_name = True
     _attr_translation_key = "activity"
     _attr_icon = "mdi:format-list-bulleted"
     # EventEntity declares `_attr_event_types` as an instance var (not
@@ -88,7 +81,6 @@ class ActivityLogEvent(  # type: ignore[override]
         """Initialise the activity event entity."""
         super().__init__(coordinator)
         self._installation = installation
-        self._attr_name = f"{installation.alias} Activity"
         self._attr_device_info = securitas_device_info(installation)
         self._attr_unique_id = (
             f"v4_securitas_direct.{installation.number}_activity_event"

--- a/custom_components/securitas/event.py
+++ b/custom_components/securitas/event.py
@@ -91,9 +91,20 @@ class ActivityLogEvent(  # type: ignore[override]
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Trigger one HA event per just-arrived timeline entry, in order."""
+        """Publish one state change per just-arrived timeline entry, in order.
+
+        A single poll can surface several new events (e.g. arm-then-disarm
+        within the poll interval). ``_trigger_event`` only mutates the pending
+        event fields — the *state change* is what reaches the Logbook and
+        event-based automation triggers — so each event needs its own
+        ``async_write_ha_state()`` or only the last would be observable. The
+        empty path still writes once (keeps availability fresh; the first-poll
+        baseline carries no ``new_events`` so nothing is replayed).
+        """
         data = self.coordinator.data
         if data is not None and data.new_events:
             for event in data.new_events:
                 self._trigger_event(event.category.value, _event_attributes(event))
-        self.async_write_ha_state()
+                self.async_write_ha_state()
+        else:
+            self.async_write_ha_state()

--- a/custom_components/securitas/event.py
+++ b/custom_components/securitas/event.py
@@ -103,7 +103,11 @@ class ActivityLogEvent(  # type: ignore[override]
         """
         data = self.coordinator.data
         if data is not None and data.new_events:
-            for event in data.new_events:
+            # new_events is newest-first (the coordinator sorts reverse=True).
+            # Fire oldest→newest so each event still gets its own state change
+            # (Logbook / automation visibility) AND the NEWEST event wins the
+            # entity's resting state.
+            for event in reversed(data.new_events):
                 self._trigger_event(event.category.value, _event_attributes(event))
                 self.async_write_ha_state()
         else:

--- a/custom_components/securitas/event.py
+++ b/custom_components/securitas/event.py
@@ -1,0 +1,99 @@
+"""Verisure OWA event platform — the activity timeline as an `event` entity.
+
+Additive companion to ``ActivityLogSensor``: exposes the same xSActV2 timeline
+as a core-native ``event`` entity so it renders in the built-in Logbook and the
+stock more-info dialog. Rides ``ActivityCoordinator.data.new_events`` — the
+same delta the bus events use — so it inherits their semantics for free: no
+historical replay on restart (first poll baselines silently), no double-firing
+of HA-issued actions (``duplicate_of`` echoes are already excluded), and live
+injected arm/disarm events.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.event import EventEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import DOMAIN
+from .coordinators import ActivityCoordinator
+from .entity import securitas_device_info
+from .verisure_owa_api import Installation
+from .verisure_owa_api.models import ActivityCategory, ActivityEvent
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the Verisure OWA activity event entity.
+
+    One entity per installation, only when the activity coordinator exists
+    (it is absent when the installation has no accessible activity timeline).
+    """
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    activity_coord: ActivityCoordinator | None = entry_data.get("activity_coordinator")
+    if activity_coord is not None:
+        async_add_entities(
+            [ActivityLogEvent(activity_coord, activity_coord.installation)]
+        )
+
+
+def _event_attributes(event: ActivityEvent) -> dict[str, Any]:
+    """Flatten one ActivityEvent into a small, recorder-friendly attr dict."""
+    return {
+        "alias": event.alias,
+        "device_name": event.device_name,
+        "verisure_user": event.verisure_user,
+        "time": event.time,
+        "id_signal": event.id_signal,
+        "signal_type": event.signal_type,
+        "img": event.img,
+        "injected": event.injected,
+        "exceptions": (
+            [exc.model_dump() for exc in event.exceptions] if event.exceptions else []
+        ),
+    }
+
+
+class ActivityLogEvent(  # type: ignore[override]
+    CoordinatorEntity[ActivityCoordinator],
+    EventEntity,
+):
+    """The alarm panel's activity timeline as an ``event`` entity."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "activity"
+    _attr_icon = "mdi:format-list-bulleted"
+    # EventEntity declares `_attr_event_types` as an instance var (not
+    # ClassVar), so a ClassVar annotation here would itself be a pyright
+    # reportIncompatibleVariableOverride — plain assignment, RUF012 accepted.
+    _attr_event_types = [  # noqa: RUF012
+        category.value for category in ActivityCategory
+    ]
+
+    def __init__(
+        self, coordinator: ActivityCoordinator, installation: Installation
+    ) -> None:
+        """Initialise the activity event entity."""
+        super().__init__(coordinator)
+        self._installation = installation
+        self._attr_device_info = securitas_device_info(installation)
+        self._attr_unique_id = (
+            f"v4_securitas_direct.{installation.number}_activity_event"
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Trigger one HA event per just-arrived timeline entry, in order."""
+        data = self.coordinator.data
+        if data is not None and data.new_events:
+            for event in data.new_events:
+                self._trigger_event(event.category.value, _event_attributes(event))
+        self.async_write_ha_state()

--- a/custom_components/securitas/event.py
+++ b/custom_components/securitas/event.py
@@ -65,7 +65,14 @@ class ActivityLogEvent(  # type: ignore[override]
 ):
     """The alarm panel's activity timeline as an ``event`` entity."""
 
-    _attr_has_entity_name = True
+    # has_entity_name is False (like the sibling ActivityLogSensor) so the
+    # entity_id derives from the explicit name below — `event.<alias>_activity`
+    # — rather than HA's has_entity_name path, which prefixes the device's area
+    # (e.g. `event.kitchen_<alias>_activity` when the alarm device sits in an
+    # area). translation_key is still set so the event_type STATE labels stay
+    # translated; it drives state-attribute translations regardless of
+    # has_entity_name (the entity name comes from `_attr_name`).
+    _attr_has_entity_name = False
     _attr_translation_key = "activity"
     _attr_icon = "mdi:format-list-bulleted"
     # EventEntity declares `_attr_event_types` as an instance var (not
@@ -81,6 +88,7 @@ class ActivityLogEvent(  # type: ignore[override]
         """Initialise the activity event entity."""
         super().__init__(coordinator)
         self._installation = installation
+        self._attr_name = f"{installation.alias} Activity"
         self._attr_device_info = securitas_device_info(installation)
         self._attr_unique_id = (
             f"v4_securitas_direct.{installation.number}_activity_event"

--- a/custom_components/securitas/event.py
+++ b/custom_components/securitas/event.py
@@ -11,7 +11,6 @@ injected arm/disarm events.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.components.event import EventEntity
@@ -25,8 +24,6 @@ from .coordinators import ActivityCoordinator
 from .entity import securitas_device_info
 from .verisure_owa_api import Installation
 from .verisure_owa_api.models import ActivityCategory, ActivityEvent
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(

--- a/custom_components/securitas/strings.json
+++ b/custom_components/securitas/strings.json
@@ -261,5 +261,37 @@
             "title": "Leftover verisure_owa folder",
             "description": "An obsolete `verisure_owa` directory was left at `{path}` by an earlier (broken) upgrade. It does nothing now and can be safely deleted. Remove the directory and restart Home Assistant to clear this notice."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Activity",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armed",
+                            "armed_with_exceptions": "Armed with exceptions",
+                            "arming_failed": "Arming failed",
+                            "disarmed": "Disarmed",
+                            "alarm": "Alarm",
+                            "alarm_resolved": "Alarm resolved",
+                            "tampering": "Tampering",
+                            "sabotage": "Sabotage",
+                            "image_request": "Image request",
+                            "power_cut": "Power cut",
+                            "power_restored": "Power restored",
+                            "status_check": "Status check",
+                            "communication_failed": "Communication failed",
+                            "communication_restored": "Communication restored",
+                            "door_opened": "Door opened",
+                            "door_closed": "Door closed",
+                            "routine_executed": "Routine executed",
+                            "tag_or_remote_activated": "Tag or remote activated",
+                            "unknown": "Unknown"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/custom_components/securitas/translations/ca.json
+++ b/custom_components/securitas/translations/ca.json
@@ -261,5 +261,37 @@
             "title": "Carpeta verisure_owa sobrant",
             "description": "S'ha trobat una carpeta obsoleta `verisure_owa` a `{path}` d'una actualització anterior. Ja no fa res i es pot esborrar amb seguretat. Elimina-la i reinicia Home Assistant per amagar aquest avís."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Activitat",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armat",
+                            "armed_with_exceptions": "Armat amb excepcions",
+                            "arming_failed": "Armament fallit",
+                            "disarmed": "Desarmat",
+                            "alarm": "Alarma",
+                            "alarm_resolved": "Alarma resolta",
+                            "tampering": "Manipulació",
+                            "sabotage": "Sabotatge",
+                            "image_request": "Petició d'imatge",
+                            "power_cut": "Tall de corrent",
+                            "power_restored": "Corrent restablert",
+                            "status_check": "Comprovació d'estat",
+                            "communication_failed": "Error de comunicació",
+                            "communication_restored": "Comunicació restablerta",
+                            "door_opened": "Porta oberta",
+                            "door_closed": "Porta tancada",
+                            "routine_executed": "Rutina executada",
+                            "tag_or_remote_activated": "Tag o comandament activat",
+                            "unknown": "Esdeveniment desconegut"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/custom_components/securitas/translations/en.json
+++ b/custom_components/securitas/translations/en.json
@@ -261,5 +261,37 @@
             "title": "Leftover verisure_owa folder",
             "description": "An obsolete `verisure_owa` directory was left at `{path}` by an earlier (broken) upgrade. It does nothing now and can be safely deleted. Remove the directory and restart Home Assistant to clear this notice."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Activity",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armed",
+                            "armed_with_exceptions": "Armed with exceptions",
+                            "arming_failed": "Arming failed",
+                            "disarmed": "Disarmed",
+                            "alarm": "Alarm",
+                            "alarm_resolved": "Alarm resolved",
+                            "tampering": "Tampering",
+                            "sabotage": "Sabotage",
+                            "image_request": "Image request",
+                            "power_cut": "Power cut",
+                            "power_restored": "Power restored",
+                            "status_check": "Status check",
+                            "communication_failed": "Communication failed",
+                            "communication_restored": "Communication restored",
+                            "door_opened": "Door opened",
+                            "door_closed": "Door closed",
+                            "routine_executed": "Routine executed",
+                            "tag_or_remote_activated": "Tag or remote activated",
+                            "unknown": "Unknown"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/custom_components/securitas/translations/es.json
+++ b/custom_components/securitas/translations/es.json
@@ -261,5 +261,37 @@
             "title": "Carpeta verisure_owa obsoleta",
             "description": "Una carpeta obsoleta `verisure_owa` quedó en `{path}` tras una actualización anterior. No hace nada y se puede eliminar sin problemas. Elimina la carpeta y reinicia Home Assistant para borrar este aviso."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Actividad",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armado",
+                            "armed_with_exceptions": "Armado con excepciones",
+                            "arming_failed": "Armado fallido",
+                            "disarmed": "Desarmado",
+                            "alarm": "Alarma",
+                            "alarm_resolved": "Alarma resuelta",
+                            "tampering": "Manipulación",
+                            "sabotage": "Sabotaje",
+                            "image_request": "Petición de imagen",
+                            "power_cut": "Corte de energía",
+                            "power_restored": "Energía restablecida",
+                            "status_check": "Comprobación de estado",
+                            "communication_failed": "Fallo de comunicación",
+                            "communication_restored": "Comunicación restablecida",
+                            "door_opened": "Puerta abierta",
+                            "door_closed": "Puerta cerrada",
+                            "routine_executed": "Rutina ejecutada",
+                            "tag_or_remote_activated": "Tag o mando activado",
+                            "unknown": "Evento desconocido"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/custom_components/securitas/translations/fr.json
+++ b/custom_components/securitas/translations/fr.json
@@ -261,5 +261,37 @@
             "title": "Dossier verisure_owa obsolète",
             "description": "Un dossier obsolète `verisure_owa` a été laissé dans `{path}` par une mise à jour précédente. Il ne sert plus à rien et peut être supprimé sans risque. Supprimez le dossier et redémarrez Home Assistant pour effacer cette notification."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Activité",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armé",
+                            "armed_with_exceptions": "Armé avec exceptions",
+                            "arming_failed": "Échec de l'armement",
+                            "disarmed": "Désarmé",
+                            "alarm": "Alarme",
+                            "alarm_resolved": "Alarme résolue",
+                            "tampering": "Manipulation",
+                            "sabotage": "Sabotage",
+                            "image_request": "Demande d'image",
+                            "power_cut": "Coupure de courant",
+                            "power_restored": "Courant rétabli",
+                            "status_check": "Vérification de l'état",
+                            "communication_failed": "Échec de communication",
+                            "communication_restored": "Communication rétablie",
+                            "door_opened": "Porte ouverte",
+                            "door_closed": "Porte fermée",
+                            "routine_executed": "Routine exécutée",
+                            "tag_or_remote_activated": "Badge ou télécommande activé",
+                            "unknown": "Événement inconnu"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/custom_components/securitas/translations/it.json
+++ b/custom_components/securitas/translations/it.json
@@ -261,5 +261,37 @@
             "title": "Cartella verisure_owa obsoleta",
             "description": "Una cartella obsoleta `verisure_owa` è rimasta in `{path}` da un precedente aggiornamento. Non fa più nulla e può essere eliminata in sicurezza. Eliminala e riavvia Home Assistant per rimuovere questo avviso."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Attività",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armato",
+                            "armed_with_exceptions": "Armato con eccezioni",
+                            "arming_failed": "Armamento fallito",
+                            "disarmed": "Disarmato",
+                            "alarm": "Allarme",
+                            "alarm_resolved": "Allarme risolto",
+                            "tampering": "Manomissione",
+                            "sabotage": "Sabotaggio",
+                            "image_request": "Richiesta immagine",
+                            "power_cut": "Interruzione di corrente",
+                            "power_restored": "Corrente ripristinata",
+                            "status_check": "Verifica di stato",
+                            "communication_failed": "Errore di comunicazione",
+                            "communication_restored": "Comunicazione ripristinata",
+                            "door_opened": "Porta aperta",
+                            "door_closed": "Porta chiusa",
+                            "routine_executed": "Routine eseguita",
+                            "tag_or_remote_activated": "Tag o telecomando attivato",
+                            "unknown": "Evento sconosciuto"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/custom_components/securitas/translations/pt-BR.json
+++ b/custom_components/securitas/translations/pt-BR.json
@@ -261,5 +261,37 @@
             "title": "Pasta verisure_owa obsoleta",
             "description": "Uma pasta obsoleta `verisure_owa` ficou em `{path}` de uma atualização anterior. Não faz mais nada e pode ser apagada com segurança. Apague a pasta e reinicie o Home Assistant para limpar este aviso."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Atividade",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armado",
+                            "armed_with_exceptions": "Armado com exceções",
+                            "arming_failed": "Falha ao armar",
+                            "disarmed": "Desarmado",
+                            "alarm": "Alarme",
+                            "alarm_resolved": "Alarme resolvido",
+                            "tampering": "Adulteração",
+                            "sabotage": "Sabotagem",
+                            "image_request": "Solicitação de imagem",
+                            "power_cut": "Corte de energia",
+                            "power_restored": "Energia restaurada",
+                            "status_check": "Verificação de status",
+                            "communication_failed": "Falha de comunicação",
+                            "communication_restored": "Comunicação restaurada",
+                            "door_opened": "Porta aberta",
+                            "door_closed": "Porta fechada",
+                            "routine_executed": "Rotina executada",
+                            "tag_or_remote_activated": "Tag ou controle ativado",
+                            "unknown": "Evento desconhecido"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/custom_components/securitas/translations/pt.json
+++ b/custom_components/securitas/translations/pt.json
@@ -261,5 +261,37 @@
             "title": "Pasta verisure_owa obsoleta",
             "description": "Uma pasta obsoleta `verisure_owa` ficou em `{path}` de uma atualização anterior. Já não faz nada e pode ser apagada com segurança. Apague a pasta e reinicie o Home Assistant para limpar este aviso."
         }
+    },
+    "entity": {
+        "event": {
+            "activity": {
+                "name": "Atividade",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "armed": "Armado",
+                            "armed_with_exceptions": "Armado com exceções",
+                            "arming_failed": "Falha ao armar",
+                            "disarmed": "Desarmado",
+                            "alarm": "Alarme",
+                            "alarm_resolved": "Alarme resolvido",
+                            "tampering": "Adulteração",
+                            "sabotage": "Sabotagem",
+                            "image_request": "Pedido de imagem",
+                            "power_cut": "Corte de energia",
+                            "power_restored": "Energia restaurada",
+                            "status_check": "Verificação de estado",
+                            "communication_failed": "Falha de comunicação",
+                            "communication_restored": "Comunicação restaurada",
+                            "door_opened": "Porta aberta",
+                            "door_closed": "Porta fechada",
+                            "routine_executed": "Rotina executada",
+                            "tag_or_remote_activated": "Tag ou comando ativado",
+                            "unknown": "Evento desconhecido"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -8,8 +8,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.components.event.const import ATTR_EVENT_TYPE
+from homeassistant.const import Platform
 
-from custom_components.securitas.const import DOMAIN
+from custom_components.securitas.const import DOMAIN, PLATFORMS
 from custom_components.securitas.coordinators import ActivityData
 from custom_components.securitas.event import (
     ActivityLogEvent,
@@ -166,3 +167,7 @@ class TestActivityEventTranslations:
                 "event_type"
             ]["state"]
             assert set(states) == expected, f"event_type states drift in {path}"
+
+
+def test_event_platform_is_registered():
+    assert Platform.EVENT in PLATFORMS

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -79,6 +79,8 @@ class TestActivityLogEvent:
         e2 = _make_event("2", alias="Disarmed", category="disarmed")
         entity = _entity(ActivityData(events=[e2, e1], new_events=[e1, e2]))
         entity._handle_coordinator_update()
+        # Each new event publishes its own state change — not just the last.
+        assert entity.async_write_ha_state.call_count == 2
         # Last triggered wins the exposed event_type; state is a timestamp.
         assert entity.state_attributes[ATTR_EVENT_TYPE] == "disarmed"
         assert entity.state is not None

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -137,3 +139,30 @@ async def test_setup_adds_nothing_without_activity_coordinator():
     added: list = []
     await async_setup_entry(hass, entry, lambda ents: added.extend(ents))
     assert added == []
+
+
+_COMPONENT = Path("custom_components/securitas")
+_LOCALES = ["ca", "en", "es", "fr", "it", "pt", "pt-BR"]
+
+
+def _all_translation_files() -> list[Path]:
+    return [_COMPONENT / "strings.json"] + [
+        _COMPONENT / "translations" / f"{loc}.json" for loc in _LOCALES
+    ]
+
+
+class TestActivityEventTranslations:
+    def test_every_file_has_activity_event_name(self):
+        for path in _all_translation_files():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            name = data["entity"]["event"]["activity"]["name"]
+            assert name, f"missing entity.event.activity.name in {path}"
+
+    def test_every_file_translates_every_event_type(self):
+        expected = {c.value for c in ActivityCategory}
+        for path in _all_translation_files():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            states = data["entity"]["event"]["activity"]["state_attributes"][
+                "event_type"
+            ]["state"]
+            assert set(states) == expected, f"event_type states drift in {path}"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -75,17 +75,23 @@ class TestActivityLogEvent:
         assert entity.state is None
         entity.async_write_ha_state.assert_called_once()
 
-    def test_triggers_for_each_new_event_in_order(self):
-        # Set `category` explicitly — the model validator honours it and skips
-        # numeric type→category derivation, keeping the assertion deterministic.
-        e1 = _make_event("1", alias="Armed", category="armed")
-        e2 = _make_event("2", alias="Disarmed", category="disarmed")
-        entity = _entity(ActivityData(events=[e2, e1], new_events=[e1, e2]))
+    def test_newest_batched_event_wins_resting_state(self):
+        # The coordinator emits new_events NEWEST-FIRST (coordinators.py sorts
+        # reverse=True). The entity must still fire each event's own state
+        # change, but its resting state must be the NEWEST event, not the
+        # oldest of the batch.
+        newest = _make_event(
+            "2", alias="Disarmed", category="disarmed", time="2026-05-05 15:05:00"
+        )
+        oldest = _make_event(
+            "1", alias="Armed", category="armed", time="2026-05-05 15:00:00"
+        )
+        entity = _entity(
+            ActivityData(events=[newest, oldest], new_events=[newest, oldest])
+        )
         entity._handle_coordinator_update()
-        # Each new event publishes its own state change — not just the last.
         assert entity.async_write_ha_state.call_count == 2
-        # Last triggered wins the exposed event_type; state is a timestamp.
-        assert entity.state_attributes[ATTR_EVENT_TYPE] == "disarmed"
+        assert entity.state_attributes[ATTR_EVENT_TYPE] == "disarmed"  # newest wins
         assert entity.state is not None
 
     def test_image_request_carries_id_signal_and_signal_type(self):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,137 @@
+"""Tests for the Verisure OWA activity `event` entity."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.components.event.const import ATTR_EVENT_TYPE
+
+from custom_components.securitas.const import DOMAIN
+from custom_components.securitas.coordinators import ActivityData
+from custom_components.securitas.event import (
+    ActivityLogEvent,
+    _event_attributes,
+    async_setup_entry,
+)
+from custom_components.securitas.verisure_owa_api.models import (
+    ActivityCategory,
+    ActivityEvent,
+    Installation,
+)
+
+
+def make_installation() -> Installation:
+    return Installation(
+        number="123456", alias="Home", panel="SDVFAST", type="PLUS", address="123 St"
+    )
+
+
+def _make_event(id_signal: str, **overrides) -> ActivityEvent:
+    base = {
+        "alias": "Armed",
+        "type": 701,
+        "signal_type": 701,
+        "id_signal": id_signal,
+        "time": "2026-05-05 15:00:00",
+        "img": 0,
+        "device_name": "Ingresso",
+        "verisure_user": "Luci",
+    }
+    base.update(overrides)
+    return ActivityEvent.model_validate(base)
+
+
+def _make_coordinator(data: ActivityData | None = None) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.installation = make_installation()
+    return coordinator
+
+
+def _entity(data: ActivityData | None = None) -> ActivityLogEvent:
+    coordinator = _make_coordinator(data)
+    entity = ActivityLogEvent(coordinator, coordinator.installation)
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    return entity
+
+
+class TestActivityLogEvent:
+    def test_event_types_are_every_activity_category(self):
+        entity = _entity()
+        assert entity.event_types == [c.value for c in ActivityCategory]
+
+    def test_unique_id_is_activity_event_suffixed(self):
+        entity = _entity()
+        assert entity._attr_unique_id == "v4_securitas_direct.123456_activity_event"
+
+    def test_no_trigger_when_new_events_empty(self):
+        """First-poll baseline / no-new: state stays None, nothing fired."""
+        entity = _entity(ActivityData(events=[_make_event("1")], new_events=[]))
+        entity._handle_coordinator_update()
+        assert entity.state is None
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_triggers_for_each_new_event_in_order(self):
+        # Set `category` explicitly — the model validator honours it and skips
+        # numeric type→category derivation, keeping the assertion deterministic.
+        e1 = _make_event("1", alias="Armed", category="armed")
+        e2 = _make_event("2", alias="Disarmed", category="disarmed")
+        entity = _entity(ActivityData(events=[e2, e1], new_events=[e1, e2]))
+        entity._handle_coordinator_update()
+        # Last triggered wins the exposed event_type; state is a timestamp.
+        assert entity.state_attributes[ATTR_EVENT_TYPE] == "disarmed"
+        assert entity.state is not None
+
+    def test_image_request_carries_id_signal_and_signal_type(self):
+        img = _make_event(
+            "9",
+            alias="Image request",
+            category="image_request",
+            signal_type=99,
+            verisure_user=None,
+            device_name="Cucina",
+        )
+        entity = _entity(ActivityData(events=[img], new_events=[img]))
+        entity._handle_coordinator_update()
+        attrs = entity.state_attributes
+        assert attrs[ATTR_EVENT_TYPE] == ActivityCategory.IMAGE_REQUEST.value
+        assert attrs["id_signal"] == "9"
+        assert attrs["signal_type"] == 99
+
+    def test_attributes_are_single_event_not_a_dump(self):
+        e1 = _make_event("1")
+        attrs = _event_attributes(e1)
+        assert set(attrs) == {
+            "alias",
+            "device_name",
+            "verisure_user",
+            "time",
+            "id_signal",
+            "signal_type",
+            "img",
+            "injected",
+            "exceptions",
+        }
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_one_event_entity_when_activity_coordinator_present():
+    coordinator = _make_coordinator(ActivityData(events=[], new_events=[]))
+    entry = MagicMock()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: {"activity_coordinator": coordinator}}}
+    added: list = []
+    await async_setup_entry(hass, entry, lambda ents: added.extend(ents))
+    assert len(added) == 1
+    assert isinstance(added[0], ActivityLogEvent)
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_nothing_without_activity_coordinator():
+    entry = MagicMock()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: {"activity_coordinator": None}}}
+    added: list = []
+    await async_setup_entry(hass, entry, lambda ents: added.extend(ents))
+    assert added == []

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -68,6 +68,16 @@ class TestActivityLogEvent:
         entity = _entity()
         assert entity._attr_unique_id == "v4_securitas_direct.123456_activity_event"
 
+    def test_naming_matches_the_activity_sensor(self):
+        # has_entity_name=False + an explicit name so the entity_id derives
+        # from the alias alone (like sensor.<alias>_activity_log), never
+        # picking up the device's area as a prefix. translation_key is kept so
+        # the event_type state labels stay translated.
+        entity = _entity()
+        assert entity._attr_has_entity_name is False
+        assert entity.name == "Home Activity"
+        assert entity._attr_translation_key == "activity"
+
     def test_no_trigger_when_new_events_empty(self):
         """First-poll baseline / no-new: state stays None, nothing fired."""
         entity = _entity(ActivityData(events=[_make_event("1")], new_events=[]))

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -68,16 +68,6 @@ class TestActivityLogEvent:
         entity = _entity()
         assert entity._attr_unique_id == "v4_securitas_direct.123456_activity_event"
 
-    def test_naming_matches_the_activity_sensor(self):
-        # has_entity_name=False + an explicit name so the entity_id derives
-        # from the alias alone (like sensor.<alias>_activity_log), never
-        # picking up the device's area as a prefix. translation_key is kept so
-        # the event_type state labels stay translated.
-        entity = _entity()
-        assert entity._attr_has_entity_name is False
-        assert entity.name == "Home Activity"
-        assert entity._attr_translation_key == "activity"
-
     def test_no_trigger_when_new_events_empty(self):
         """First-poll baseline / no-new: state stays None, nothing fired."""
         entity = _entity(ActivityData(events=[_make_event("1")], new_events=[]))

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -25,6 +25,7 @@ EXPECTED_INTEGRATION_FILES = frozenset(
         "test_config_flow.py",
         "test_coordinators.py",
         "test_entity.py",
+        "test_event.py",
         "test_ha_platforms.py",
         "test_hub.py",
         "test_init.py",


### PR DESCRIPTION
## What

Adds a core-native Home Assistant **`event` entity** (`event.<alias>_activity`) that surfaces the alarm's activity timeline — the same xSActV2 data as the existing `sensor.<alias>_activity_log` — so it renders in the built-in **Logbook** and stock more-info, and can be used directly as an automation trigger.

This is the first step toward replacing the integration's custom Lovelace cards with core primitives (the activity-log card here; the camera card is a separate future piece). It also fixes a real data-modelling smell: the activity sensor's state is a formatted string with a memoised 30-row attribute dump (recorder-unfriendly), whereas an `event` entity is the purpose-built primitive for "something happened, with a type and attributes".

## How it works

- One `ActivityLogEvent` per installation, grouped under the alarm device.
- It's a `CoordinatorEntity` on the existing `ActivityCoordinator` and rides `data.new_events` — **the same delta the bus events already use** — so it inherits their semantics for free: no historical replay on restart (first poll baselines silently), no double-firing of HA-issued actions (`duplicate_of` echoes are already excluded), and live injected arm/disarm events. No second dedup implementation.
- `event_types` is derived from the `ActivityCategory` enum (can't drift); `unique_id` is distinct from the sensor's.
- Each new event in a batched poll publishes its own state change (so every event reaches the Logbook / automations), and — since `new_events` is newest-first — the loop iterates `reversed()` so the **newest** event wins the entity's resting state.
- Attributes are a single, small event (recorder-friendly), not the sensor's 30-row dump. `image_request` events keep `id_signal`/`signal_type` so the `verisure_owa.fetch_activity_image` service still works.
- The event category (`armed`, `disarmed`, `image_request`, …) is translated in all seven locales, ported verbatim from the activity-log card's existing labels.

## Fully additive

`sensor.<alias>_activity_log`, the activity-log card, the `verisure_owa_activity` / `securitas_activity` bus events, and all services are **untouched**. `manifest.json` is unchanged (native `event`-domain Logbook rendering needs no dependency). Retiring the sensor or the card stays a separate, future decision.

## Testing

- New `tests/test_event.py` (12 tests): `event_types` == full `ActivityCategory` set; per-event firing with order/resting-state; no-replay on empty `new_events`; `image_request` attributes; setup with/without the activity coordinator; translation completeness across all 8 files (`strings.json` + 7 locales).
- Full suite: **1866 passed**. `ruff` / `ruff format` / `pyright` clean.
