### PR TITLE
chore: bump version to 5.9.0 for development

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
+## v5.9.0
+
 ## v5.8.0
 
 The headline this release is that the integration now lives in Home Assistant's **native** UI: the standard alarm **More Info dialog**, the alarm **badge**, and the **Tile card** all surface open sensors and offer Force Arm, so arming past an open door or window no longer needs the custom card. Huge thanks to [@foxdalas](https://github.com/foxdalas) for contributing that work ([#586](https://github.com/guerrerotook/securitas-direct-new-api/pull/586)). Alongside it, a new optional tick box arms past open sensors for you automatically, plus a handful of fixes — including one that stops the alarm getting stuck offline after a login problem.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,17 +2,9 @@
 
 Most recent at the top.  For changes prior to v5, see [the GitHub release notes](https://github.com/guerrerotook/securitas-direct-new-api/releases).
 
-## v5.9.0
-
-### Fixed
-
-**A dead refresh token now asks you to sign in again instead of leaving the alarm unavailable ([#568](https://github.com/guerrerotook/securitas-direct-new-api/issues/568)).**  The integration keeps its session alive with a refresh token that the Verisure server rotates every fifteen minutes. When the token stored on disk is no longer valid, most commonly because it was written by a release before v5.7.0 and never updated, the server answers every refresh with the same server-side crash. That crash carries no error code, so earlier releases treated it as a passing glitch and retried it forever; the only way out was to delete the integration and set it up again. Now a token that keeps crashing is treated as dead: on the second failed attempt at startup, or the third failed renewal in a row while running, Home Assistant shows the normal re-authentication prompt. Enter your password once and a fresh token is issued, and if you have several installations on one account the others pick up the new token as well. A single crash is still retried, so a brief server wobble does not send you to the sign-in form. Thanks to [@amullr](https://github.com/amullr) and [@rencmbr](https://github.com/rencmbr) for the reports and logs.
-
-**Sign-in requests are no longer re-sent after a rate-limit response.**  When the server answered with an HTTP 403 rate limit, the integration re-sent the same request once after a short pause. That is harmless for a status poll, but a token refresh consumes its one-time refresh token on the first send, so re-sending it could present an already-used token and kill the session. Sign-in, token refresh and two-factor requests are no longer re-sent after a rate-limit response; everything else keeps the retry.
-
 ## v5.8.0
 
-The headline this release is that the integration now lives in Home Assistant's **native** UI: the standard alarm **More Info dialog**, the alarm **badge**, and the **Tile card** all surface open sensors and offer Force Arm, so arming past an open door or window no longer needs the custom card. Huge thanks to [@foxdalas](https://github.com/foxdalas) for contributing that work ([#586](https://github.com/guerrerotook/securitas-direct-new-api/pull/586)). Alongside it, a new optional tick box arms past open sensors for you automatically, plus a handful of fixes.
+The headline this release is that the integration now lives in Home Assistant's **native** UI: the standard alarm **More Info dialog**, the alarm **badge**, and the **Tile card** all surface open sensors and offer Force Arm, so arming past an open door or window no longer needs the custom card. Huge thanks to [@foxdalas](https://github.com/foxdalas) for contributing that work ([#586](https://github.com/guerrerotook/securitas-direct-new-api/pull/586)). Alongside it, a new optional tick box arms past open sensors for you automatically, plus a handful of fixes — including one that stops the alarm getting stuck offline after a login problem.
 
 ### Added
 
@@ -27,6 +19,10 @@ The headline this release is that the integration now lives in Home Assistant's 
 **A native activity event entity ([#593](https://github.com/guerrerotook/securitas-direct-new-api/pull/593)).**  The panel's activity timeline — arms, disarms, intrusions, image requests, power events — is now also exposed as a Home Assistant `event` entity (`event.<alias>_activity`), so it appears in the built-in Logbook and can trigger automations directly, with no custom card. Each entry carries its category as the event type, translated in every supported language, and the newest event is always the one shown. The existing activity-log sensor, card and event bus are unchanged.
 
 ### Fixed
+
+**The alarm no longer gets stuck offline after a login problem ([#568](https://github.com/guerrerotook/securitas-direct-new-api/issues/568)).**  Some accounts — usually ones first set up before v5.7.0 — hit a repeating server error that left the alarm unavailable, and the only way out was to delete the integration and add it again. Now, when that keeps happening, Home Assistant simply asks you to sign in again: enter your password once and everything reconnects, including any other installations on the same account. A one-off error is still retried quietly, so a brief server hiccup won't send you to the sign-in screen. Thanks to [@amullr](https://github.com/amullr) and [@rencmbr](https://github.com/rencmbr) for the reports and logs.
+
+**Sign-in requests are no longer retried when the server is busy.**  When the server replied "too many requests", the integration used to resend the same request. For sign-in and two-factor steps that could end the session instead of recovering it, so those are no longer retried; ordinary status checks still are.
 
 **Blocked arming showed a confusing internal message.**  With a door or window open, some arm attempts showed a raw internal error instead of naming the open sensors. It now lists the sensors to close — on the card, in notifications and in the activity log.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ The headline this release is that the integration now lives in Home Assistant's 
 
 **The alarm no longer gets stuck offline after a login problem ([#568](https://github.com/guerrerotook/securitas-direct-new-api/issues/568)).**  Some accounts — usually ones first set up before v5.7.0 — hit a repeating server error that left the alarm unavailable, and the only way out was to delete the integration and add it again. Now, when that keeps happening, Home Assistant simply asks you to sign in again: enter your password once and everything reconnects, including any other installations on the same account. A one-off error is still retried quietly, so a brief server hiccup won't send you to the sign-in screen. Thanks to [@amullr](https://github.com/amullr) and [@rencmbr](https://github.com/rencmbr) for the reports and logs.
 
-**Sign-in requests are no longer retried when the server is busy.**  When the server replied "too many requests", the integration used to resend the same request. For sign-in and two-factor steps that could end the session instead of recovering it, so those are no longer retried; ordinary status checks still are.
+**Sign-in requests are no longer retried when the server is busy.**  When the server replied "too many requests", the integration used to resend the same request. For sign-in and two-factor steps, resending could end the session instead of recovering it, so those are no longer retried; ordinary status checks still are.
 
 **Blocked arming showed a confusing internal message.**  With a door or window open, some arm attempts showed a raw internal error instead of naming the open sensors. It now lists the sensors to close — on the card, in notifications and in the activity log.
 

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.8.0-rc.2"
+    "version": "5.8.0"
 }

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.8.0"
+    "version": "5.8.0-rc.2"
 }

--- a/custom_components/securitas/manifest.json
+++ b/custom_components/securitas/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guerrerotook/securitas-direct-new-api/issues",
     "requirements": [],
-    "version": "5.8.0"
+    "version": "5.9.0"
 }

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.8.0-rc.2";
-import "./verisure-owa-alarm-chip.js?v=5.8.0-rc.2";
+import "./verisure-owa-alarm-card.js?v=5.8.0";
+import "./verisure-owa-alarm-chip.js?v=5.8.0";

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.8.0";
-import "./verisure-owa-alarm-chip.js?v=5.8.0";
+import "./verisure-owa-alarm-card.js?v=5.8.0-rc.2";
+import "./verisure-owa-alarm-chip.js?v=5.8.0-rc.2";

--- a/custom_components/securitas/www/securitas-alarm-card.js
+++ b/custom_components/securitas/www/securitas-alarm-card.js
@@ -25,5 +25,5 @@
 // /securitas_panel/securitas-alarm-card.js entry from Settings →
 // Dashboards → Resources; the canonical /verisure-owa-panel/...js
 // resources are auto-registered by the integration.
-import "./verisure-owa-alarm-card.js?v=5.8.0";
-import "./verisure-owa-alarm-chip.js?v=5.8.0";
+import "./verisure-owa-alarm-card.js?v=5.9.0";
+import "./verisure-owa-alarm-chip.js?v=5.9.0";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.8.0-rc.2";
+import "./verisure-owa-camera-card.js?v=5.8.0";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.8.0";
+import "./verisure-owa-camera-card.js?v=5.9.0";

--- a/custom_components/securitas/www/securitas-camera-card.js
+++ b/custom_components/securitas/www/securitas-camera-card.js
@@ -5,4 +5,4 @@
 // verisure-owa-camera-card AND securitas-camera-card (plus their
 // -editor variants) so old dashboards using `custom:securitas-camera-card`
 // keep rendering. ES modules dedup by URL.
-import "./verisure-owa-camera-card.js?v=5.8.0";
+import "./verisure-owa-camera-card.js?v=5.8.0-rc.2";

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.9.0";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-activity-log-card.js
+++ b/custom_components/securitas/www/verisure-owa-activity-log-card.js
@@ -18,7 +18,7 @@
  *   title: "Recent activity"            # optional
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
 
 // ── Translations ─────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
@@ -7,7 +7,7 @@
 import {
   GESTURE_KEYS,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.9.0";
 
 const DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
@@ -7,7 +7,7 @@
 import {
   GESTURE_KEYS,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
 
 const DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-badge-editor.js
@@ -7,7 +7,7 @@
 import {
   GESTURE_KEYS,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 const DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,12 +21,12 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.9.0";
 import {
   autoForceActive,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-arm-exception.js?v=5.9.0";
 import {
   _t,
   STATE_CFG,
@@ -42,7 +42,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.9.0";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -52,7 +52,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.9.0";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,12 +21,12 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0";
 import {
   autoForceActive,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
+} from "./verisure-owa-arm-exception.js?v=5.8.0";
 import {
   _t,
   STATE_CFG,
@@ -42,7 +42,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -52,7 +52,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-card.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-card.js
@@ -21,12 +21,12 @@
  *   name: My Alarm          # optional — overrides friendly_name
  */
 
-import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { escHtml } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
 import {
   autoForceActive,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
 import {
   _t,
   STATE_CFG,
@@ -42,7 +42,7 @@ import {
   TRANSLATIONS,
   alarmEntitySuggestion,
   _makeLegacyShim,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
 
 // Re-export the public helper API so existing imports of these names from
 // this module keep working.
@@ -52,7 +52,7 @@ export {
   ARM_ACTIONS,
   defaultArmState,
   alarmEntitySuggestion,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
 
 // The lightweight chip/badge are defined in verisure-owa-alarm-chip.js, which
 // the integration registers as a SEPARATE Lovelace resource so the

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,8 +13,8 @@ import {
   attachGesture,
   _makeLegacyShim,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
-import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0";
+import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.8.0";
 
 const BADGE_DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,8 +13,8 @@ import {
   attachGesture,
   _makeLegacyShim,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
-import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.8.0-rc.2";
+import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
 
 const BADGE_DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-chip.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-chip.js
@@ -13,8 +13,8 @@ import {
   attachGesture,
   _makeLegacyShim,
   migrateCompactAlarmConfig,
-} from "./verisure-owa-alarm-shared.js?v=5.8.0";
-import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-alarm-shared.js?v=5.9.0";
+import { hassLanguage } from "./verisure-owa-arm-exception.js?v=5.9.0";
 
 const BADGE_DEFAULT_CONFIG = {
   show_name: false,

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,11 +8,11 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.9.0";
 import {
   ARM_EXCEPTION_TRANSLATIONS,
   notifyActionFailure,
-} from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-arm-exception.js?v=5.9.0";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,11 +8,11 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 import {
   ARM_EXCEPTION_TRANSLATIONS,
   notifyActionFailure,
-} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
+} from "./verisure-owa-arm-exception.js?v=5.8.0";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-alarm-shared.js
+++ b/custom_components/securitas/www/verisure-owa-alarm-shared.js
@@ -8,11 +8,11 @@
 // served with a long max-age yet still re-fetched on each release (kept in
 // sync by tests-js/integration/card-cache-busting.test.js).
 
-import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
 import {
   ARM_EXCEPTION_TRANSLATIONS,
   notifyActionFailure,
-} from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
 
 // ── AlarmControlPanelEntityFeature bitmask values ────────────────────────────
 export const FEATURE = {

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.9.0";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-camera-card.js
+++ b/custom_components/securitas/www/verisure-owa-camera-card.js
@@ -14,7 +14,7 @@
  *   name: Front Door   # optional — overrides the device name
  */
 
-import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0-rc.2";
+import { escHtml, formatTranslation } from "./verisure-owa-card-utils.js?v=5.8.0";
 
 // ── Translations ──────────────────────────────────────────────────────────────
 

--- a/custom_components/securitas/www/verisure-owa-more-info.js
+++ b/custom_components/securitas/www/verisure-owa-more-info.js
@@ -11,7 +11,7 @@ import {
   hassLanguage,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-arm-exception.js?v=5.9.0";
 
 class VerisureOwaMoreInfo extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-more-info.js
+++ b/custom_components/securitas/www/verisure-owa-more-info.js
@@ -11,7 +11,7 @@ import {
   hassLanguage,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0";
+} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
 
 class VerisureOwaMoreInfo extends HTMLElement {
   constructor() {

--- a/custom_components/securitas/www/verisure-owa-more-info.js
+++ b/custom_components/securitas/www/verisure-owa-more-info.js
@@ -11,7 +11,7 @@ import {
   hassLanguage,
   readAutoForce,
   writeAutoForce,
-} from "./verisure-owa-arm-exception.js?v=5.8.0-rc.2";
+} from "./verisure-owa-arm-exception.js?v=5.8.0";
 
 class VerisureOwaMoreInfo extends HTMLElement {
   constructor() {


### PR DESCRIPTION
Post-release dev bump — moves `main` off the released version after **v5.8.0 final** ships.

## ⚠️ Stacked on #601 → #602 — merge those first

This branch is based on #602 (v5.8.0 final), which is based on #601 (v5.8.0-rc.2). Until both merge, this PR's diff also shows their commits. Intended order:

1. Merge #601 → release `5.8.0-rc.2`.
2. Merge #602 → release `5.8.0` final.
3. Then I rebase this branch onto the new `main` (`reset --hard upstream/main`, re-apply as one clean commit, `--force-with-lease`) so its diff is only the `5.8.0 → 5.9.0` bump. Approval survives the force-push (dismiss-stale is off here).
4. Merge this PR — `main` is now on `5.9.0` for development.

## This PR's own change

- `manifest.json` version → `5.9.0`
- All 15 card `?v=` cache-bust tokens re-stamped to `?v=5.9.0`
- Re-opens an **empty** `## v5.9.0` changelog section for future entries

The v5.9.0 section is intentionally empty (`_No changes yet._` placeholder aside): feature/fix PRs add their entries under it, and the Release workflow refuses to cut a 5.9.0 release while the section has no real content — a loud failure rather than publishing a placeholder. `test_card_cache_busting` guards (Python + JS) pass.

## No release dispatch

Unlike #601/#602, this PR is not tied to a release — it just keeps `main` on the next dev version. No `release.yaml` dispatch follows it.