### PR TITLE
chore: project-scoped Codex config, CLAUDE.md and AGENTS.md

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+# Project-scoped Codex config. Codex reads AGENTS.md (a symlink to CLAUDE.md here).
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
+
+[sandbox_workspace_write]
+# Closed by default; pip and the Docker HA instance need it.
+network_access = true

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,12 @@
-# Project-scoped Codex config. Codex reads AGENTS.md (a symlink to CLAUDE.md here).
+# Project-scoped Codex config. Codex reads AGENTS.md, a git symlink to CLAUDE.md, so
+# the seats follow the same repo rules as Claude. Codex only loads this file when the
+# checkout path has a trust_level = "trusted" entry in ~/.codex/config.toml.
 model = "gpt-6-astra"
 model_reasoning_effort = "high"
 
 [sandbox_workspace_write]
-# Closed by default; pip and the Docker HA instance need it.
+# Codex closes sandbox network access by default. The seats need it open: the test
+# install pip-fetches Home Assistant and the run-it seat talks to the Docker HA
+# instance. Codex has no allowlist, so this is all-or-nothing; the sandbox still
+# confines writes to the worktree.
 network_access = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# Claude Code Instructions
+
+## Git Workflow
+
+- **NEVER commit directly to main** — always create a feature branch first.
+- This checkout is a fork. Push branches to `origin` (clintongormley); PRs go to
+    `upstream` (guerrerotook/securitas-direct-new-api), which is `gh`'s default.
+- **Branch naming**: descriptive (e.g. `fix/reauth-on-dead-refresh-token`).
+    Never include version numbers in branch names — HACS scans all branches and
+    complains about non-compliant ones, even after deletion.
+- Commit subjects are conventional commits with a scope (`fix(alarm): …`,
+    `feat(activity): …`).
+- Do NOT merge PRs automatically — wait for user approval.
+- When merging a PR (after approval), delete the feature branch.
+
+## Changelog
+
+- Record all user-facing changes in `CHANGES.md` (most recent at the top) under
+    the next version's `## vX.Y.Z` section, with `### Added` / `### Fixed`
+    headings. Each entry is a bold one-line summary linking the issue or PR,
+    followed by a user-facing explanation; credit external contributors.
+
+## Code Quality
+
+- Run `bash bin/install-hooks.sh` once per clone/worktree. The committed
+    `.githooks/pre-push` mirrors CI: ruff format + lint, pyright, translation
+    drift (`scripts/check_translations.py`), docs drift (`scripts/check_docs.py`
+    — adding, removing or renaming a module or service without touching
+    README/docs blocks the push), then the unit tests
+    (`pytest tests/ -m "not integration"`) and, when the card changed,
+    `npm run lint` and `npm test`. Bypass in an emergency with
+    `git push --no-verify`.
+- CI additionally runs pylint, the integration suite (`-m integration`) on the
+    stable, dev and minimum HA channels, and a combined 90% coverage gate.
+- Before creating a PR run `ruff check .`, `ruff format .` and
+    `pyright custom_components/`.
+- New user-facing strings must be translated into every locale in
+    `custom_components/securitas/translations/`; `strings.json` stays English.
+- The `manifest.json` keys must be sorted: `domain`, `name` first, then all
+    remaining keys in alphabetical order.
+- Raw HAR captures contain auth tokens: only sanitised fixtures are committed
+    (`tests/fixtures/*.har` and `*-events.json` are gitignored).
+- `docs/superpowers/`, `docs/plans/` and `docs/handoffs/` are gitignored —
+    specs, plans and handoffs are local working files; never commit them.
+    `docs/architecture.md` is the committed developer overview.
+
+## Integration Layout
+
+- Component lives in `custom_components/securitas/`; the Lovelace cards under
+    `custom_components/securitas/www/` with vitest tests in `tests-js/`.
+- Domain: `securitas` (branded Verisure OWA). Alias in
+    `~/workspace/tools/worktree.py`: `securitas`.
+- Main HA dev container: `ha-securitas-main` (start with `ha-wt securitas-main`).
+- Feature worktrees: `/new-worktree securitas <branch>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Git Workflow
 
 - **NEVER commit directly to main** — always create a feature branch first.
-- This checkout is a fork. Push branches to `origin` (clintongormley); PRs go to
-    `upstream` (guerrerotook/securitas-direct-new-api), which is `gh`'s default.
+- Work from a fork: push branches to your fork and open the PR against
+    `guerrerotook/securitas-direct-new-api` `main` (`gh repo set-default` there).
 - **Branch naming**: descriptive (e.g. `fix/reauth-on-dead-refresh-token`).
     Never include version numbers in branch names — HACS scans all branches and
     complains about non-compliant ones, even after deletion.


### PR DESCRIPTION
Adds a short `CLAUDE.md` capturing the repo's git workflow, changelog convention, pre-push gate and layout; `.codex/config.toml` (pins `gpt-6-astra` at high reasoning effort, opens sandbox network access for pip and the Docker HA instance); and `AGENTS.md` as a symlink to `CLAUDE.md` so Codex seats read the same repo rules Claude does.