### PR TITLE
feat(activity): map event type 56 to new high_temperature category

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ If you want every event to fire on the bus, turn on continuous polling under **S
 
 Each entry carries a **category** — a stable label for the type of event. The full list:
 
-`armed`, `armed_with_exceptions`, `arming_failed`, `disarmed`, `alarm`, `alarm_resolved`, `tampering`, `sabotage`, `image_request`, `power_cut`, `power_restored`, `status_check`, `communication_failed`, `communication_restored`, `door_opened`, `door_closed`, `routine_executed`, `tag_or_remote_activated`, `unknown`.
+`armed`, `armed_with_exceptions`, `arming_failed`, `disarmed`, `alarm`, `alarm_resolved`, `tampering`, `sabotage`, `image_request`, `power_cut`, `power_restored`, `status_check`, `communication_failed`, `communication_restored`, `door_opened`, `door_closed`, `routine_executed`, `tag_or_remote_activated`, `high_temperature`, `unknown`.
 
 ### Activity events vs the alarm panel entity
 

--- a/custom_components/securitas/verisure_owa_api/models/activity.py
+++ b/custom_components/securitas/verisure_owa_api/models/activity.py
@@ -81,6 +81,10 @@ class ActivityCategory(StrEnum):
     # Verisure app. Administrative device-management event, not an alarm-state
     # change — users keep unused tags deactivated and enable them on demand.
     TAG_OR_REMOTE_ACTIVATED = "tag_or_remote_activated"
+    # Panel-emitted environmental warning that the ambient temperature has
+    # risen above a threshold. Seen on a Spanish panel as "Temperatura
+    # elevada". Distinct from an intrusion ALARM — an environmental event.
+    HIGH_TEMPERATURE = "high_temperature"
     UNKNOWN = "unknown"
 
 
@@ -166,6 +170,10 @@ _ACTIVITY_TYPE_TO_CATEGORY: dict[int, ActivityCategory] = {
     # Seen on a French panel as "Activation du badge ou de la télécommande",
     # with the tag's colour name in `device`. GitHub #579.
     41: ActivityCategory.TAG_OR_REMOTE_ACTIVATED,
+    # High-temperature environmental warning. Seen on a Spanish panel as
+    # "Temperatura elevada" (device/interface reported as "J2"). An
+    # environmental event, not an intrusion alarm. GitHub #594.
+    56: ActivityCategory.HIGH_TEMPERATURE,
 }
 
 

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -43,6 +43,7 @@ export const TRANSLATIONS = {
       door_closed: "Door closed",
       routine_executed: "Routine executed",
       tag_or_remote_activated: "Tag or remote activated",
+      high_temperature: "High temperature",
       unknown: "Unknown event",
     },
     exception_status: {
@@ -87,6 +88,7 @@ export const TRANSLATIONS = {
       door_closed: "Puerta cerrada",
       routine_executed: "Rutina ejecutada",
       tag_or_remote_activated: "Tag o mando activado",
+      high_temperature: "Temperatura elevada",
       unknown: "Evento desconocido",
     },
     exception_status: {
@@ -131,6 +133,7 @@ export const TRANSLATIONS = {
       door_closed: "Porta chiusa",
       routine_executed: "Routine eseguita",
       tag_or_remote_activated: "Tag o telecomando attivato",
+      high_temperature: "Temperatura elevata",
       unknown: "Evento sconosciuto",
     },
     exception_status: {
@@ -175,6 +178,7 @@ export const TRANSLATIONS = {
       door_closed: "Porte fermée",
       routine_executed: "Routine exécutée",
       tag_or_remote_activated: "Badge ou télécommande activé",
+      high_temperature: "Température élevée",
       unknown: "Événement inconnu",
     },
     exception_status: {
@@ -219,6 +223,7 @@ export const TRANSLATIONS = {
       door_closed: "Porta fechada",
       routine_executed: "Rotina executada",
       tag_or_remote_activated: "Tag ou comando ativado",
+      high_temperature: "Temperatura elevada",
       unknown: "Evento desconhecido",
     },
     exception_status: {
@@ -263,6 +268,7 @@ export const TRANSLATIONS = {
       door_closed: "Porta fechada",
       routine_executed: "Rotina executada",
       tag_or_remote_activated: "Tag ou controle ativado",
+      high_temperature: "Temperatura elevada",
       unknown: "Evento desconhecido",
     },
     exception_status: {
@@ -307,6 +313,7 @@ export const TRANSLATIONS = {
       door_closed: "Porta tancada",
       routine_executed: "Rutina executada",
       tag_or_remote_activated: "Tag o comandament activat",
+      high_temperature: "Temperatura elevada",
       unknown: "Esdeveniment desconegut",
     },
     exception_status: {
@@ -356,6 +363,7 @@ const CATEGORY_ICONS = {
   door_closed: "mdi:door-closed",
   routine_executed: "mdi:robot",
   tag_or_remote_activated: "mdi:key-wireless",
+  high_temperature: "mdi:thermometer-alert",
   unknown: "mdi:help-circle",
 };
 
@@ -382,6 +390,8 @@ const CATEGORY_COLORS = {
   routine_executed: "var(--secondary-text-color)",
   // Tag/remote enabled from the app — administrative, neutral.
   tag_or_remote_activated: "var(--secondary-text-color)",
+  // High-temperature environmental warning — warning-orange, not intrusion-red.
+  high_temperature: "var(--warning-color, #ff9800)",
   unknown: "var(--secondary-text-color)",
 };
 

--- a/tests-js/integration/activity-log-card.test.js
+++ b/tests-js/integration/activity-log-card.test.js
@@ -552,6 +552,7 @@ describe("verisure-owa-activity-log-card extra branches", () => {
     ["door_closed", "mdi:door-closed", "Door closed"],
     ["routine_executed", "mdi:robot", "Routine executed"],
     ["tag_or_remote_activated", "mdi:key-wireless", "Tag or remote activated"],
+    ["high_temperature", "mdi:thermometer-alert", "High temperature"],
   ])(
     "renders the %s category with its own icon, label, and no unknown prompt",
     (category, icon, label) => {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -997,6 +997,7 @@ class TestActivityEvent:
             (701, ActivityCategory.ARMED),
             (823, ActivityCategory.ARMED),
             (13, ActivityCategory.ALARM),
+            (56, ActivityCategory.HIGH_TEMPERATURE),
             (850, ActivityCategory.ARMED_WITH_EXCEPTIONS),
         ):
             data = self._minimal()
@@ -1162,6 +1163,13 @@ class TestActivityEventCategory:
         with the tag's colour name in `device`. An administrative event, not
         an alarm-state change. GitHub #579."""
         assert self._ev(41).category == ActivityCategory.TAG_OR_REMOTE_ACTIVATED
+
+    def test_high_temperature(self):
+        """56 is a high-temperature environmental warning from the panel.
+
+        Seen on a Spanish panel as "Temperatura elevada". Not an intrusion
+        alarm — a distinct environmental category. GitHub #594."""
+        assert self._ev(56).category == ActivityCategory.HIGH_TEMPERATURE
 
     def test_unknown_codes(self):
         """Codes we haven't seen fall through to UNKNOWN — future-proofing."""


### PR DESCRIPTION
## What

Maps alarm-panel activity event **type 56** — `Temperatura elevada`, a high-temperature environmental warning seen on a Spanish panel — to a new `high_temperature` activity category.

Closes #594.

## Why

Type 56 was unmapped, so it fell through to the `unknown` category and triggered the activity-log card's "please screenshot this and file an issue" prompt (which is how #594 came to be).

Rather than fold it into the generic intrusion `alarm`, this adds a dedicated category: it's an *environmental* event, not a break-in, and the codebase already favours granular categories (`routine_executed`, `tag_or_remote_activated`, etc. were each added for a single observed code).

## Changes

- **`ActivityCategory.HIGH_TEMPERATURE`** + `56 → HIGH_TEMPERATURE` map entry in `activity.py`.
- **Card** (`verisure-owa-activity-log-card.js`): label in all 7 languages (en `High temperature`, es/pt/pt-BR/ca `Temperatura elevada`, it `Temperatura elevata`, fr `Température élevée`), icon `mdi:thermometer-alert`, colour warning-orange (not intrusion-red).
- **README**: added to the category list.
- Deliberately **not** added to `HA_INJECTABLE_CATEGORIES` — it's panel-emitted only, never HA-initiated, so it stays out of the echo-dedup set.

## Tests

- Python: new `test_high_temperature` mapping assertion + added `56` to the polled-event derivation test (`tests/test_models.py`).
- JS: added a `high_temperature` case to the per-category icon/label render test; the locale key-parity test enforces the label exists in every language.
- Full suites green (1856 Python, 479 JS); Ruff, Prettier, Pylint 10/10, Pyright 0 errors.

> Note: the mapping is based on the panel label and the #594 report. If anyone has a fixture confirming the exact device/interface semantics of type 56 on other firmwares, happy to refine.